### PR TITLE
Fix #57: Add State Persistence & Checkpointing for Sessions

### DIFF
--- a/core/agents.py
+++ b/core/agents.py
@@ -439,3 +439,141 @@ class AgentRegistry:
             if agent:
                 session_ids.append(agent.session_id)
         return session_ids
+
+    # ==================== State Persistence ====================
+
+    def save_state(self) -> Dict:
+        """Serialize registry state to a JSON-compatible dict.
+
+        Returns a complete snapshot of the registry state including
+        agents, teams, active session, and recent message history.
+        This can be used for checkpointing, crash recovery, or debugging.
+
+        Returns:
+            Dict containing serializable registry state
+        """
+        # Serialize agents
+        agents_state = {}
+        for name, agent in self._agents.items():
+            agents_state[name] = {
+                "name": agent.name,
+                "session_id": agent.session_id,
+                "teams": agent.teams,
+                "created_at": agent.created_at.isoformat(),
+                "metadata": agent.metadata
+            }
+
+        # Serialize teams
+        teams_state = {}
+        for name, team in self._teams.items():
+            teams_state[name] = {
+                "name": team.name,
+                "description": team.description,
+                "parent_team": team.parent_team,
+                "created_at": team.created_at.isoformat()
+            }
+
+        # Serialize recent message history (for deduplication state)
+        message_history = []
+        for record in list(self._message_history)[-100:]:  # Limit to last 100
+            message_history.append({
+                "content_hash": record.content_hash,
+                "recipients": record.recipients,
+                "timestamp": record.timestamp.isoformat()
+            })
+
+        return {
+            "agents": agents_state,
+            "teams": teams_state,
+            "active_session": self._active_session,
+            "message_history": message_history,
+            "created_at": datetime.now(timezone.utc).isoformat()
+        }
+
+    def load_state(self, state: Dict) -> None:
+        """Restore registry state from a saved state dict.
+
+        This replaces the current registry state with the state from
+        the checkpoint. Useful for crash recovery or session resumption.
+
+        Args:
+            state: Previously saved state dict from save_state()
+        """
+        # Clear current state
+        self._agents.clear()
+        self._teams.clear()
+        self._message_history.clear()
+
+        # Restore agents
+        agents_data = state.get("agents", {})
+        for name, agent_data in agents_data.items():
+            # Parse created_at if it's a string
+            created_at = agent_data.get("created_at")
+            if isinstance(created_at, str):
+                created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            elif created_at is None:
+                created_at = datetime.now(timezone.utc)
+
+            agent = Agent(
+                name=agent_data["name"],
+                session_id=agent_data["session_id"],
+                teams=agent_data.get("teams", []),
+                created_at=created_at,
+                metadata=agent_data.get("metadata", {})
+            )
+            self._agents[name] = agent
+
+        # Restore teams
+        teams_data = state.get("teams", {})
+        for name, team_data in teams_data.items():
+            created_at = team_data.get("created_at")
+            if isinstance(created_at, str):
+                created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            elif created_at is None:
+                created_at = datetime.now(timezone.utc)
+
+            team = Team(
+                name=team_data["name"],
+                description=team_data.get("description", ""),
+                parent_team=team_data.get("parent_team"),
+                created_at=created_at
+            )
+            self._teams[name] = team
+
+        # Restore active session
+        self._active_session = state.get("active_session")
+
+        # Restore message history
+        message_history = state.get("message_history", [])
+        for record_data in message_history:
+            timestamp = record_data.get("timestamp")
+            if isinstance(timestamp, str):
+                timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            elif timestamp is None:
+                timestamp = datetime.now(timezone.utc)
+
+            record = MessageRecord(
+                content_hash=record_data["content_hash"],
+                recipients=record_data["recipients"],
+                timestamp=timestamp
+            )
+            self._message_history.append(record)
+
+        # Persist restored state to files
+        self._save_agents()
+        self._save_teams()
+
+    def get_state_summary(self) -> Dict:
+        """Get a brief summary of registry state for logging/debugging.
+
+        Returns:
+            Dict with key registry state info
+        """
+        return {
+            "agent_count": len(self._agents),
+            "team_count": len(self._teams),
+            "active_session": self._active_session,
+            "message_history_count": len(self._message_history),
+            "agents": list(self._agents.keys()),
+            "teams": list(self._teams.keys())
+        }

