### PR TITLE
Support hierarchical pane layouts and cascading controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,43 @@ async def my_advanced_script():
 asyncio.run(my_advanced_script())
 ```
 
+#### Hierarchical team orchestration (CEO -> Team Leads -> ICs)
+
+The layout manager and MCP tools now understand hierarchical pane specs that include
+team/agent metadata. Pane titles are derived automatically (e.g., `Team Leads :: TL-Backend`),
+and the MCP servers will register the agents and teams for you.
+
+```python
+# Create a 2x2 grid with explicit team/agent hierarchy
+session_map = await layout_manager.create_layout(
+    layout_type=LayoutType.QUAD,
+    pane_hierarchy=[
+        {"team": "Executive", "agent": "CEO"},
+        {"team": "Team Leads", "agent": "TL-Frontend"},
+        {"team": "Team Leads", "agent": "TL-Backend"},
+        {"team": "ICs", "agent": "IC-Oncall"},
+    ],
+)
+
+# When using the FastMCP or gRPC CreateSessions APIs the same hierarchy is
+# auto-registered in AgentRegistry:
+# create_sessions(layout="quad", session_configs=[...])
+
+# Target panes by hierarchy and send cascading messages
+await select_panes_by_hierarchy([
+    {"team": "Team Leads", "agent": "TL-Frontend"}
+])
+
+await send_hierarchical_message(
+    targets=[
+        {"team": "Team Leads", "message": "Share updates for the CEO."},
+        {"team": "Team Leads", "agent": "TL-Backend", "message": "Ship the API fixes."},
+        {"team": "ICs", "agent": "IC-Oncall", "message": "Monitor logs for regressions."},
+    ],
+    broadcast="CEO broadcast: align on launch goals.",
+)
+```
+
 ## MCP Tools and Resources
 
 The FastMCP implementation provides the following:

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -332,7 +332,7 @@ async def create_sessions(
             pane_hierarchy = [
                 {
                     "name": c.get("name"),
-                    "team": c.get("team") or (c.get("team_path")[-1] if c.get("team_path") else None),
+                    "team": c.get("team") or (c.get("team_path")[-1] if c.get("team_path") and len(c.get("team_path")) > 0 else None),
                     "agent": c.get("agent"),
                     "team_path": c.get("team_path"),
                 }

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -813,7 +813,7 @@ async def select_panes_by_hierarchy(
 @mcp.tool()
 async def send_hierarchical_message(
     ctx: Context,
-    targets: List[Dict[str, str]],
+    targets: List[Dict[str, Optional[str]]],
     broadcast: Optional[str] = None,
     skip_duplicates: bool = True,
     execute: bool = True,

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -737,7 +737,7 @@ async def send_cascade_message(
 @mcp.tool()
 async def select_panes_by_hierarchy(
     ctx: Context,
-    targets: List[Dict[str, str]],
+    targets: List[Dict[str, Optional[str]]],
     set_active: bool = True,
 ) -> str:
     """Resolve panes by team/agent hierarchy and optionally focus the first.

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -18,7 +18,7 @@ from mcp.server.fastmcp import FastMCP, Context
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
 from core.terminal import ItermTerminal
-from core.agents import AgentRegistry, CascadingMessage
+from core.agents import AgentRegistry, CascadingMessage, SendTarget
 
 # Global references for resources (set during lifespan)
 _terminal: Optional[ItermTerminal] = None
@@ -140,9 +140,15 @@ async def resolve_session(
     """
     sessions = []
 
-    # If team specified, get all agents in team
+    # If team specified, get all agents in team (optionally filtered by agent)
     if team:
         team_agents = agent_registry.list_agents(team=team)
+
+        if agent:
+            team_agents = [a for a in team_agents if a.name == agent]
+            if not team_agents:
+                return []
+
         for a in team_agents:
             session = await terminal.get_session_by_id(a.session_id)
             if session:
@@ -320,20 +326,33 @@ async def create_sessions(
 
         # Extract session names from configs
         session_names = None
+        pane_hierarchy = None
         if session_configs:
-            session_names = [c.get("name", f"Session-{i}") for i, c in enumerate(session_configs)]
+            session_names = [c.get("name") for c in session_configs]
+            pane_hierarchy = [
+                {
+                    "name": c.get("name"),
+                    "team": c.get("team") or (c.get("team_path")[-1] if c.get("team_path") else None),
+                    "agent": c.get("agent"),
+                    "team_path": c.get("team_path"),
+                }
+                for c in session_configs
+            ]
 
         # Create the layout
         logger.info(f"Creating {layout_type} layout with sessions: {session_names}")
         sessions_map = await layout_manager.create_layout(
             layout_type=layout_type_enum,
-            pane_names=session_names
+            pane_names=session_names,
+            pane_hierarchy=pane_hierarchy,
         )
 
         result = []
 
+        created_items = list(sessions_map.items())
+
         # Process each created session
-        for session_name, session_id in sessions_map.items():
+        for idx, (session_name, session_id) in enumerate(created_items):
             session = await terminal.get_session_by_id(session_id)
             if not session:
                 continue
@@ -346,30 +365,36 @@ async def create_sessions(
                 "team": None
             }
 
-            # Find matching config
+            # Find matching config (preserve ordering fallback)
             if session_configs:
-                for config in session_configs:
-                    if config.get("name") == session_name:
-                        # Register agent if specified
-                        agent_name = config.get("agent")
-                        team_name = config.get("team")
+                config = session_configs[idx] if idx < len(session_configs) else {}
+                if config:
+                    # Register agent if specified
+                    agent_name = config.get("agent")
+                    team_name = config.get("team") or (config.get("team_path")[-1] if config.get("team_path") else None)
 
-                        if agent_name:
-                            teams = [team_name] if team_name else []
-                            agent_registry.register_agent(
-                                name=agent_name,
-                                session_id=session.id,
-                                teams=teams
-                            )
-                            session_info["agent"] = agent_name
-                            session_info["team"] = team_name
+                    # Materialize team hierarchy (parent chain) if provided
+                    team_path = config.get("team_path") or ([] if not team_name else [team_name])
+                    parent_team = None
+                    for t_name in team_path:
+                        if t_name and not agent_registry.get_team(t_name):
+                            agent_registry.create_team(name=t_name, parent_team=parent_team)
+                        parent_team = t_name
 
-                        # Execute initial command
-                        command = config.get("command")
-                        if command:
-                            await session.execute_command(command)
+                    if agent_name:
+                        teams = [team_name] if team_name else []
+                        agent_registry.register_agent(
+                            name=agent_name,
+                            session_id=session.id,
+                            teams=teams
+                        )
+                        session_info["agent"] = agent_name
+                        session_info["team"] = team_name
 
-                        break
+                    # Execute initial command
+                    command = config.get("command")
+                    if command:
+                        await session.execute_command(command)
 
             result.append(session_info)
 
@@ -602,6 +627,70 @@ async def read_sessions(
         return f"Error: {e}"
 
 
+async def _deliver_cascade(
+    terminal: ItermTerminal,
+    agent_registry: AgentRegistry,
+    cascade: CascadingMessage,
+    skip_duplicates: bool,
+    execute: bool,
+    logger: logging.Logger,
+) -> str:
+    """Send a cascading message and return serialized results."""
+
+    try:
+        message_targets = agent_registry.resolve_cascade_targets(cascade)
+
+        results = []
+        delivered = 0
+        skipped = 0
+
+        for message, agent_names in message_targets.items():
+            if skip_duplicates:
+                agent_names = agent_registry.filter_unsent_recipients(message, agent_names)
+
+            actually_delivered = []
+
+            for agent_name in agent_names:
+                agent = agent_registry.get_agent(agent_name)
+                if not agent:
+                    continue
+
+                session = await terminal.get_session_by_id(agent.session_id)
+                if not session:
+                    results.append({
+                        "agent": agent_name,
+                        "delivered": False,
+                        "skipped_reason": "session_not_found"
+                    })
+                    skipped += 1
+                    continue
+
+                await session.send_text(message, execute=execute)
+                agent_registry.record_message_sent(message, [agent_name])
+                delivered += 1
+                actually_delivered.append(agent_name)
+
+            if not actually_delivered:
+                skipped += len(agent_names)
+
+            results.append({
+                "message": message,
+                "targets": agent_names,
+                "delivered": actually_delivered
+            })
+
+        logger.info(f"Delivered {delivered} cascading messages ({skipped} skipped)")
+
+        return json.dumps({
+            "results": results,
+            "delivered": delivered,
+            "skipped": skipped
+        }, indent=2)
+    except Exception as e:
+        logger.error(f"Error sending cascading message: {e}")
+        return f"Error: {e}"
+
+
 @mcp.tool()
 async def send_cascade_message(
     ctx: Context,
@@ -629,78 +718,136 @@ async def send_cascade_message(
     agent_registry = ctx.request_context.lifespan_context["agent_registry"]
     logger = ctx.request_context.lifespan_context["logger"]
 
-    try:
-        cascade = CascadingMessage(
-            broadcast=broadcast,
-            teams=teams or {},
-            agents=agents or {}
-        )
+    cascade = CascadingMessage(
+        broadcast=broadcast,
+        teams=teams or {},
+        agents=agents or {}
+    )
 
-        # Resolve cascade to message -> [agent_names]
-        message_targets = agent_registry.resolve_cascade_targets(cascade)
+    return await _deliver_cascade(
+        terminal=terminal,
+        agent_registry=agent_registry,
+        cascade=cascade,
+        skip_duplicates=skip_duplicates,
+        execute=execute,
+        logger=logger,
+    )
 
-        results = []
-        delivered = 0
-        skipped = 0
 
-        for message, agent_names in message_targets.items():
-            # Filter duplicates
-            if skip_duplicates:
-                agent_names = agent_registry.filter_unsent_recipients(message, agent_names)
+@mcp.tool()
+async def select_panes_by_hierarchy(
+    ctx: Context,
+    targets: List[Dict[str, str]],
+    set_active: bool = True,
+) -> str:
+    """Resolve panes by team/agent hierarchy and optionally focus the first.
 
-            actually_delivered = []
-            # Get session IDs
-            for agent_name in agent_names:
-                agent = agent_registry.get_agent(agent_name)
-                if not agent:
-                    continue
+    Args:
+        targets: List of target dicts using SendTarget fields (team/agent)
+        set_active: Whether to set the first resolved session as active
+    """
 
+    terminal = ctx.request_context.lifespan_context["terminal"]
+    agent_registry = ctx.request_context.lifespan_context["agent_registry"]
+    logger = ctx.request_context.lifespan_context["logger"]
+
+    results = []
+    resolved_sessions = []
+
+    for target in targets:
+        send_target = SendTarget(**target)
+        team = send_target.team
+        agent_name = send_target.agent
+
+        if agent_name:
+            agent = agent_registry.get_agent(agent_name)
+            if not agent:
+                results.append({"agent": agent_name, "team": team, "error": "unknown_agent"})
+                continue
+
+            if team and not agent.is_member_of(team):
+                results.append({"agent": agent_name, "team": team, "error": "agent_not_in_team"})
+                continue
+
+            session = await terminal.get_session_by_id(agent.session_id)
+            if not session:
+                results.append({"agent": agent_name, "team": team, "error": "session_not_found"})
+                continue
+
+            resolved_sessions.append(session)
+            results.append({
+                "agent": agent_name,
+                "team": team,
+                "session_id": session.id,
+                "session_name": session.name
+            })
+            continue
+
+        if team:
+            team_agents = agent_registry.list_agents(team=team)
+            if not team_agents:
+                results.append({"team": team, "error": "team_has_no_agents"})
+                continue
+
+            for agent in team_agents:
                 session = await terminal.get_session_by_id(agent.session_id)
-                if not session:
+                if session:
+                    resolved_sessions.append(session)
                     results.append({
-                        "agent": agent_name,
-                        "delivered": False,
-                        "skipped_reason": "session_not_found"
+                        "agent": agent.name,
+                        "team": team,
+                        "session_id": session.id,
+                        "session_name": session.name
                     })
-                    skipped += 1
-                    continue
 
-                # Determine message type based on where this specific message came from
-                message_type = "broadcast"
-                if agent_name in (agents or {}) and (agents or {}).get(agent_name) == message:
-                    message_type = "agent"
-                elif any(agent.is_member_of(t) and (teams or {}).get(t) == message for t in (teams or {}).keys()):
-                    message_type = "team"
+    if set_active and resolved_sessions:
+        agent_registry.active_session = resolved_sessions[0].id
+        logger.info(f"Active session set via hierarchy: {resolved_sessions[0].name}")
 
-                # Send message
-                if execute:
-                    await session.execute_command(message)
-                else:
-                    await session.send_text(message, execute=False)
+    return json.dumps({
+        "resolved": results,
+        "active_session": resolved_sessions[0].id if set_active and resolved_sessions else None
+    }, indent=2)
 
-                results.append({
-                    "agent": agent_name,
-                    "session_id": session.id,
-                    "message_type": message_type,
-                    "delivered": True
-                })
-                delivered += 1
-                actually_delivered.append(agent_name)
 
-            # Record messages sent
-            if actually_delivered:
-                agent_registry.record_message_sent(message, actually_delivered)
+@mcp.tool()
+async def send_hierarchical_message(
+    ctx: Context,
+    targets: List[Dict[str, str]],
+    broadcast: Optional[str] = None,
+    skip_duplicates: bool = True,
+    execute: bool = True,
+) -> str:
+    """Send cascading messages using hierarchical SendTarget specs."""
 
-        logger.info(f"Cascade: delivered={delivered}, skipped={skipped}")
+    terminal = ctx.request_context.lifespan_context["terminal"]
+    agent_registry = ctx.request_context.lifespan_context["agent_registry"]
+    logger = ctx.request_context.lifespan_context["logger"]
 
-        return json.dumps({
-            "results": results,
-            "delivered_count": delivered,
-            "skipped_count": skipped
-        }, indent=2)
-    except Exception as e:
-        logger.error(f"Error in send_cascade_message: {e}")
-        return f"Error: {e}"
+    send_targets = [SendTarget(**t) for t in targets]
+
+    cascade = CascadingMessage(
+        broadcast=broadcast,
+        teams={},
+        agents={},
+    )
+
+    for target in send_targets:
+        if target.team and target.agent:
+            cascade.agents[target.agent] = target.message or broadcast or ""
+        elif target.agent:
+            cascade.agents[target.agent] = target.message or broadcast or ""
+        elif target.team:
+            cascade.teams[target.team] = target.message or broadcast or ""
+
+    return await _deliver_cascade(
+        terminal=terminal,
+        agent_registry=agent_registry,
+        cascade=cascade,
+        skip_duplicates=skip_duplicates,
+        execute=execute,
+        logger=logger,
+    )
 
 
 # ============================================================================

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -834,6 +834,10 @@ async def send_hierarchical_message(
 
     for target in send_targets:
         if target.team and target.agent:
+            agent_obj = agent_registry.get_agent(target.agent)
+            if not agent_obj or not agent_obj.is_member_of(target.team):
+                logger.error(f"Agent '{target.agent}' is not a member of team '{target.team}'. Skipping.")
+                continue
             cascade.agents[target.agent] = target.message or broadcast or ""
         elif target.agent:
             cascade.agents[target.agent] = target.message or broadcast or ""

--- a/iterm_mcpy/grpc_server.py
+++ b/iterm_mcpy/grpc_server.py
@@ -8,6 +8,7 @@ from typing import Optional
 import grpc
 import iterm2
 
+from core.agents import AgentRegistry
 from core.layouts import LayoutManager, LayoutType
 from core.terminal import ItermTerminal
 from iterm_mcpy import iterm_mcp_pb2
@@ -30,6 +31,7 @@ class ITermService(iterm_mcp_pb2_grpc.ITermServiceServicer):
         self.connection: Optional[iterm2.Connection] = None
         self.log_dir = os.path.expanduser("~/.iterm_mcp_logs")
         self._init_lock = asyncio.Lock()
+        self.agent_registry: AgentRegistry = AgentRegistry()
 
     async def initialize(self):
         """Initialize the iTerm2 connection and services.
@@ -79,11 +81,13 @@ class ITermService(iterm_mcp_pb2_grpc.ITermServiceServicer):
         sessions = list(self.terminal.sessions.values())
         pb_sessions = []
         for s in sessions:
+            agent = self.agent_registry.get_agent_by_session(s.id)
             pb_sessions.append(iterm_mcp_pb2.Session(
                 id=s.id,
                 name=s.name,
                 persistent_id=s.persistent_id,
-                is_processing=getattr(s, 'is_processing', False)
+                is_processing=getattr(s, 'is_processing', False),
+                agent=agent.name if agent else ""
             ))
         return iterm_mcp_pb2.SessionList(sessions=pb_sessions)
 
@@ -148,6 +152,83 @@ class ITermService(iterm_mcp_pb2_grpc.ITermServiceServicer):
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(e))
             return iterm_mcp_pb2.SessionList()
+
+    async def CreateSessions(self, request, context):
+        if not await self.initialize():
+            context.set_code(grpc.StatusCode.INTERNAL)
+            return iterm_mcp_pb2.CreateSessionsResponse()
+
+        layout_type_map = {
+            "single": LayoutType.SINGLE,
+            "horizontal": LayoutType.HORIZONTAL_SPLIT,
+            "vertical": LayoutType.VERTICAL_SPLIT,
+            "quad": LayoutType.QUAD
+        }
+
+        layout_enum = layout_type_map.get(request.layout.lower(), LayoutType.SINGLE) if request.layout else LayoutType.SINGLE
+
+        session_configs = list(request.sessions)
+        pane_names = [cfg.name for cfg in session_configs]
+        pane_hierarchy = [
+            {
+                "name": cfg.name,
+                "team": cfg.team,
+                "agent": cfg.agent,
+            }
+            for cfg in session_configs
+        ]
+
+        try:
+            sessions_map = await self.layout_manager.create_layout(
+                layout_type=layout_enum,
+                pane_names=pane_names,
+                pane_hierarchy=pane_hierarchy,
+            )
+
+            created_sessions = []
+            created_items = list(sessions_map.items())
+
+            for idx, (pane_name, session_id) in enumerate(created_items):
+                session = await self.terminal.get_session_by_id(session_id)
+                if not session:
+                    continue
+
+                cfg = session_configs[idx] if idx < len(session_configs) else None
+                agent_name = ""
+                team_name = ""
+
+                if cfg:
+                    team_name = cfg.team
+                    if team_name and not self.agent_registry.get_team(team_name):
+                        self.agent_registry.create_team(team_name)
+
+                    if cfg.agent:
+                        teams = [team_name] if team_name else []
+                        self.agent_registry.register_agent(
+                            name=cfg.agent,
+                            session_id=session.id,
+                            teams=teams,
+                        )
+                        agent_name = cfg.agent
+
+                    if cfg.command:
+                        await session.execute_command(cfg.command)
+
+                created_sessions.append(iterm_mcp_pb2.CreatedSession(
+                    session_id=session.id,
+                    name=session.name,
+                    agent=agent_name,
+                    persistent_id=session.persistent_id,
+                ))
+
+            if created_sessions and not self.agent_registry.active_session:
+                self.agent_registry.active_session = created_sessions[0].session_id
+
+            return iterm_mcp_pb2.CreateSessionsResponse(sessions=created_sessions)
+        except Exception as e:
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details(str(e))
+            return iterm_mcp_pb2.CreateSessionsResponse()
 
     async def WriteToTerminal(self, request, context):
         if not await self.initialize():
@@ -242,6 +323,10 @@ class ITermService(iterm_mcp_pb2_grpc.ITermServiceServicer):
             session = await self.terminal.get_session_by_name(identifier)
         if not session:
             session = await self.terminal.get_session_by_persistent_id(identifier)
+        if not session:
+            agent = self.agent_registry.get_agent(identifier)
+            if agent:
+                session = await self.terminal.get_session_by_id(agent.session_id)
         return session
 
 

--- a/iterm_mcpy/grpc_server.py
+++ b/iterm_mcpy/grpc_server.py
@@ -199,8 +199,16 @@ class ITermService(iterm_mcp_pb2_grpc.ITermServiceServicer):
 
                 if cfg:
                     team_name = cfg.team
-                    if team_name and not self.agent_registry.get_team(team_name):
-                        self.agent_registry.create_team(team_name)
+                    # Materialize team hierarchy if team_name is a path (e.g., "parent/child")
+                    if team_name:
+                        team_path = team_name.split("/")
+                        parent = None
+                        current_path = ""
+                        for part in team_path:
+                            current_path = part if not current_path else f"{current_path}/{part}"
+                            if not self.agent_registry.get_team(current_path):
+                                self.agent_registry.create_team(current_path, parent=parent)
+                            parent = current_path
 
                     if cfg.agent:
                         teams = [team_name] if team_name else []


### PR DESCRIPTION
## Summary
- allow layout creation to accept hierarchical team/agent pane specs and name panes accordingly
- auto-register agents/teams during session creation in FastMCP and gRPC servers, and add hierarchical selection/cascade tools
- document CEO -> Team Leads -> ICs orchestration workflow in the README

## Testing
- python -m pytest tests/test_agent_registry.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693536ede70c8324883a7f2ea1dc34ee)