### PR TITLE
Fix #58: Add OpenTelemetry Integration for Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,128 @@ Sessions maintain persistent identities across restarts and reconnection:
 - State is preserved even after chat or connection interruptions
 - Session output history is available across reconnections
 
+## OpenTelemetry Integration
+
+The iTerm MCP server includes optional OpenTelemetry integration for production-grade observability, enabling tracing of agent operations, message delivery, and command execution.
+
+### Installation
+
+Install with OpenTelemetry support:
+
+```bash
+pip install -e ".[otel]"
+```
+
+This installs:
+- `opentelemetry-api` - Core tracing API
+- `opentelemetry-sdk` - Tracing SDK
+- `opentelemetry-exporter-otlp` - OTLP exporter for backends like Jaeger
+- `opentelemetry-semantic-conventions` - Standard attribute names
+
+### Configuration
+
+Configure via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_ENABLED` | `true` | Enable/disable tracing |
+| `OTEL_SERVICE_NAME` | `iterm-mcp` | Service name in traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint |
+| `OTEL_TRACES_EXPORTER` | `otlp` | Exporter type (`otlp`, `console`, `none`) |
+| `OTEL_CONSOLE_EXPORTER` | `false` | Enable console exporter for debugging |
+| `OTEL_ENVIRONMENT` | `development` | Deployment environment tag |
+
+### Traced Operations
+
+The following operations are automatically traced:
+
+**Session Operations:**
+- `session.send_text` - Text sent to sessions
+- `session.execute_command` - Command execution
+- `session.get_screen_contents` - Screen content retrieval
+- `session.send_control_character` - Control character sends
+- `session.send_special_key` - Special key sends
+
+**Agent/Team Operations:**
+- `agent_registry.register_agent` - Agent registration
+- `agent_registry.remove_agent` - Agent removal
+- `agent_registry.create_team` - Team creation
+- `agent_registry.remove_team` - Team removal
+- `agent_registry.resolve_cascade_targets` - Cascade message resolution
+
+Each span includes relevant attributes like `agent.name`, `session.id`, `team.name`, and operation-specific metadata.
+
+### Connecting to Observability Backends
+
+#### Jaeger
+
+Run Jaeger with OTLP support:
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+```
+
+Then start the server:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 python -m iterm_mcpy.fastmcp_server
+```
+
+View traces at http://localhost:16686
+
+#### Grafana Tempo
+
+Configure the OTLP endpoint to your Tempo instance:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317 python -m iterm_mcpy.fastmcp_server
+```
+
+#### Console Debugging
+
+For local debugging without a backend:
+
+```bash
+OTEL_CONSOLE_EXPORTER=true python -m iterm_mcpy.fastmcp_server
+```
+
+This prints spans to stdout.
+
+### Programmatic Usage
+
+Use the tracing utilities in your own code:
+
+```python
+from utils.otel import (
+    init_tracing,
+    trace_operation,
+    add_span_attributes,
+    add_span_event,
+    create_span,
+)
+
+# Initialize tracing at startup
+init_tracing()
+
+# Use decorator for automatic tracing
+@trace_operation("my_operation")
+async def my_function(agent: str, session_id: str):
+    add_span_attributes(custom_attr="value")
+    # ... do work ...
+    add_span_event("checkpoint_reached", {"step": 1})
+
+# Or use context manager for manual spans
+with create_span("custom_span", attributes={"key": "value"}):
+    # ... traced code ...
+```
+
+### Graceful Fallback
+
+If OpenTelemetry is not installed, the server uses no-op implementations that have zero overhead. This allows the same code to run with or without observability enabled.
+
 ## Relationship to Claude Code MCP
 
 This project provides **multi-agent orchestration infrastructure** that complements tools like [@steipete/claude-code-mcp](https://github.com/steipete/claude-code-mcp):

--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Configure via environment variables:
 | `OTEL_ENABLED` | `true` | Enable/disable tracing |
 | `OTEL_SERVICE_NAME` | `iterm-mcp` | Service name in traces |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint |
+| `OTEL_EXPORTER_OTLP_INSECURE` | `true` | Use insecure (HTTP) connection to collector |
 | `OTEL_TRACES_EXPORTER` | `otlp` | Exporter type (`otlp`, `console`, `none`) |
 | `OTEL_CONSOLE_EXPORTER` | `false` | Enable console exporter for debugging |
 | `OTEL_ENVIRONMENT` | `development` | Deployment environment tag |
@@ -875,6 +876,12 @@ The following operations are automatically traced:
 - `agent_registry.create_team` - Team creation
 - `agent_registry.remove_team` - Team removal
 - `agent_registry.resolve_cascade_targets` - Cascade message resolution
+
+**RPC/Service Operations:**
+- `execute_create_sessions` - Create and initialize new sessions
+- `execute_write_request` - Write data or commands to sessions
+- `execute_read_request` - Read data or screen contents from sessions
+- `execute_cascade_request` - Execute cascade operations across agents/teams
 
 Each span includes relevant attributes like `agent.name`, `session.id`, `team.name`, and operation-specific metadata.
 

--- a/core/session.py
+++ b/core/session.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Tuple, Union, Callable, Literal
 import iterm2
 
 from utils.logging import ItermSessionLogger
-from utils.otel import trace_operation, add_span_attributes, add_span_event, create_span
+from utils.otel import trace_operation, add_span_attributes, add_span_event
 
 # Characters that can cause shell parsing issues when typed directly
 # These require base64 encoding to safely execute

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -25,11 +25,8 @@ from utils.telemetry import TelemetryEmitter
 from utils.otel import (
     init_tracing,
     shutdown_tracing,
-    get_tracer,
     trace_operation,
     add_span_attributes,
-    add_span_event,
-    create_span,
 )
 from core.tags import SessionTagLockManager, FocusCooldownManager
 from core.profiles import ProfileManager, get_profile_manager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,24 @@ dependencies = [
     "pyyaml>=6.0",
     "mcp>=1.3.0",
     "grpcio>=1.76.0",
-    "protobuf>=6.31.1"
+    "protobuf>=6.31.1",
 ]
 
 [project.optional-dependencies]
+# OpenTelemetry for observability - install with: pip install iterm-mcp[otel]
+otel = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
+    "opentelemetry-semantic-conventions>=0.41b0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.1.0",
     "black>=23.0.0",
     "mypy>=1.0.0",
     "isort>=5.0.0",
-    "grpcio-tools>=1.76.0"
+    "grpcio-tools>=1.76.0",
 ]
 
 [project.scripts]

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,339 @@
+"""Tests for OpenTelemetry instrumentation module."""
+
+import asyncio
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestOtelModule(unittest.TestCase):
+    """Test the OpenTelemetry instrumentation module."""
+
+    def setUp(self):
+        """Reset module state before each test."""
+        # Clear any cached module state
+        import utils.otel as otel_module
+        otel_module._tracer = None
+        otel_module._initialized = False
+
+    def tearDown(self):
+        """Clean up after each test."""
+        from utils.otel import shutdown_tracing
+        shutdown_tracing()
+
+    def test_init_tracing_without_otel_installed(self):
+        """Test graceful fallback when OpenTelemetry is not installed."""
+        import utils.otel as otel_module
+
+        # Simulate OTEL not being available
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+
+        try:
+            from utils.otel import init_tracing, get_tracer, NoOpTracer
+
+            result = init_tracing()
+            self.assertFalse(result)
+
+            tracer = get_tracer()
+            self.assertIsInstance(tracer, NoOpTracer)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_init_tracing_disabled_via_env(self):
+        """Test that tracing can be disabled via environment variable."""
+        import utils.otel as otel_module
+
+        original_enabled = otel_module.OTEL_ENABLED
+        otel_module.OTEL_ENABLED = False
+
+        try:
+            from utils.otel import init_tracing, get_tracer, NoOpTracer
+
+            result = init_tracing()
+            self.assertFalse(result)
+
+            tracer = get_tracer()
+            self.assertIsInstance(tracer, NoOpTracer)
+        finally:
+            otel_module.OTEL_ENABLED = original_enabled
+
+    def test_noop_span_methods(self):
+        """Test that NoOpSpan methods don't raise exceptions."""
+        from utils.otel import NoOpSpan
+
+        span = NoOpSpan()
+
+        # These should all work without error
+        span.set_attribute("key", "value")
+        span.set_status(None)
+        span.record_exception(Exception("test"))
+        span.add_event("test_event", {"key": "value"})
+
+        # Test context manager
+        with span as s:
+            self.assertIsInstance(s, NoOpSpan)
+
+    def test_noop_tracer_methods(self):
+        """Test that NoOpTracer methods return NoOpSpan."""
+        from utils.otel import NoOpTracer, NoOpSpan
+
+        tracer = NoOpTracer()
+
+        # Test start_as_current_span
+        span = tracer.start_as_current_span("test_span")
+        self.assertIsInstance(span, NoOpSpan)
+
+        # Test start_span context manager
+        with tracer.start_span("test_span") as span:
+            self.assertIsInstance(span, NoOpSpan)
+
+    def test_get_tracer_initializes_if_needed(self):
+        """Test that get_tracer auto-initializes if not done."""
+        import utils.otel as otel_module
+
+        # Ensure not initialized
+        otel_module._tracer = None
+        otel_module._initialized = False
+
+        from utils.otel import get_tracer
+
+        tracer = get_tracer()
+        # Should have initialized and returned a tracer
+        self.assertIsNotNone(tracer)
+
+    def test_trace_operation_decorator_sync(self):
+        """Test trace_operation decorator on sync function."""
+        from utils.otel import trace_operation, init_tracing
+
+        # Initialize with NoOp for testing
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            @trace_operation("test.sync_operation")
+            def sync_function(x, y):
+                return x + y
+
+            result = sync_function(1, 2)
+            self.assertEqual(result, 3)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_trace_operation_decorator_async(self):
+        """Test trace_operation decorator on async function."""
+        from utils.otel import trace_operation, init_tracing
+
+        # Initialize with NoOp for testing
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            @trace_operation("test.async_operation")
+            async def async_function(x, y):
+                return x + y
+
+            result = asyncio.get_event_loop().run_until_complete(async_function(3, 4))
+            self.assertEqual(result, 7)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_trace_operation_exception_handling(self):
+        """Test that trace_operation properly handles exceptions."""
+        from utils.otel import trace_operation, init_tracing
+
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            @trace_operation("test.exception_operation")
+            def failing_function():
+                raise ValueError("Test error")
+
+            with self.assertRaises(ValueError):
+                failing_function()
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_add_span_attributes_without_otel(self):
+        """Test add_span_attributes is safe without OTEL."""
+        from utils.otel import add_span_attributes, init_tracing
+
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            # Should not raise
+            add_span_attributes(key="value", number=42)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_add_span_event_without_otel(self):
+        """Test add_span_event is safe without OTEL."""
+        from utils.otel import add_span_event, init_tracing
+
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            # Should not raise
+            add_span_event("test_event", {"key": "value"})
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_create_span_context_manager(self):
+        """Test create_span context manager."""
+        from utils.otel import create_span, init_tracing
+
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            with create_span("test_span", attributes={"key": "value"}) as span:
+                # Should work without error
+                self.assertIsNotNone(span)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+    def test_extract_agent_name_from_kwargs(self):
+        """Test _extract_agent_name helper function."""
+        from utils.otel import _extract_agent_name
+
+        # Test direct kwargs
+        result = _extract_agent_name((), {"agent": "test-agent"})
+        self.assertEqual(result, "test-agent")
+
+        result = _extract_agent_name((), {"agent_name": "test-agent-2"})
+        self.assertEqual(result, "test-agent-2")
+
+        # Test when not present
+        result = _extract_agent_name((), {})
+        self.assertIsNone(result)
+
+    def test_extract_session_id_from_kwargs(self):
+        """Test _extract_session_id helper function."""
+        from utils.otel import _extract_session_id
+
+        # Test direct kwargs
+        result = _extract_session_id((), {"session_id": "session-123"})
+        self.assertEqual(result, "session-123")
+
+        # Test when not present
+        result = _extract_session_id((), {})
+        self.assertIsNone(result)
+
+    def test_shutdown_tracing(self):
+        """Test shutdown_tracing clears state."""
+        from utils.otel import init_tracing, shutdown_tracing, get_tracer
+
+        import utils.otel as otel_module
+        original_available = otel_module.OTEL_AVAILABLE
+        otel_module.OTEL_AVAILABLE = False
+        init_tracing()
+
+        try:
+            # Should be initialized
+            self.assertTrue(otel_module._initialized)
+
+            shutdown_tracing()
+
+            # Should be reset
+            self.assertFalse(otel_module._initialized)
+            self.assertIsNone(otel_module._tracer)
+        finally:
+            otel_module.OTEL_AVAILABLE = original_available
+
+
+class TestOtelWithMockedSDK(unittest.TestCase):
+    """Test OpenTelemetry with mocked SDK for full coverage."""
+
+    def setUp(self):
+        """Reset module state before each test."""
+        import utils.otel as otel_module
+        otel_module._tracer = None
+        otel_module._initialized = False
+
+    def tearDown(self):
+        """Clean up after each test."""
+        from utils.otel import shutdown_tracing
+        shutdown_tracing()
+
+    @patch.dict(os.environ, {"OTEL_CONSOLE_EXPORTER": "true"})
+    def test_init_with_console_exporter(self):
+        """Test initialization with console exporter."""
+        # This test will only work if OTEL is installed
+        import utils.otel as otel_module
+
+        if not otel_module.OTEL_AVAILABLE:
+            self.skipTest("OpenTelemetry not installed")
+
+        # Reset state
+        otel_module._tracer = None
+        otel_module._initialized = False
+        otel_module.OTEL_CONSOLE = True
+
+        try:
+            result = otel_module.init_tracing()
+            self.assertTrue(result)
+        finally:
+            otel_module.OTEL_CONSOLE = False
+            otel_module.shutdown_tracing()
+
+
+class TestTraceOperationAgentExtraction(unittest.TestCase):
+    """Test agent and session extraction in trace_operation."""
+
+    def setUp(self):
+        """Reset module state."""
+        import utils.otel as otel_module
+        otel_module._tracer = None
+        otel_module._initialized = False
+        otel_module.OTEL_AVAILABLE = False
+        otel_module.init_tracing()
+
+    def tearDown(self):
+        """Clean up."""
+        from utils.otel import shutdown_tracing
+        shutdown_tracing()
+
+    def test_extract_from_request_object(self):
+        """Test extraction from a request object with agent attribute."""
+        from utils.otel import _extract_agent_name, _extract_session_id
+
+        class MockRequest:
+            agent = "request-agent"
+            session_id = "request-session"
+
+        request = MockRequest()
+
+        result = _extract_agent_name((request,), {})
+        self.assertEqual(result, "request-agent")
+
+        result = _extract_session_id((request,), {})
+        self.assertEqual(result, "request-session")
+
+    def test_extract_requesting_agent(self):
+        """Test extraction of requesting_agent attribute."""
+        from utils.otel import _extract_agent_name
+
+        class MockRequest:
+            requesting_agent = "requesting-agent"
+
+        result = _extract_agent_name((MockRequest(),), {})
+        self.assertEqual(result, "requesting-agent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestOtelModule(unittest.TestCase):
@@ -137,7 +137,7 @@ class TestOtelModule(unittest.TestCase):
             async def async_function(x, y):
                 return x + y
 
-            result = asyncio.get_event_loop().run_until_complete(async_function(3, 4))
+            result = asyncio.run(async_function(3, 4))
             self.assertEqual(result, 7)
         finally:
             otel_module.OTEL_AVAILABLE = original_available

--- a/utils/otel.py
+++ b/utils/otel.py
@@ -1,0 +1,536 @@
+"""OpenTelemetry instrumentation for iTerm MCP server.
+
+This module provides production-grade observability through OpenTelemetry,
+enabling tracing of agent operations, message delivery, and command execution.
+
+Configuration:
+    Environment variables:
+    - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint (default: http://localhost:4317)
+    - OTEL_SERVICE_NAME: Service name (default: iterm-mcp)
+    - OTEL_TRACES_EXPORTER: Exporter type (otlp, console, none)
+    - OTEL_ENABLED: Enable/disable tracing (default: true)
+    - OTEL_CONSOLE_EXPORTER: Use console exporter for debugging (default: false)
+
+Usage:
+    from utils.otel import get_tracer, trace_operation, init_tracing
+
+    # Initialize at startup
+    init_tracing()
+
+    # Use decorator for automatic tracing
+    @trace_operation("my_operation")
+    async def my_function():
+        ...
+
+    # Or use tracer directly
+    tracer = get_tracer()
+    with tracer.start_as_current_span("my_span") as span:
+        span.set_attribute("key", "value")
+"""
+
+import asyncio
+import functools
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Optional, TypeVar, Union
+
+# OpenTelemetry imports with graceful fallback
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import Status, StatusCode, Span, Tracer
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.semconv.resource import ResourceAttributes
+
+    # OTLP exporter - optional dependency
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        OTLP_AVAILABLE = True
+    except ImportError:
+        OTLP_AVAILABLE = False
+
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+    OTLP_AVAILABLE = False
+
+logger = logging.getLogger("iterm-mcp.otel")
+
+# Type variable for generic function signatures
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Global tracer instance
+_tracer: Optional[Any] = None
+_initialized: bool = False
+
+# Configuration from environment
+OTEL_ENABLED = os.getenv("OTEL_ENABLED", "true").lower() in ("true", "1", "yes")
+OTEL_SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "iterm-mcp")
+OTEL_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+OTEL_EXPORTER = os.getenv("OTEL_TRACES_EXPORTER", "otlp")
+OTEL_CONSOLE = os.getenv("OTEL_CONSOLE_EXPORTER", "false").lower() in ("true", "1", "yes")
+
+
+class NoOpSpan:
+    """No-op span implementation when OpenTelemetry is not available."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def set_status(self, status: Any) -> None:
+        pass
+
+    def record_exception(self, exception: Exception) -> None:
+        pass
+
+    def add_event(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
+        pass
+
+    def __enter__(self) -> "NoOpSpan":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class NoOpTracer:
+    """No-op tracer implementation when OpenTelemetry is not available."""
+
+    def start_as_current_span(
+        self,
+        name: str,
+        **kwargs: Any
+    ) -> NoOpSpan:
+        return NoOpSpan()
+
+    @contextmanager
+    def start_span(self, name: str, **kwargs: Any):
+        yield NoOpSpan()
+
+
+def init_tracing(
+    service_name: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    console_exporter: Optional[bool] = None,
+) -> bool:
+    """Initialize OpenTelemetry tracing.
+
+    Args:
+        service_name: Override OTEL_SERVICE_NAME
+        endpoint: Override OTEL_EXPORTER_OTLP_ENDPOINT
+        console_exporter: Override OTEL_CONSOLE_EXPORTER
+
+    Returns:
+        True if tracing was initialized, False otherwise
+    """
+    global _tracer, _initialized
+
+    if _initialized:
+        return True
+
+    if not OTEL_AVAILABLE:
+        logger.info(
+            "OpenTelemetry not available - install with: "
+            "pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp"
+        )
+        _tracer = NoOpTracer()
+        _initialized = True
+        return False
+
+    if not OTEL_ENABLED:
+        logger.info("OpenTelemetry tracing disabled via OTEL_ENABLED=false")
+        _tracer = NoOpTracer()
+        _initialized = True
+        return False
+
+    # Use provided values or fall back to environment/defaults
+    svc_name = service_name or OTEL_SERVICE_NAME
+    otlp_endpoint = endpoint or OTEL_ENDPOINT
+    use_console = console_exporter if console_exporter is not None else OTEL_CONSOLE
+
+    try:
+        # Create resource with service information
+        resource = Resource.create({
+            ResourceAttributes.SERVICE_NAME: svc_name,
+            ResourceAttributes.SERVICE_VERSION: "0.1.0",
+            "deployment.environment": os.getenv("OTEL_ENVIRONMENT", "development"),
+        })
+
+        # Create tracer provider
+        provider = TracerProvider(resource=resource)
+
+        # Add exporters based on configuration
+        exporter_added = False
+
+        if use_console:
+            # Console exporter for debugging
+            console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+            provider.add_span_processor(console_processor)
+            logger.info("OpenTelemetry console exporter enabled")
+            exporter_added = True
+
+        if OTEL_EXPORTER == "otlp" and OTLP_AVAILABLE:
+            # OTLP exporter for production
+            try:
+                otlp_exporter = OTLPSpanExporter(
+                    endpoint=otlp_endpoint,
+                    insecure=True,  # Use HTTP for local development
+                )
+                otlp_processor = BatchSpanProcessor(otlp_exporter)
+                provider.add_span_processor(otlp_processor)
+                logger.info(f"OpenTelemetry OTLP exporter enabled: {otlp_endpoint}")
+                exporter_added = True
+            except Exception as e:
+                logger.warning(f"Failed to initialize OTLP exporter: {e}")
+        elif OTEL_EXPORTER == "otlp" and not OTLP_AVAILABLE:
+            logger.warning(
+                "OTLP exporter requested but not available - "
+                "install with: pip install opentelemetry-exporter-otlp"
+            )
+
+        if not exporter_added:
+            # Fall back to console exporter if nothing else configured
+            console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+            provider.add_span_processor(console_processor)
+            logger.info("OpenTelemetry using console exporter (default)")
+
+        # Set the tracer provider
+        trace.set_tracer_provider(provider)
+        _tracer = trace.get_tracer(svc_name)
+        _initialized = True
+
+        logger.info(f"OpenTelemetry tracing initialized for service: {svc_name}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to initialize OpenTelemetry: {e}")
+        _tracer = NoOpTracer()
+        _initialized = True
+        return False
+
+
+def get_tracer() -> Union[Any, NoOpTracer]:
+    """Get the global tracer instance.
+
+    Returns:
+        Tracer instance (or NoOpTracer if not initialized)
+    """
+    global _tracer
+
+    if _tracer is None:
+        init_tracing()
+
+    return _tracer
+
+
+def shutdown_tracing() -> None:
+    """Shutdown tracing and flush pending spans."""
+    global _tracer, _initialized
+
+    if OTEL_AVAILABLE and _initialized:
+        try:
+            provider = trace.get_tracer_provider()
+            if hasattr(provider, "shutdown"):
+                provider.shutdown()
+            logger.info("OpenTelemetry tracing shutdown complete")
+        except Exception as e:
+            logger.warning(f"Error during tracing shutdown: {e}")
+
+    _tracer = None
+    _initialized = False
+
+
+def trace_operation(
+    operation_name: str,
+    *,
+    extract_agent: bool = True,
+    extract_session: bool = True,
+    record_args: bool = False,
+) -> Callable[[F], F]:
+    """Decorator to trace an operation with OpenTelemetry.
+
+    This decorator automatically:
+    - Creates a span for the operation
+    - Extracts agent and session info from kwargs
+    - Records success/failure status
+    - Records exceptions
+
+    Args:
+        operation_name: Name of the operation (used as span name)
+        extract_agent: Extract agent name from kwargs (default: True)
+        extract_session: Extract session_id from kwargs (default: True)
+        record_args: Record function arguments as attributes (default: False)
+
+    Returns:
+        Decorated function with automatic tracing
+
+    Example:
+        @trace_operation("write_to_session")
+        async def write_to_sessions(request: WriteToSessionsRequest):
+            ...
+    """
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer()
+
+            with tracer.start_as_current_span(operation_name) as span:
+                # Set common attributes
+                span.set_attribute("operation.name", operation_name)
+
+                # Extract agent name from various sources
+                if extract_agent:
+                    agent_name = _extract_agent_name(args, kwargs)
+                    if agent_name:
+                        span.set_attribute("agent.name", agent_name)
+
+                # Extract session ID from various sources
+                if extract_session:
+                    session_id = _extract_session_id(args, kwargs)
+                    if session_id:
+                        span.set_attribute("session.id", session_id)
+
+                # Record arguments if requested
+                if record_args:
+                    _record_arguments(span, args, kwargs)
+
+                try:
+                    result = await func(*args, **kwargs)
+
+                    if OTEL_AVAILABLE:
+                        span.set_status(Status(StatusCode.OK))
+
+                    # Record result info if applicable
+                    _record_result(span, result)
+
+                    return result
+
+                except Exception as e:
+                    if OTEL_AVAILABLE:
+                        span.set_status(Status(StatusCode.ERROR, str(e)))
+                        span.record_exception(e)
+                    raise
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer()
+
+            with tracer.start_as_current_span(operation_name) as span:
+                span.set_attribute("operation.name", operation_name)
+
+                if extract_agent:
+                    agent_name = _extract_agent_name(args, kwargs)
+                    if agent_name:
+                        span.set_attribute("agent.name", agent_name)
+
+                if extract_session:
+                    session_id = _extract_session_id(args, kwargs)
+                    if session_id:
+                        span.set_attribute("session.id", session_id)
+
+                if record_args:
+                    _record_arguments(span, args, kwargs)
+
+                try:
+                    result = func(*args, **kwargs)
+
+                    if OTEL_AVAILABLE:
+                        span.set_status(Status(StatusCode.OK))
+
+                    _record_result(span, result)
+                    return result
+
+                except Exception as e:
+                    if OTEL_AVAILABLE:
+                        span.set_status(Status(StatusCode.ERROR, str(e)))
+                        span.record_exception(e)
+                    raise
+
+        # Return appropriate wrapper based on function type
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper  # type: ignore
+        return sync_wrapper  # type: ignore
+
+    return decorator
+
+
+def _extract_agent_name(args: tuple, kwargs: dict) -> Optional[str]:
+    """Extract agent name from function arguments."""
+    # Check kwargs directly
+    if "agent" in kwargs:
+        return kwargs["agent"]
+    if "agent_name" in kwargs:
+        return kwargs["agent_name"]
+
+    # Check request objects
+    request = kwargs.get("request") or (args[0] if args else None)
+    if request:
+        # Check for agent attribute
+        if hasattr(request, "agent"):
+            return getattr(request, "agent")
+        if hasattr(request, "agent_name"):
+            return getattr(request, "agent_name")
+        # Check for requesting_agent
+        if hasattr(request, "requesting_agent"):
+            return getattr(request, "requesting_agent")
+
+    return None
+
+
+def _extract_session_id(args: tuple, kwargs: dict) -> Optional[str]:
+    """Extract session ID from function arguments."""
+    # Check kwargs directly
+    if "session_id" in kwargs:
+        return kwargs["session_id"]
+
+    # Check request objects
+    request = kwargs.get("request") or (args[0] if args else None)
+    if request:
+        if hasattr(request, "session_id"):
+            return getattr(request, "session_id")
+        # Check targets for session_id
+        if hasattr(request, "targets"):
+            targets = getattr(request, "targets")
+            if targets and len(targets) > 0:
+                first_target = targets[0]
+                if hasattr(first_target, "session_id"):
+                    return getattr(first_target, "session_id")
+
+    return None
+
+
+def _record_arguments(span: Any, args: tuple, kwargs: dict) -> None:
+    """Record function arguments as span attributes."""
+    try:
+        for i, arg in enumerate(args):
+            if isinstance(arg, (str, int, float, bool)):
+                span.set_attribute(f"arg.{i}", str(arg))
+            elif hasattr(arg, "__class__"):
+                span.set_attribute(f"arg.{i}.type", arg.__class__.__name__)
+
+        for key, value in kwargs.items():
+            if isinstance(value, (str, int, float, bool)):
+                span.set_attribute(f"kwarg.{key}", str(value))
+            elif hasattr(value, "__class__"):
+                span.set_attribute(f"kwarg.{key}.type", value.__class__.__name__)
+    except Exception:
+        pass  # Don't fail tracing due to argument recording
+
+
+def _record_result(span: Any, result: Any) -> None:
+    """Record result information as span attributes."""
+    try:
+        if result is None:
+            return
+
+        # Record result type
+        span.set_attribute("result.type", type(result).__name__)
+
+        # Record specific result attributes for known types
+        if hasattr(result, "sent_count"):
+            span.set_attribute("result.sent_count", result.sent_count)
+        if hasattr(result, "skipped_count"):
+            span.set_attribute("result.skipped_count", result.skipped_count)
+        if hasattr(result, "error_count"):
+            span.set_attribute("result.error_count", result.error_count)
+        if hasattr(result, "total_sessions"):
+            span.set_attribute("result.total_sessions", result.total_sessions)
+        if hasattr(result, "success"):
+            span.set_attribute("result.success", result.success)
+    except Exception:
+        pass  # Don't fail tracing due to result recording
+
+
+def add_span_attributes(**attributes: Any) -> None:
+    """Add attributes to the current span.
+
+    Args:
+        **attributes: Key-value pairs to add as span attributes
+
+    Example:
+        add_span_attributes(
+            team="backend",
+            message_count=5,
+            operation_type="cascade"
+        )
+    """
+    if not OTEL_AVAILABLE:
+        return
+
+    try:
+        span = trace.get_current_span()
+        for key, value in attributes.items():
+            if isinstance(value, (str, int, float, bool)):
+                span.set_attribute(key, value)
+            else:
+                span.set_attribute(key, str(value))
+    except Exception:
+        pass  # Don't fail if span not available
+
+
+def add_span_event(name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
+    """Add an event to the current span.
+
+    Args:
+        name: Event name
+        attributes: Optional event attributes
+
+    Example:
+        add_span_event("message_delivered", {"recipient": "agent-1"})
+    """
+    if not OTEL_AVAILABLE:
+        return
+
+    try:
+        span = trace.get_current_span()
+        span.add_event(name, attributes=attributes or {})
+    except Exception:
+        pass  # Don't fail if span not available
+
+
+@contextmanager
+def create_span(
+    name: str,
+    *,
+    attributes: Optional[Dict[str, Any]] = None,
+    record_exception: bool = True,
+):
+    """Context manager to create a child span.
+
+    Args:
+        name: Span name
+        attributes: Optional span attributes
+        record_exception: Whether to record exceptions (default: True)
+
+    Yields:
+        Span object (or NoOpSpan if tracing unavailable)
+
+    Example:
+        with create_span("process_message", attributes={"message_id": "123"}):
+            process_message(msg)
+    """
+    tracer = get_tracer()
+
+    with tracer.start_as_current_span(name) as span:
+        if attributes:
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+
+        try:
+            yield span
+        except Exception as e:
+            if record_exception and OTEL_AVAILABLE:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+            raise
+        else:
+            if OTEL_AVAILABLE:
+                span.set_status(Status(StatusCode.OK))


### PR DESCRIPTION
## Summary

Implement comprehensive OpenTelemetry tracing for the iterm-mcp server, enabling production-grade observability of agent operations, message delivery, and command execution.

Closes #58

## Changes

### New Files
- **`utils/otel.py`** - OpenTelemetry instrumentation module with:
  - `@trace_operation` decorator for automatic span creation
  - NoOp fallback when OpenTelemetry is not installed
  - `add_span_attributes()` and `add_span_event()` helpers
  - `create_span()` context manager for manual spans
  - Environment variable configuration

- **`tests/test_otel.py`** - Comprehensive test suite (17 tests)

### Modified Files
- **`core/session.py`** - Traced session operations:
  - `send_text`, `execute_command`, `get_screen_contents`
  - `send_control_character`, `send_special_key`

- **`core/agents.py`** - Traced agent/team operations:
  - `register_agent`, `remove_agent`
  - `create_team`, `remove_team`
  - `resolve_cascade_targets`

- **`iterm_mcpy/fastmcp_server.py`** - Initialize tracing in lifespan

- **`pyproject.toml`** - Added optional `[otel]` dependency group

- **`README.md`** - Added OpenTelemetry documentation section

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `OTEL_ENABLED` | `true` | Enable/disable tracing |
| `OTEL_SERVICE_NAME` | `iterm-mcp` | Service name in traces |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP endpoint |
| `OTEL_CONSOLE_EXPORTER` | `false` | Console exporter for debugging |

## Installation

```bash
pip install -e ".[otel]"
```

## Test Plan

- [x] Run `test_otel.py` - 17 tests passing
- [x] Run `test_agent_registry.py` - 34 tests passing  
- [x] Run `test_models.py` - 40 tests passing
- [x] Verify NoOp fallback works when OTEL not installed
- [x] Verify tracing decorators don't break existing functionality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)