--- a/core/checkpointing.py
+++ b/core/checkpointing.py
@@ -1,0 +1,685 @@
+"""State persistence and checkpointing for sessions and agents.
+
+This module provides checkpointing capabilities for crash recovery, session resumption,
+and state replay for debugging. Inspired by patterns from LangGraph, AutoGen, and
+Agency Swarm frameworks.
+
+Key features:
+- Automatic checkpoint creation on major operations
+- FileCheckpointer for local development
+- SQLiteCheckpointer for production use
+- Session and agent state serialization
+"""
+
+import json
+import os
+import sqlite3
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Union, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class SessionState(BaseModel):
+    """Serializable state of an iTerm session."""
+
+    session_id: str = Field(..., description="The iTerm session ID")
+    persistent_id: str = Field(..., description="Persistent ID for reconnection")
+    name: str = Field(..., description="Session name")
+    max_lines: int = Field(default=50, description="Max lines to retrieve")
+    is_monitoring: bool = Field(default=False, description="Whether monitoring is active")
+    last_screen_update: float = Field(default=0.0, description="Timestamp of last screen update")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # Optional context data
+    last_command: Optional[str] = Field(default=None, description="Last command executed")
+    last_output: Optional[str] = Field(default=None, description="Last captured output")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional session metadata")
+
+
+class AgentState(BaseModel):
+    """Serializable state of an agent."""
+
+    name: str = Field(..., description="Agent name")
+    session_id: str = Field(..., description="Associated session ID")
+    teams: List[str] = Field(default_factory=list, description="Team memberships")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: Dict[str, str] = Field(default_factory=dict, description="Agent metadata")
+
+
+class TeamState(BaseModel):
+    """Serializable state of a team."""
+
+    name: str = Field(..., description="Team name")
+    description: str = Field(default="", description="Team description")
+    parent_team: Optional[str] = Field(default=None, description="Parent team name")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class RegistryState(BaseModel):
+    """Serializable state of the agent registry."""
+
+    agents: Dict[str, AgentState] = Field(default_factory=dict)
+    teams: Dict[str, TeamState] = Field(default_factory=dict)
+    active_session: Optional[str] = Field(default=None)
+    message_history: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class Checkpoint(BaseModel):
+    """A complete checkpoint containing session and registry state."""
+
+    checkpoint_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    version: str = Field(default="1.0", description="Checkpoint format version")
+
+    # Session states
+    sessions: Dict[str, SessionState] = Field(default_factory=dict)
+
+    # Registry state (agents, teams, messages)
+    registry: Optional[RegistryState] = Field(default=None)
+
+    # Metadata about what triggered this checkpoint
+    trigger: str = Field(default="manual", description="What triggered this checkpoint")
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+@runtime_checkable
+class Checkpointer(Protocol):
+    """Protocol for checkpoint storage backends.
+
+    Checkpointers handle saving and loading checkpoint data.
+    Implementations include file-based and SQLite-based storage.
+    """
+
+    async def save(self, checkpoint: Checkpoint) -> str:
+        """Save a checkpoint.
+
+        Args:
+            checkpoint: The checkpoint to save
+
+        Returns:
+            The checkpoint ID
+        """
+        ...
+
+    async def load(self, checkpoint_id: str) -> Optional[Checkpoint]:
+        """Load a checkpoint by ID.
+
+        Args:
+            checkpoint_id: The checkpoint ID to load
+
+        Returns:
+            The checkpoint if found, None otherwise
+        """
+        ...
+
+    async def list_checkpoints(
+        self,
+        session_id: Optional[str] = None,
+        limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """List available checkpoints.
+
+        Args:
+            session_id: Optional filter by session ID
+            limit: Maximum number of checkpoints to return
+
+        Returns:
+            List of checkpoint metadata dicts with id, created_at, trigger
+        """
+        ...
+
+    async def delete(self, checkpoint_id: str) -> bool:
+        """Delete a checkpoint.
+
+        Args:
+            checkpoint_id: The checkpoint ID to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        ...
+
+    async def get_latest(self, session_id: Optional[str] = None) -> Optional[Checkpoint]:
+        """Get the most recent checkpoint.
+
+        Args:
+            session_id: Optional filter by session ID
+
+        Returns:
+            The latest checkpoint if any exist
+        """
+        ...
+
+
+class FileCheckpointer:
+    """File-based checkpointer for local development.
+
+    Stores checkpoints as JSON files in a directory structure.
+    Good for development and debugging, not recommended for production.
+    """
+
+    def __init__(self, checkpoint_dir: Optional[str] = None):
+        """Initialize the file checkpointer.
+
+        Args:
+            checkpoint_dir: Directory to store checkpoints.
+                           Defaults to ~/.iterm-mcp/checkpoints/
+        """
+        if checkpoint_dir is None:
+            checkpoint_dir = os.path.expanduser("~/.iterm-mcp/checkpoints")
+
+        self.checkpoint_dir = Path(checkpoint_dir)
+        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        # Index file for quick lookups
+        self.index_file = self.checkpoint_dir / "index.json"
+        self._index: Dict[str, Dict[str, Any]] = {}
+        self._load_index()
+
+    def _load_index(self) -> None:
+        """Load the checkpoint index from disk."""
+        if self.index_file.exists():
+            try:
+                with open(self.index_file, 'r') as f:
+                    self._index = json.load(f)
+            except (json.JSONDecodeError, IOError):
+                self._index = {}
+
+    def _save_index(self) -> None:
+        """Save the checkpoint index to disk."""
+        with open(self.index_file, 'w') as f:
+            json.dump(self._index, f, indent=2, default=str)
+
+    def _get_checkpoint_path(self, checkpoint_id: str) -> Path:
+        """Get the file path for a checkpoint."""
+        return self.checkpoint_dir / f"{checkpoint_id}.json"
+
+    async def save(self, checkpoint: Checkpoint) -> str:
+        """Save a checkpoint to disk.
+
+        Args:
+            checkpoint: The checkpoint to save
+
+        Returns:
+            The checkpoint ID
+        """
+        checkpoint_path = self._get_checkpoint_path(checkpoint.checkpoint_id)
+
+        # Serialize checkpoint to JSON
+        checkpoint_data = checkpoint.model_dump(mode='json')
+
+        with open(checkpoint_path, 'w') as f:
+            json.dump(checkpoint_data, f, indent=2, default=str)
+
+        # Update index
+        session_ids = list(checkpoint.sessions.keys())
+        self._index[checkpoint.checkpoint_id] = {
+            "created_at": checkpoint.created_at.isoformat(),
+            "trigger": checkpoint.trigger,
+            "session_ids": session_ids,
+            "has_registry": checkpoint.registry is not None
+        }
+        self._save_index()
+
+        return checkpoint.checkpoint_id
+
+    async def load(self, checkpoint_id: str) -> Optional[Checkpoint]:
+        """Load a checkpoint from disk.
+
+        Args:
+            checkpoint_id: The checkpoint ID to load
+
+        Returns:
+            The checkpoint if found, None otherwise
+        """
+        checkpoint_path = self._get_checkpoint_path(checkpoint_id)
+
+        if not checkpoint_path.exists():
+            return None
+
+        try:
+            with open(checkpoint_path, 'r') as f:
+                data = json.load(f)
+            return Checkpoint.model_validate(data)
+        except (json.JSONDecodeError, IOError, Exception):
+            return None
+
+    async def list_checkpoints(
+        self,
+        session_id: Optional[str] = None,
+        limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """List available checkpoints.
+
+        Args:
+            session_id: Optional filter by session ID
+            limit: Maximum number of checkpoints to return
+
+        Returns:
+            List of checkpoint metadata dicts
+        """
+        results = []
+
+        for cp_id, meta in self._index.items():
+            # Filter by session if specified
+            if session_id and session_id not in meta.get("session_ids", []):
+                continue
+
+            results.append({
+                "checkpoint_id": cp_id,
+                "created_at": meta.get("created_at"),
+                "trigger": meta.get("trigger"),
+                "session_ids": meta.get("session_ids", []),
+                "has_registry": meta.get("has_registry", False)
+            })
+
+        # Sort by created_at descending
+        results.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+
+        return results[:limit]
+
+    async def delete(self, checkpoint_id: str) -> bool:
+        """Delete a checkpoint from disk.
+
+        Args:
+            checkpoint_id: The checkpoint ID to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        checkpoint_path = self._get_checkpoint_path(checkpoint_id)
+
+        if not checkpoint_path.exists():
+            return False
+
+        try:
+            checkpoint_path.unlink()
+            if checkpoint_id in self._index:
+                del self._index[checkpoint_id]
+                self._save_index()
+            return True
+        except IOError:
+            return False
+
+    async def get_latest(self, session_id: Optional[str] = None) -> Optional[Checkpoint]:
+        """Get the most recent checkpoint.
+
+        Args:
+            session_id: Optional filter by session ID
+
+        Returns:
+            The latest checkpoint if any exist
+        """
+        checkpoints = await self.list_checkpoints(session_id=session_id, limit=1)
+
+        if not checkpoints:
+            return None
+
+        return await self.load(checkpoints[0]["checkpoint_id"])
+
+
+class SQLiteCheckpointer:
+    """SQLite-based checkpointer for production use.
+
+    Provides efficient storage and querying of checkpoints using SQLite.
+    Suitable for production deployments with many checkpoints.
+    """
+
+    def __init__(self, db_path: Optional[str] = None):
+        """Initialize the SQLite checkpointer.
+
+        Args:
+            db_path: Path to SQLite database file.
+                    Defaults to ~/.iterm-mcp/checkpoints.db
+        """
+        if db_path is None:
+            db_dir = os.path.expanduser("~/.iterm-mcp")
+            os.makedirs(db_dir, exist_ok=True)
+            db_path = os.path.join(db_dir, "checkpoints.db")
+
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initialize the database schema."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS checkpoints (
+                    checkpoint_id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    trigger TEXT NOT NULL,
+                    data TEXT NOT NULL
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS checkpoint_sessions (
+                    checkpoint_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    PRIMARY KEY (checkpoint_id, session_id),
+                    FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(checkpoint_id) ON DELETE CASCADE
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_checkpoints_created_at
+                ON checkpoints(created_at DESC)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_checkpoint_sessions_session_id
+                ON checkpoint_sessions(session_id)
+            """)
+            conn.commit()
+
+    async def save(self, checkpoint: Checkpoint) -> str:
+        """Save a checkpoint to SQLite.
+
+        Args:
+            checkpoint: The checkpoint to save
+
+        Returns:
+            The checkpoint ID
+        """
+        checkpoint_data = checkpoint.model_dump_json()
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                INSERT OR REPLACE INTO checkpoints
+                (checkpoint_id, created_at, version, trigger, data)
+                VALUES (?, ?, ?, ?, ?)
+            """, (
+                checkpoint.checkpoint_id,
+                checkpoint.created_at.isoformat(),
+                checkpoint.version,
+                checkpoint.trigger,
+                checkpoint_data
+            ))
+
+            # Store session associations for efficient querying
+            conn.execute(
+                "DELETE FROM checkpoint_sessions WHERE checkpoint_id = ?",
+                (checkpoint.checkpoint_id,)
+            )
+            for session_id in checkpoint.sessions.keys():
+                conn.execute("""
+                    INSERT INTO checkpoint_sessions (checkpoint_id, session_id)
+                    VALUES (?, ?)
+                """, (checkpoint.checkpoint_id, session_id))
+
+            conn.commit()
+
+        return checkpoint.checkpoint_id
+
+    async def load(self, checkpoint_id: str) -> Optional[Checkpoint]:
+        """Load a checkpoint from SQLite.
+
+        Args:
+            checkpoint_id: The checkpoint ID to load
+
+        Returns:
+            The checkpoint if found, None otherwise
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT data FROM checkpoints WHERE checkpoint_id = ?",
+                (checkpoint_id,)
+            )
+            row = cursor.fetchone()
+
+            if row is None:
+                return None
+
+            try:
+                data = json.loads(row[0])
+                return Checkpoint.model_validate(data)
+            except (json.JSONDecodeError, Exception):
+                return None
+
+    async def list_checkpoints(
+        self,
+        session_id: Optional[str] = None,
+        limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """List available checkpoints.
+
+        Args:
+            session_id: Optional filter by session ID
+            limit: Maximum number of checkpoints to return
+
+        Returns:
+            List of checkpoint metadata dicts
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            if session_id:
+                cursor = conn.execute("""
+                    SELECT c.checkpoint_id, c.created_at, c.trigger
+                    FROM checkpoints c
+                    INNER JOIN checkpoint_sessions cs ON c.checkpoint_id = cs.checkpoint_id
+                    WHERE cs.session_id = ?
+                    ORDER BY c.created_at DESC
+                    LIMIT ?
+                """, (session_id, limit))
+            else:
+                cursor = conn.execute("""
+                    SELECT checkpoint_id, created_at, trigger
+                    FROM checkpoints
+                    ORDER BY created_at DESC
+                    LIMIT ?
+                """, (limit,))
+
+            results = []
+            for row in cursor.fetchall():
+                # Get session IDs for this checkpoint
+                sessions_cursor = conn.execute(
+                    "SELECT session_id FROM checkpoint_sessions WHERE checkpoint_id = ?",
+                    (row[0],)
+                )
+                session_ids = [s[0] for s in sessions_cursor.fetchall()]
+
+                results.append({
+                    "checkpoint_id": row[0],
+                    "created_at": row[1],
+                    "trigger": row[2],
+                    "session_ids": session_ids
+                })
+
+            return results
+
+    async def delete(self, checkpoint_id: str) -> bool:
+        """Delete a checkpoint from SQLite.
+
+        Args:
+            checkpoint_id: The checkpoint ID to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "DELETE FROM checkpoints WHERE checkpoint_id = ?",
+                (checkpoint_id,)
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    async def get_latest(self, session_id: Optional[str] = None) -> Optional[Checkpoint]:
+        """Get the most recent checkpoint.
+
+        Args:
+            session_id: Optional filter by session ID
+
+        Returns:
+            The latest checkpoint if any exist
+        """
+        checkpoints = await self.list_checkpoints(session_id=session_id, limit=1)
+
+        if not checkpoints:
+            return None
+
+        return await self.load(checkpoints[0]["checkpoint_id"])
+
+    async def cleanup_old_checkpoints(
+        self,
+        max_age_days: int = 7,
+        max_count: int = 100
+    ) -> int:
+        """Clean up old checkpoints to manage storage.
+
+        Args:
+            max_age_days: Delete checkpoints older than this
+            max_count: Keep at most this many checkpoints
+
+        Returns:
+            Number of checkpoints deleted
+        """
+        from datetime import timedelta
+
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+        deleted_count = 0
+
+        with sqlite3.connect(self.db_path) as conn:
+            # Delete by age
+            cursor = conn.execute(
+                "DELETE FROM checkpoints WHERE created_at < ?",
+                (cutoff_date.isoformat(),)
+            )
+            deleted_count += cursor.rowcount
+
+            # Delete oldest if over count limit
+            cursor = conn.execute("""
+                DELETE FROM checkpoints WHERE checkpoint_id IN (
+                    SELECT checkpoint_id FROM checkpoints
+                    ORDER BY created_at DESC
+                    LIMIT -1 OFFSET ?
+                )
+            """, (max_count,))
+            deleted_count += cursor.rowcount
+
+            conn.commit()
+
+        return deleted_count
+
+
+class CheckpointManager:
+    """High-level manager for checkpointing operations.
+
+    Provides a unified interface for creating, loading, and managing
+    checkpoints across sessions and agents.
+    """
+
+    def __init__(
+        self,
+        checkpointer: Optional[Union[FileCheckpointer, SQLiteCheckpointer]] = None,
+        auto_checkpoint: bool = True,
+        checkpoint_interval: int = 5
+    ):
+        """Initialize the checkpoint manager.
+
+        Args:
+            checkpointer: Storage backend. Defaults to FileCheckpointer.
+            auto_checkpoint: Whether to auto-checkpoint on major operations.
+            checkpoint_interval: Operations between auto-checkpoints.
+        """
+        self.checkpointer = checkpointer or FileCheckpointer()
+        self.auto_checkpoint = auto_checkpoint
+        self.checkpoint_interval = checkpoint_interval
+        self._operation_count = 0
+        self._last_checkpoint_id: Optional[str] = None
+
+    async def create_checkpoint(
+        self,
+        sessions: Optional[Dict[str, "SessionState"]] = None,
+        registry: Optional["RegistryState"] = None,
+        trigger: str = "manual",
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> Checkpoint:
+        """Create and save a new checkpoint.
+
+        Args:
+            sessions: Session states to include
+            registry: Registry state to include
+            trigger: What triggered this checkpoint
+            metadata: Additional metadata
+
+        Returns:
+            The created checkpoint
+        """
+        checkpoint = Checkpoint(
+            sessions=sessions or {},
+            registry=registry,
+            trigger=trigger,
+            metadata=metadata or {}
+        )
+
+        await self.checkpointer.save(checkpoint)
+        self._last_checkpoint_id = checkpoint.checkpoint_id
+        self._operation_count = 0
+
+        return checkpoint
+
+    async def restore_checkpoint(
+        self,
+        checkpoint_id: Optional[str] = None
+    ) -> Optional[Checkpoint]:
+        """Restore from a checkpoint.
+
+        Args:
+            checkpoint_id: Specific checkpoint to restore.
+                          If None, restores from latest.
+
+        Returns:
+            The restored checkpoint, or None if not found
+        """
+        if checkpoint_id:
+            return await self.checkpointer.load(checkpoint_id)
+        return await self.checkpointer.get_latest()
+
+    async def should_auto_checkpoint(self) -> bool:
+        """Check if an auto-checkpoint should be created.
+
+        Returns:
+            True if auto-checkpoint threshold reached
+        """
+        if not self.auto_checkpoint:
+            return False
+
+        self._operation_count += 1
+        return self._operation_count >= self.checkpoint_interval
+
+    async def list_checkpoints(
+        self,
+        session_id: Optional[str] = None,
+        limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """List available checkpoints.
+
+        Args:
+            session_id: Optional filter by session
+            limit: Maximum results
+
+        Returns:
+            List of checkpoint metadata
+        """
+        return await self.checkpointer.list_checkpoints(
+            session_id=session_id,
+            limit=limit
+        )
+
+    async def delete_checkpoint(self, checkpoint_id: str) -> bool:
+        """Delete a checkpoint.
+
+        Args:
+            checkpoint_id: Checkpoint to delete
+
+        Returns:
+            True if deleted
+        """
+        return await self.checkpointer.delete(checkpoint_id)
+
+    @property
+    def last_checkpoint_id(self) -> Optional[str]:
+        """Get the ID of the last created checkpoint."""
+        return self._last_checkpoint_id

--- a/core/session.py
+++ b/core/session.py
@@ -7,14 +7,11 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union, Callable, Literal, TYPE_CHECKING
+from typing import Any, Dict, Optional, Union, Callable, Literal
 
 import iterm2
 
 from utils.logging import ItermSessionLogger
-
-if TYPE_CHECKING:
-    from .checkpointing import SessionState
 
 # Characters that can cause shell parsing issues when typed directly
 # These require base64 encoding to safely execute
@@ -633,11 +630,8 @@ class ItermSession:
         except Exception:
             pass  # Screen content may not be available
 
-        # Get last command from logger if available
+        # Get last command from logger if available (currently not exposed)
         last_command = None
-        if self.logger and hasattr(self.logger, 'latest_output'):
-            # Try to extract last command from logger telemetry
-            pass  # Logger doesn't expose last command directly
 
         state = {
             "session_id": self.id,

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,0 +1,923 @@
+"""Tests for checkpointing functionality.
+
+Tests cover:
+- FileCheckpointer save/load/list/delete operations
+- SQLiteCheckpointer save/load/list/delete operations
+- CheckpointManager functionality
+- AgentRegistry save_state/load_state methods
+- Session state serialization patterns
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from core.checkpointing import (
+    AgentState,
+    Checkpoint,
+    CheckpointManager,
+    Checkpointer,
+    FileCheckpointer,
+    RegistryState,
+    SessionState,
+    SQLiteCheckpointer,
+    TeamState,
+)
+from core.agents import Agent, AgentRegistry, Team
+
+
+class TestSessionState(unittest.TestCase):
+    """Tests for SessionState model."""
+
+    def test_session_state_creation(self):
+        """Test creating a SessionState with required fields."""
+        state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+
+        self.assertEqual(state.session_id, "session-123")
+        self.assertEqual(state.persistent_id, "persist-456")
+        self.assertEqual(state.name, "test-session")
+        self.assertEqual(state.max_lines, 50)  # Default
+        self.assertFalse(state.is_monitoring)  # Default
+        self.assertIsNotNone(state.created_at)
+
+    def test_session_state_with_optional_fields(self):
+        """Test SessionState with optional fields."""
+        state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session",
+            max_lines=100,
+            is_monitoring=True,
+            last_command="echo hello",
+            last_output="hello",
+            metadata={"key": "value"}
+        )
+
+        self.assertEqual(state.max_lines, 100)
+        self.assertTrue(state.is_monitoring)
+        self.assertEqual(state.last_command, "echo hello")
+        self.assertEqual(state.last_output, "hello")
+        self.assertEqual(state.metadata, {"key": "value"})
+
+    def test_session_state_serialization(self):
+        """Test that SessionState can be serialized to JSON."""
+        state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+
+        # Should not raise
+        data = state.model_dump(mode='json')
+        self.assertIsInstance(data, dict)
+        self.assertEqual(data["session_id"], "session-123")
+
+
+class TestAgentState(unittest.TestCase):
+    """Tests for AgentState model."""
+
+    def test_agent_state_creation(self):
+        """Test creating an AgentState."""
+        state = AgentState(
+            name="agent-1",
+            session_id="session-123"
+        )
+
+        self.assertEqual(state.name, "agent-1")
+        self.assertEqual(state.session_id, "session-123")
+        self.assertEqual(state.teams, [])
+        self.assertIsNotNone(state.created_at)
+
+    def test_agent_state_with_teams(self):
+        """Test AgentState with team memberships."""
+        state = AgentState(
+            name="agent-1",
+            session_id="session-123",
+            teams=["team-a", "team-b"],
+            metadata={"role": "worker"}
+        )
+
+        self.assertEqual(state.teams, ["team-a", "team-b"])
+        self.assertEqual(state.metadata, {"role": "worker"})
+
+
+class TestTeamState(unittest.TestCase):
+    """Tests for TeamState model."""
+
+    def test_team_state_creation(self):
+        """Test creating a TeamState."""
+        state = TeamState(name="team-1")
+
+        self.assertEqual(state.name, "team-1")
+        self.assertEqual(state.description, "")
+        self.assertIsNone(state.parent_team)
+
+    def test_team_state_with_parent(self):
+        """Test TeamState with parent team."""
+        state = TeamState(
+            name="sub-team",
+            description="A sub team",
+            parent_team="parent-team"
+        )
+
+        self.assertEqual(state.parent_team, "parent-team")
+
+
+class TestCheckpoint(unittest.TestCase):
+    """Tests for Checkpoint model."""
+
+    def test_checkpoint_creation(self):
+        """Test creating a Checkpoint."""
+        checkpoint = Checkpoint()
+
+        self.assertIsNotNone(checkpoint.checkpoint_id)
+        self.assertIsNotNone(checkpoint.created_at)
+        self.assertEqual(checkpoint.version, "1.0")
+        self.assertEqual(checkpoint.trigger, "manual")
+        self.assertEqual(checkpoint.sessions, {})
+        self.assertIsNone(checkpoint.registry)
+
+    def test_checkpoint_with_sessions(self):
+        """Test Checkpoint with session states."""
+        session_state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+
+        checkpoint = Checkpoint(
+            sessions={"session-123": session_state},
+            trigger="auto"
+        )
+
+        self.assertIn("session-123", checkpoint.sessions)
+        self.assertEqual(checkpoint.trigger, "auto")
+
+    def test_checkpoint_with_registry(self):
+        """Test Checkpoint with registry state."""
+        registry = RegistryState(
+            agents={"agent-1": AgentState(name="agent-1", session_id="s1")},
+            teams={"team-1": TeamState(name="team-1")},
+            active_session="s1"
+        )
+
+        checkpoint = Checkpoint(registry=registry)
+
+        self.assertIsNotNone(checkpoint.registry)
+        self.assertIn("agent-1", checkpoint.registry.agents)
+
+
+class TestFileCheckpointer(unittest.TestCase):
+    """Tests for FileCheckpointer."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.checkpointer = FileCheckpointer(checkpoint_dir=self.temp_dir)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_save_and_load_checkpoint(self):
+        """Test saving and loading a checkpoint."""
+        session_state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+        checkpoint = Checkpoint(
+            sessions={"session-123": session_state},
+            trigger="test"
+        )
+
+        async def run_test():
+            checkpoint_id = await self.checkpointer.save(checkpoint)
+            self.assertEqual(checkpoint_id, checkpoint.checkpoint_id)
+
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.checkpoint_id, checkpoint.checkpoint_id)
+            self.assertIn("session-123", loaded.sessions)
+
+        asyncio.run(run_test())
+
+    def test_load_nonexistent_checkpoint(self):
+        """Test loading a checkpoint that doesn't exist."""
+        async def run_test():
+            loaded = await self.checkpointer.load("nonexistent-id")
+            self.assertIsNone(loaded)
+
+        asyncio.run(run_test())
+
+    def test_list_checkpoints(self):
+        """Test listing checkpoints."""
+        async def run_test():
+            # Create multiple checkpoints
+            for i in range(3):
+                checkpoint = Checkpoint(
+                    sessions={f"session-{i}": SessionState(
+                        session_id=f"session-{i}",
+                        persistent_id=f"persist-{i}",
+                        name=f"test-{i}"
+                    )},
+                    trigger=f"test-{i}"
+                )
+                await self.checkpointer.save(checkpoint)
+
+            # List all checkpoints
+            checkpoints = await self.checkpointer.list_checkpoints()
+            self.assertEqual(len(checkpoints), 3)
+
+            # List with limit
+            limited = await self.checkpointer.list_checkpoints(limit=2)
+            self.assertEqual(len(limited), 2)
+
+        asyncio.run(run_test())
+
+    def test_list_checkpoints_by_session(self):
+        """Test listing checkpoints filtered by session ID."""
+        async def run_test():
+            # Create checkpoints with different sessions
+            cp1 = Checkpoint(
+                sessions={"session-a": SessionState(
+                    session_id="session-a",
+                    persistent_id="persist-a",
+                    name="session-a"
+                )}
+            )
+            cp2 = Checkpoint(
+                sessions={"session-b": SessionState(
+                    session_id="session-b",
+                    persistent_id="persist-b",
+                    name="session-b"
+                )}
+            )
+
+            await self.checkpointer.save(cp1)
+            await self.checkpointer.save(cp2)
+
+            # Filter by session
+            filtered = await self.checkpointer.list_checkpoints(session_id="session-a")
+            self.assertEqual(len(filtered), 1)
+            self.assertIn("session-a", filtered[0]["session_ids"])
+
+        asyncio.run(run_test())
+
+    def test_delete_checkpoint(self):
+        """Test deleting a checkpoint."""
+        checkpoint = Checkpoint()
+
+        async def run_test():
+            checkpoint_id = await self.checkpointer.save(checkpoint)
+
+            # Verify it exists
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNotNone(loaded)
+
+            # Delete it
+            result = await self.checkpointer.delete(checkpoint_id)
+            self.assertTrue(result)
+
+            # Verify it's gone
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNone(loaded)
+
+        asyncio.run(run_test())
+
+    def test_delete_nonexistent_checkpoint(self):
+        """Test deleting a checkpoint that doesn't exist."""
+        async def run_test():
+            result = await self.checkpointer.delete("nonexistent-id")
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    def test_get_latest_checkpoint(self):
+        """Test getting the latest checkpoint."""
+        async def run_test():
+            # Create multiple checkpoints
+            checkpoints_created = []
+            for i in range(3):
+                checkpoint = Checkpoint(trigger=f"test-{i}")
+                await self.checkpointer.save(checkpoint)
+                checkpoints_created.append(checkpoint)
+                await asyncio.sleep(0.01)  # Ensure different timestamps
+
+            # Get latest
+            latest = await self.checkpointer.get_latest()
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest.checkpoint_id, checkpoints_created[-1].checkpoint_id)
+
+        asyncio.run(run_test())
+
+    def test_index_persistence(self):
+        """Test that the index persists across checkpointer instances."""
+        checkpoint = Checkpoint()
+
+        async def run_test():
+            # Save with first checkpointer
+            checkpoint_id = await self.checkpointer.save(checkpoint)
+
+            # Create new checkpointer with same directory
+            new_checkpointer = FileCheckpointer(checkpoint_dir=self.temp_dir)
+
+            # Verify index was loaded
+            checkpoints = await new_checkpointer.list_checkpoints()
+            self.assertEqual(len(checkpoints), 1)
+            self.assertEqual(checkpoints[0]["checkpoint_id"], checkpoint_id)
+
+        asyncio.run(run_test())
+
+
+class TestSQLiteCheckpointer(unittest.TestCase):
+    """Tests for SQLiteCheckpointer."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test_checkpoints.db")
+        self.checkpointer = SQLiteCheckpointer(db_path=self.db_path)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_save_and_load_checkpoint(self):
+        """Test saving and loading a checkpoint."""
+        session_state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+        checkpoint = Checkpoint(
+            sessions={"session-123": session_state},
+            trigger="test"
+        )
+
+        async def run_test():
+            checkpoint_id = await self.checkpointer.save(checkpoint)
+            self.assertEqual(checkpoint_id, checkpoint.checkpoint_id)
+
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.checkpoint_id, checkpoint.checkpoint_id)
+            self.assertIn("session-123", loaded.sessions)
+
+        asyncio.run(run_test())
+
+    def test_list_checkpoints(self):
+        """Test listing checkpoints."""
+        async def run_test():
+            # Create multiple checkpoints
+            for i in range(3):
+                checkpoint = Checkpoint(
+                    sessions={f"session-{i}": SessionState(
+                        session_id=f"session-{i}",
+                        persistent_id=f"persist-{i}",
+                        name=f"test-{i}"
+                    )},
+                    trigger=f"test-{i}"
+                )
+                await self.checkpointer.save(checkpoint)
+
+            # List all checkpoints
+            checkpoints = await self.checkpointer.list_checkpoints()
+            self.assertEqual(len(checkpoints), 3)
+
+        asyncio.run(run_test())
+
+    def test_list_checkpoints_by_session(self):
+        """Test listing checkpoints filtered by session ID."""
+        async def run_test():
+            # Create checkpoints with different sessions
+            cp1 = Checkpoint(
+                sessions={"session-a": SessionState(
+                    session_id="session-a",
+                    persistent_id="persist-a",
+                    name="session-a"
+                )}
+            )
+            cp2 = Checkpoint(
+                sessions={"session-b": SessionState(
+                    session_id="session-b",
+                    persistent_id="persist-b",
+                    name="session-b"
+                )}
+            )
+
+            await self.checkpointer.save(cp1)
+            await self.checkpointer.save(cp2)
+
+            # Filter by session
+            filtered = await self.checkpointer.list_checkpoints(session_id="session-a")
+            self.assertEqual(len(filtered), 1)
+
+        asyncio.run(run_test())
+
+    def test_delete_checkpoint(self):
+        """Test deleting a checkpoint."""
+        checkpoint = Checkpoint()
+
+        async def run_test():
+            checkpoint_id = await self.checkpointer.save(checkpoint)
+
+            # Verify it exists
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNotNone(loaded)
+
+            # Delete it
+            result = await self.checkpointer.delete(checkpoint_id)
+            self.assertTrue(result)
+
+            # Verify it's gone
+            loaded = await self.checkpointer.load(checkpoint_id)
+            self.assertIsNone(loaded)
+
+        asyncio.run(run_test())
+
+    def test_get_latest_checkpoint(self):
+        """Test getting the latest checkpoint."""
+        async def run_test():
+            # Create multiple checkpoints
+            checkpoints_created = []
+            for i in range(3):
+                checkpoint = Checkpoint(trigger=f"test-{i}")
+                await self.checkpointer.save(checkpoint)
+                checkpoints_created.append(checkpoint)
+                await asyncio.sleep(0.01)  # Ensure different timestamps
+
+            # Get latest
+            latest = await self.checkpointer.get_latest()
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest.checkpoint_id, checkpoints_created[-1].checkpoint_id)
+
+        asyncio.run(run_test())
+
+    def test_cleanup_old_checkpoints(self):
+        """Test cleaning up old checkpoints."""
+        async def run_test():
+            # Create many checkpoints
+            for i in range(15):
+                checkpoint = Checkpoint(trigger=f"test-{i}")
+                await self.checkpointer.save(checkpoint)
+
+            # Cleanup keeping only 5
+            deleted = await self.checkpointer.cleanup_old_checkpoints(
+                max_age_days=365,  # Won't delete by age
+                max_count=5
+            )
+
+            self.assertEqual(deleted, 10)  # 15 - 5 = 10 deleted
+
+            # Verify only 5 remain
+            remaining = await self.checkpointer.list_checkpoints(limit=20)
+            self.assertEqual(len(remaining), 5)
+
+        asyncio.run(run_test())
+
+
+class TestCheckpointManager(unittest.TestCase):
+    """Tests for CheckpointManager."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.checkpointer = FileCheckpointer(checkpoint_dir=self.temp_dir)
+        self.manager = CheckpointManager(
+            checkpointer=self.checkpointer,
+            auto_checkpoint=True,
+            checkpoint_interval=3
+        )
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_create_checkpoint(self):
+        """Test creating a checkpoint through the manager."""
+        session_state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+
+        async def run_test():
+            checkpoint = await self.manager.create_checkpoint(
+                sessions={"session-123": session_state},
+                trigger="test"
+            )
+
+            self.assertIsNotNone(checkpoint)
+            self.assertEqual(self.manager.last_checkpoint_id, checkpoint.checkpoint_id)
+
+        asyncio.run(run_test())
+
+    def test_restore_checkpoint(self):
+        """Test restoring from a checkpoint."""
+        session_state = SessionState(
+            session_id="session-123",
+            persistent_id="persist-456",
+            name="test-session"
+        )
+
+        async def run_test():
+            # Create a checkpoint
+            checkpoint = await self.manager.create_checkpoint(
+                sessions={"session-123": session_state}
+            )
+
+            # Restore by ID
+            restored = await self.manager.restore_checkpoint(checkpoint.checkpoint_id)
+            self.assertIsNotNone(restored)
+            self.assertEqual(restored.checkpoint_id, checkpoint.checkpoint_id)
+
+            # Restore latest
+            latest = await self.manager.restore_checkpoint()
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest.checkpoint_id, checkpoint.checkpoint_id)
+
+        asyncio.run(run_test())
+
+    def test_auto_checkpoint_threshold(self):
+        """Test auto-checkpoint threshold detection."""
+        async def run_test():
+            # With interval of 3, should return False until 3rd call
+            self.assertFalse(await self.manager.should_auto_checkpoint())
+            self.assertFalse(await self.manager.should_auto_checkpoint())
+            self.assertTrue(await self.manager.should_auto_checkpoint())  # 3rd call
+
+        asyncio.run(run_test())
+
+    def test_auto_checkpoint_disabled(self):
+        """Test that auto-checkpoint can be disabled."""
+        manager = CheckpointManager(
+            checkpointer=self.checkpointer,
+            auto_checkpoint=False
+        )
+
+        async def run_test():
+            for _ in range(10):
+                self.assertFalse(await manager.should_auto_checkpoint())
+
+        asyncio.run(run_test())
+
+    def test_auto_checkpoint_resets_after_create(self):
+        """Test that operation count resets after creating a checkpoint."""
+        async def run_test():
+            # Increment count
+            await self.manager.should_auto_checkpoint()
+            await self.manager.should_auto_checkpoint()
+
+            # Create checkpoint (should reset count)
+            await self.manager.create_checkpoint()
+
+            # Should be back to 0, so first call returns False
+            self.assertFalse(await self.manager.should_auto_checkpoint())
+
+        asyncio.run(run_test())
+
+    def test_list_checkpoints(self):
+        """Test listing checkpoints through manager."""
+        async def run_test():
+            # Create some checkpoints
+            for i in range(3):
+                await self.manager.create_checkpoint(trigger=f"test-{i}")
+
+            checkpoints = await self.manager.list_checkpoints()
+            self.assertEqual(len(checkpoints), 3)
+
+        asyncio.run(run_test())
+
+    def test_delete_checkpoint(self):
+        """Test deleting a checkpoint through manager."""
+        async def run_test():
+            checkpoint = await self.manager.create_checkpoint()
+
+            result = await self.manager.delete_checkpoint(checkpoint.checkpoint_id)
+            self.assertTrue(result)
+
+            # Verify it's gone
+            restored = await self.manager.restore_checkpoint(checkpoint.checkpoint_id)
+            self.assertIsNone(restored)
+
+        asyncio.run(run_test())
+
+
+class TestAgentRegistryState(unittest.TestCase):
+    """Tests for AgentRegistry save_state/load_state methods."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.registry = AgentRegistry(data_dir=self.temp_dir)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_save_state_empty_registry(self):
+        """Test saving state of an empty registry."""
+        state = self.registry.save_state()
+
+        self.assertIn("agents", state)
+        self.assertIn("teams", state)
+        self.assertIn("created_at", state)
+        self.assertEqual(state["agents"], {})
+        self.assertEqual(state["teams"], {})
+
+    def test_save_state_with_agents(self):
+        """Test saving state with registered agents."""
+        # Register an agent
+        self.registry.register_agent(
+            name="agent-1",
+            session_id="session-123",
+            teams=["team-1"],
+            metadata={"role": "worker"}
+        )
+
+        state = self.registry.save_state()
+
+        self.assertIn("agent-1", state["agents"])
+        agent_state = state["agents"]["agent-1"]
+        self.assertEqual(agent_state["name"], "agent-1")
+        self.assertEqual(agent_state["session_id"], "session-123")
+        self.assertEqual(agent_state["teams"], ["team-1"])
+
+    def test_save_state_with_teams(self):
+        """Test saving state with teams."""
+        # Create a team
+        self.registry.create_team(
+            name="team-1",
+            description="Test team"
+        )
+
+        state = self.registry.save_state()
+
+        self.assertIn("team-1", state["teams"])
+        team_state = state["teams"]["team-1"]
+        self.assertEqual(team_state["name"], "team-1")
+        self.assertEqual(team_state["description"], "Test team")
+
+    def test_save_state_with_message_history(self):
+        """Test saving state with message history."""
+        # Add some message history using the internal deque
+        from core.agents import MessageRecord
+        import hashlib
+
+        content_hash = hashlib.sha256("Hello".encode()).hexdigest()
+        record = MessageRecord(
+            content_hash=content_hash,
+            recipients=["agent-1"]
+        )
+        self.registry._message_history.append(record)
+
+        state = self.registry.save_state()
+
+        self.assertEqual(len(state["message_history"]), 1)
+        self.assertEqual(state["message_history"][0]["content_hash"], content_hash)
+
+    def test_load_state_empty(self):
+        """Test loading an empty state."""
+        state = {
+            "agents": {},
+            "teams": {},
+            "active_session": None,
+            "message_history": [],
+            "created_at": datetime.now(timezone.utc).isoformat()
+        }
+
+        self.registry.load_state(state)
+
+        self.assertEqual(len(self.registry._agents), 0)
+        self.assertEqual(len(self.registry._teams), 0)
+
+    def test_load_state_with_agents(self):
+        """Test loading state with agents."""
+        state = {
+            "agents": {
+                "agent-1": {
+                    "name": "agent-1",
+                    "session_id": "session-123",
+                    "teams": ["team-1"],
+                    "metadata": {"role": "worker"},
+                    "created_at": datetime.now(timezone.utc).isoformat()
+                }
+            },
+            "teams": {},
+            "active_session": "session-123",
+            "message_history": [],
+            "created_at": datetime.now(timezone.utc).isoformat()
+        }
+
+        self.registry.load_state(state)
+
+        self.assertIn("agent-1", self.registry._agents)
+        agent = self.registry._agents["agent-1"]
+        self.assertEqual(agent.name, "agent-1")
+        self.assertEqual(agent.session_id, "session-123")
+
+    def test_load_state_with_teams(self):
+        """Test loading state with teams."""
+        state = {
+            "agents": {},
+            "teams": {
+                "team-1": {
+                    "name": "team-1",
+                    "description": "Test team",
+                    "parent_team": None,
+                    "created_at": datetime.now(timezone.utc).isoformat()
+                }
+            },
+            "active_session": None,
+            "message_history": [],
+            "created_at": datetime.now(timezone.utc).isoformat()
+        }
+
+        self.registry.load_state(state)
+
+        self.assertIn("team-1", self.registry._teams)
+        team = self.registry._teams["team-1"]
+        self.assertEqual(team.name, "team-1")
+        self.assertEqual(team.description, "Test team")
+
+    def test_load_state_clears_existing(self):
+        """Test that loading state clears existing data."""
+        # Add some data first
+        self.registry.register_agent(
+            name="old-agent",
+            session_id="old-session"
+        )
+        self.registry.create_team(name="old-team")
+
+        # Load new state
+        state = {
+            "agents": {
+                "new-agent": {
+                    "name": "new-agent",
+                    "session_id": "new-session",
+                    "teams": [],
+                    "metadata": {},
+                    "created_at": datetime.now(timezone.utc).isoformat()
+                }
+            },
+            "teams": {},
+            "active_session": None,
+            "message_history": [],
+            "created_at": datetime.now(timezone.utc).isoformat()
+        }
+
+        self.registry.load_state(state)
+
+        # Old data should be gone
+        self.assertNotIn("old-agent", self.registry._agents)
+        self.assertNotIn("old-team", self.registry._teams)
+
+        # New data should be present
+        self.assertIn("new-agent", self.registry._agents)
+
+    def test_state_roundtrip(self):
+        """Test saving and loading state preserves data."""
+        # Set up initial state
+        self.registry.register_agent(
+            name="agent-1",
+            session_id="session-123",
+            teams=["team-1"],
+            metadata={"role": "worker"}
+        )
+        self.registry.create_team(
+            name="team-1",
+            description="Test team"
+        )
+
+        # Save state
+        saved_state = self.registry.save_state()
+
+        # Create new registry and load state (use separate dir to avoid conflicts)
+        new_temp_dir = tempfile.mkdtemp()
+        try:
+            new_registry = AgentRegistry(data_dir=new_temp_dir)
+            new_registry.load_state(saved_state)
+
+            # Verify data matches
+            self.assertIn("agent-1", new_registry._agents)
+            self.assertIn("team-1", new_registry._teams)
+        finally:
+            shutil.rmtree(new_temp_dir, ignore_errors=True)
+
+    def test_get_state_summary(self):
+        """Test getting a state summary."""
+        self.registry.register_agent(
+            name="agent-1",
+            session_id="session-123"
+        )
+        self.registry.create_team(name="team-1")
+
+        summary = self.registry.get_state_summary()
+
+        self.assertEqual(summary["agent_count"], 1)
+        self.assertEqual(summary["team_count"], 1)
+        self.assertIn("agent-1", summary["agents"])
+        self.assertIn("team-1", summary["teams"])
+
+
+class TestCheckpointerProtocol(unittest.TestCase):
+    """Tests for Checkpointer protocol compliance."""
+
+    def test_file_checkpointer_is_checkpointer(self):
+        """Test that FileCheckpointer implements Checkpointer protocol."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            checkpointer = FileCheckpointer(checkpoint_dir=temp_dir)
+            self.assertTrue(isinstance(checkpointer, Checkpointer))
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_sqlite_checkpointer_is_checkpointer(self):
+        """Test that SQLiteCheckpointer implements Checkpointer protocol."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            db_path = os.path.join(temp_dir, "test.db")
+            checkpointer = SQLiteCheckpointer(db_path=db_path)
+            self.assertTrue(isinstance(checkpointer, Checkpointer))
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+class TestCheckpointWithRegistry(unittest.TestCase):
+    """Integration tests for checkpointing with AgentRegistry."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.checkpoint_dir = os.path.join(self.temp_dir, "checkpoints")
+        self.registry_dir = os.path.join(self.temp_dir, "registry")
+
+        os.makedirs(self.checkpoint_dir)
+        os.makedirs(self.registry_dir)
+
+        self.checkpointer = FileCheckpointer(checkpoint_dir=self.checkpoint_dir)
+        self.manager = CheckpointManager(checkpointer=self.checkpointer)
+        self.registry = AgentRegistry(data_dir=self.registry_dir)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_checkpoint_with_registry_state(self):
+        """Test creating a checkpoint with registry state."""
+        # Set up registry
+        self.registry.register_agent(
+            name="agent-1",
+            session_id="session-123"
+        )
+        self.registry.create_team(name="team-1")
+
+        async def run_test():
+            # Create registry state for checkpoint
+            registry_state = RegistryState(
+                agents={
+                    name: AgentState(
+                        name=agent.name,
+                        session_id=agent.session_id,
+                        teams=agent.teams,
+                        metadata=agent.metadata
+                    )
+                    for name, agent in self.registry._agents.items()
+                },
+                teams={
+                    name: TeamState(
+                        name=team.name,
+                        description=team.description,
+                        parent_team=team.parent_team
+                    )
+                    for name, team in self.registry._teams.items()
+                }
+            )
+
+            # Create checkpoint
+            checkpoint = await self.manager.create_checkpoint(
+                registry=registry_state,
+                trigger="integration-test"
+            )
+
+            # Restore and verify
+            restored = await self.manager.restore_checkpoint()
+            self.assertIsNotNone(restored.registry)
+            self.assertIn("agent-1", restored.registry.agents)
+            self.assertIn("team-1", restored.registry.teams)
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -9,13 +9,11 @@ Tests cover:
 """
 
 import asyncio
-import json
 import os
 import shutil
 import tempfile
 import unittest
 from datetime import datetime, timezone
-from pathlib import Path
 
 from core.checkpointing import (
     AgentState,
@@ -28,7 +26,7 @@ from core.checkpointing import (
     SQLiteCheckpointer,
     TeamState,
 )
-from core.agents import Agent, AgentRegistry, Team
+from core.agents import AgentRegistry
 
 
 class TestSessionState(unittest.TestCase):
@@ -905,7 +903,7 @@ class TestCheckpointWithRegistry(unittest.TestCase):
             )
 
             # Create checkpoint
-            checkpoint = await self.manager.create_checkpoint(
+            await self.manager.create_checkpoint(
                 registry=registry_state,
                 trigger="integration-test"
             )


### PR DESCRIPTION
## Summary
- Add `save_state()` and `load_state()` methods to Session class
- Create FileCheckpointer for local development
- Implement automatic checkpoint on major operations
- State includes: message history, agent context, team membership

Closes #57

## Changes

### New Files
- **core/checkpointing.py**: Complete checkpointing module with:
  - `Checkpointer` protocol for pluggable storage backends
  - `FileCheckpointer`: JSON file-based storage for local development
  - `SQLiteCheckpointer`: Database storage for production use
  - `CheckpointManager`: High-level checkpoint operations with auto-checkpoint support
  - Pydantic models: `SessionState`, `AgentState`, `TeamState`, `RegistryState`, `Checkpoint`

- **tests/test_checkpointing.py**: Comprehensive test suite with 44 tests covering:
  - Model serialization and deserialization
  - FileCheckpointer operations (save, load, list, delete)
  - SQLiteCheckpointer operations (with cleanup)
  - CheckpointManager auto-checkpoint behavior
  - AgentRegistry state persistence roundtrip
  - Integration tests

### Modified Files
- **core/session.py**: Added state persistence methods:
  - `save_state()`: Serialize session configuration and screen state
  - `load_state()`: Restore session configuration from checkpoints
  - `get_state_summary()`: Get brief session state for debugging

- **core/agents.py**: Added state persistence methods:
  - `save_state()`: Serialize agents, teams, active session, and message history
  - `load_state()`: Full state restoration with file persistence
  - `get_state_summary()`: Get registry state info for logging

## Test Plan
- [x] Run checkpointing tests: `python -m pytest tests/test_checkpointing.py -v` (44 tests pass)
- [x] Verify no regressions in existing functionality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)