### PR TITLE
Fix #52: Add tag/lock visibility in session listings

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -464,3 +464,60 @@ class WaitResult(BaseModel):
         default=True,
         description="Hint: is it worth waiting more?"
     )
+
+
+# ============================================================================
+# SESSION INFO MODELS (Issue #52)
+# ============================================================================
+
+
+class SessionInfo(BaseModel):
+    """Extended session information including tags and locks."""
+
+    session_id: str = Field(..., description="The session ID")
+    name: str = Field(..., description="Session name")
+    persistent_id: Optional[str] = Field(default=None, description="Persistent ID for reconnection")
+    agent: Optional[str] = Field(default=None, description="Registered agent name")
+    team: Optional[str] = Field(default=None, description="Primary team (first team if multiple)")
+    teams: List[str] = Field(default_factory=list, description="All teams the agent belongs to")
+    is_processing: bool = Field(default=False, description="Whether a command is running")
+
+    # Tag and lock information
+    tags: List[str] = Field(default_factory=list, description="Session tags")
+    locked: bool = Field(default=False, description="Whether session is locked")
+    locked_by: Optional[str] = Field(default=None, description="Agent holding the lock")
+    locked_at: Optional[datetime] = Field(default=None, description="When the lock was acquired")
+    pending_access_requests: int = Field(default=0, description="Number of pending access requests")
+
+
+class ListSessionsRequest(BaseModel):
+    """Request parameters for list_sessions with filtering."""
+
+    # Filter by tags
+    tag: Optional[str] = Field(default=None, description="Single tag to filter by")
+    tags: Optional[List[str]] = Field(default=None, description="Multiple tags to filter by")
+    match: Literal["any", "all"] = Field(
+        default="any",
+        description="How to match multiple tags: 'any' (OR) or 'all' (AND)"
+    )
+
+    # Filter by lock status
+    locked: Optional[bool] = Field(default=None, description="Filter by lock status")
+    locked_by: Optional[str] = Field(default=None, description="Filter by lock owner")
+
+    # Output format
+    format: Literal["full", "compact"] = Field(
+        default="full",
+        description="Output format: 'full' for JSON, 'compact' for one-line-per-session"
+    )
+
+    # Existing filter
+    agents_only: bool = Field(default=False, description="Only show sessions with registered agents")
+
+
+class ListSessionsResponse(BaseModel):
+    """Response from list_sessions."""
+
+    sessions: List[SessionInfo] = Field(..., description="Matching sessions")
+    total_count: int = Field(..., description="Total number of matching sessions")
+    filter_applied: bool = Field(default=False, description="Whether any filters were applied")

--- a/core/tags.py
+++ b/core/tags.py
@@ -1,8 +1,12 @@
-"""Session tagging and locking utilities."""
+"""Session tagging and locking utilities.
+
+Note: SessionTagLockManager is NOT thread-safe. If concurrent access from
+multiple threads is expected, external synchronization should be used.
+"""
 
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 
@@ -10,12 +14,21 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 DEFAULT_FOCUS_COOLDOWN_SECONDS = 5.0
 
 
+def _utc_now() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime."""
+    return datetime.now(timezone.utc)
+
+
 @dataclass
 class LockInfo:
-    """Information about a session lock."""
+    """Information about a session lock.
+
+    Note: The pending_requests set is not thread-safe. Concurrent modifications
+    from multiple threads may lead to race conditions.
+    """
 
     owner: str
-    locked_at: datetime = field(default_factory=datetime.now)
+    locked_at: datetime = field(default_factory=_utc_now)
     pending_requests: Set[str] = field(default_factory=set)
 
 

--- a/iterm_mcpy/fastmcp_server.py
+++ b/iterm_mcpy/fastmcp_server.py
@@ -72,6 +72,10 @@ from core.models import (
     # Wait for agent models
     WaitForAgentRequest,
     WaitResult,
+    # Session info models (Issue #52)
+    SessionInfo,
+    ListSessionsRequest,
+    ListSessionsResponse,
 )
 
 # Global references for resources (set during lifespan)
@@ -858,49 +862,159 @@ async def execute_cascade_request(
 # SESSION MANAGEMENT TOOLS
 # ============================================================================
 
+def _format_compact_session(session_info: SessionInfo) -> str:
+    """Format a session in compact one-line format.
+
+    Format: name  agent  lock_status  [tags]
+    Example: worker-1  claude-1  🔒claude-1  [ssh, production]
+    """
+    name = session_info.name.ljust(12)
+    agent = (session_info.agent or "").ljust(12)
+
+    # Lock status with emoji
+    if session_info.locked and session_info.locked_by:
+        lock_status = f"🔒{session_info.locked_by}"
+    else:
+        lock_status = "🔓"
+    lock_status = lock_status.ljust(14)
+
+    # Tags in brackets
+    if session_info.tags:
+        tags = f"[{', '.join(session_info.tags)}]"
+    else:
+        tags = "[]"
+
+    return f"{name}  {agent}  {lock_status}  {tags}"
+
+
 @mcp.tool()
 async def list_sessions(
     ctx: Context,
     agents_only: bool = False,
+    tag: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    match: str = "any",
+    locked: Optional[bool] = None,
+    locked_by: Optional[str] = None,
+    format: str = "full",
 ) -> str:
     """List all available terminal sessions with agent info.
 
     Args:
         agents_only: If True, only show sessions with registered agents
+        tag: Single tag to filter by
+        tags: Multiple tags to filter by
+        match: How to match multiple tags: 'any' (OR) or 'all' (AND)
+        locked: Filter by lock status (True = only locked, False = only unlocked)
+        locked_by: Filter by lock owner
+        format: Output format: 'full' for JSON, 'compact' for one-line-per-session
     """
     terminal = ctx.request_context.lifespan_context["terminal"]
     agent_registry = ctx.request_context.lifespan_context["agent_registry"]
     lock_manager = ctx.request_context.lifespan_context.get("tag_lock_manager")
     logger = ctx.request_context.lifespan_context["logger"]
 
-    logger.info(f"Listing sessions{' (agents_only)' if agents_only else ''}")
+    # Build filter description for logging
+    filters = []
+    if agents_only:
+        filters.append("agents_only")
+    if tag:
+        filters.append(f"tag={tag}")
+    if tags:
+        filters.append(f"tags={tags} (match={match})")
+    if locked is not None:
+        filters.append(f"locked={locked}")
+    if locked_by:
+        filters.append(f"locked_by={locked_by}")
+
+    filter_desc = f" [{', '.join(filters)}]" if filters else ""
+    logger.info(f"Listing sessions{filter_desc}")
 
     sessions = list(terminal.sessions.values())
-    result = []
+    result: List[SessionInfo] = []
+
+    # Combine single tag and multiple tags for filtering
+    all_filter_tags = []
+    if tag:
+        all_filter_tags.append(tag)
+    if tags:
+        all_filter_tags.extend(tags)
 
     for session in sessions:
-        agent = agent_registry.get_agent_by_session(session.id)
+        agent_obj = agent_registry.get_agent_by_session(session.id)
 
-        # Apply filter
-        if agents_only and agent is None:
+        # Apply agents_only filter
+        if agents_only and agent_obj is None:
             continue
 
-        session_meta = {
-            "id": session.id,
-            "name": session.name,
-            "persistent_id": session.persistent_id,
-            "agent": agent.name if agent else None,
-            "teams": agent.teams if agent else []
-        }
+        # Get lock info
+        is_locked = False
+        lock_owner = None
+        lock_time = None
+        pending_requests = 0
+        session_tags: List[str] = []
 
         if lock_manager:
-            session_meta["tags"] = lock_manager.get_tags(session.id)
-            session_meta["locked_by"] = lock_manager.lock_owner(session.id)
+            session_tags = lock_manager.get_tags(session.id)
+            lock_info = lock_manager.get_lock_info(session.id)
+            if lock_info:
+                is_locked = True
+                lock_owner = lock_info.owner
+                lock_time = lock_info.locked_at
+                pending_requests = len(lock_info.pending_requests)
 
-        result.append(session_meta)
+        # Apply tag filter
+        if all_filter_tags:
+            if match == "all":
+                if not lock_manager or not lock_manager.has_all_tags(session.id, all_filter_tags):
+                    continue
+            else:  # "any" match
+                if not lock_manager or not lock_manager.has_any_tags(session.id, all_filter_tags):
+                    continue
+
+        # Apply locked filter
+        if locked is not None:
+            if locked and not is_locked:
+                continue
+            if not locked and is_locked:
+                continue
+
+        # Apply locked_by filter
+        if locked_by is not None:
+            if lock_owner != locked_by:
+                continue
+
+        # Build SessionInfo
+        session_info = SessionInfo(
+            session_id=session.id,
+            name=session.name,
+            persistent_id=session.persistent_id,
+            agent=agent_obj.name if agent_obj else None,
+            team=agent_obj.teams[0] if agent_obj and agent_obj.teams else None,
+            teams=agent_obj.teams if agent_obj else [],
+            is_processing=getattr(session, "is_processing", False),
+            tags=session_tags,
+            locked=is_locked,
+            locked_by=lock_owner,
+            locked_at=lock_time,
+            pending_access_requests=pending_requests,
+        )
+        result.append(session_info)
 
     logger.info(f"Found {len(result)} active sessions")
-    return json.dumps(result, indent=2)
+
+    # Format output
+    if format == "compact":
+        lines = [_format_compact_session(s) for s in result]
+        return "\n".join(lines) if lines else "No sessions found"
+    else:
+        # Full JSON format using the response model
+        response = ListSessionsResponse(
+            sessions=result,
+            total_count=len(result),
+            filter_applied=bool(filters),
+        )
+        return response.model_dump_json(indent=2)
 
 
 @mcp.tool()
@@ -987,6 +1101,68 @@ async def request_session_access(
     )
 
     return json.dumps({"session_id": session_id, "allowed": False, "locked_by": owner}, indent=2)
+
+
+@mcp.tool()
+async def list_my_locks(
+    ctx: Context,
+    agent: str,
+) -> str:
+    """List all sessions locked by a specific agent.
+
+    Args:
+        agent: The agent name to list locks for
+
+    Returns:
+        JSON object with list of locked sessions and their details
+    """
+    lock_manager = ctx.request_context.lifespan_context.get("tag_lock_manager")
+    terminal = ctx.request_context.lifespan_context.get("terminal")
+    logger = ctx.request_context.lifespan_context.get("logger")
+
+    if not lock_manager:
+        return json.dumps({"error": "Lock manager unavailable"}, indent=2)
+
+    try:
+        # Get all session IDs locked by this agent
+        locked_session_ids = lock_manager.get_locks_by_agent(agent)
+
+        locks = []
+        for session_id in locked_session_ids:
+            lock_info = lock_manager.get_lock_info(session_id)
+            session_name = None
+
+            # Try to get session name from terminal
+            if terminal:
+                try:
+                    session = await terminal.get_session_by_id(session_id)
+                    if session:
+                        session_name = session.name
+                except Exception:
+                    pass
+
+            locks.append({
+                "session_id": session_id,
+                "session_name": session_name,
+                "locked_at": lock_info.locked_at.isoformat() if lock_info else None,
+                "pending_requests": sorted(lock_info.pending_requests) if lock_info else [],
+            })
+
+        result = {
+            "agent": agent,
+            "lock_count": len(locks),
+            "locks": locks,
+        }
+
+        if logger:
+            logger.info(f"Listed {len(locks)} locks for agent {agent}")
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        if logger:
+            logger.error(f"Error listing locks for agent {agent}: {e}")
+        return json.dumps({"error": str(e)}, indent=2)
 
 
 @mcp.tool()
@@ -1463,6 +1639,7 @@ async def check_session_status(request: SetActiveSessionRequest, ctx: Context) -
 
     terminal = ctx.request_context.lifespan_context["terminal"]
     agent_registry = ctx.request_context.lifespan_context["agent_registry"]
+    lock_manager = ctx.request_context.lifespan_context.get("tag_lock_manager")
     logger = ctx.request_context.lifespan_context["logger"]
 
     try:
@@ -1488,8 +1665,17 @@ async def check_session_status(request: SetActiveSessionRequest, ctx: Context) -
             "teams": agent_obj.teams if agent_obj else [],
             "is_processing": getattr(session, "is_processing", False),
             "is_monitoring": getattr(session, "is_monitoring", False),
-            "is_active": session.id == agent_registry.active_session
+            "is_active": session.id == agent_registry.active_session,
         }
+
+        # Add tag and lock info
+        if lock_manager:
+            lock_info = lock_manager.get_lock_info(session.id)
+            status["tags"] = lock_manager.get_tags(session.id)
+            status["locked"] = lock_info is not None
+            status["locked_by"] = lock_info.owner if lock_info else None
+            status["locked_at"] = lock_info.locked_at.isoformat() if lock_info else None
+            status["pending_access_requests"] = len(lock_info.pending_requests) if lock_info else 0
 
         logger.info(f"Status for session: {session.name}")
         return json.dumps(status, indent=2)
@@ -2229,10 +2415,11 @@ async def get_agent_status_summary(ctx: Context) -> str:
     """Get a compact status summary of all agents.
 
     Returns a one-line-per-agent summary showing the most recent
-    notification for each agent. Great for quick status checks.
+    notification for each agent, including lock counts. Great for quick status checks.
     """
     notification_manager = ctx.request_context.lifespan_context["notification_manager"]
     agent_registry = ctx.request_context.lifespan_context["agent_registry"]
+    lock_manager = ctx.request_context.lifespan_context.get("tag_lock_manager")
     logger = ctx.request_context.lifespan_context["logger"]
 
     try:
@@ -2252,7 +2439,34 @@ async def get_agent_status_summary(ctx: Context) -> str:
                 )
 
         notifications = list(latest.values())
-        formatted = notification_manager.format_compact(notifications)
+
+        # Build custom format with lock counts
+        if not notifications:
+            return "━━━ No notifications ━━━"
+
+        lines = ["━━━ Agent Status ━━━"]
+        for n in notifications:
+            icon = notification_manager.STATUS_ICONS.get(n.level, "?")
+
+            # Get lock info for this agent
+            lock_info = ""
+            if lock_manager:
+                locks = lock_manager.get_locks_by_agent(n.agent)
+                lock_count = len(locks)
+                if lock_count == 0:
+                    lock_info = "[0 locks]"
+                elif lock_count == 1:
+                    lock_info = f"[1 lock: {locks[0][:12]}]"
+                else:
+                    lock_info = f"[{lock_count} locks]"
+
+            # Format: agent (12 chars) | icon | summary (truncated) | lock info
+            agent_name = n.agent[:12].ljust(12)
+            summary = n.summary[:20].ljust(20) if len(n.summary) > 20 else n.summary.ljust(20)
+            lines.append(f"{agent_name} {icon} {summary} {lock_info}")
+
+        lines.append("━━━━━━━━━━━━━━━━━━━━")
+        formatted = "\n".join(lines)
 
         logger.info(f"Generated status summary for {len(notifications)} agents")
         return formatted

--- a/tests/test_session_tags.py
+++ b/tests/test_session_tags.py
@@ -379,5 +379,195 @@ class TestFocusCooldown(unittest.TestCase):
         self.assertGreater(remaining, 0)
 
 
+class TestTagFiltering(unittest.TestCase):
+    """Tests for filtering sessions by tags (Issue #52).
+
+    Based on Gherkin specs from issue #52.
+    """
+
+    def setUp(self):
+        self.manager = SessionTagLockManager()
+        # Set up test sessions with various tags
+        self.manager.set_tags("s1", ["ipython", "daemon"])
+        self.manager.set_tags("s2", ["ssh", "production"])
+        self.manager.set_tags("s3", ["ipython", "ssh"])
+        self.manager.set_tags("s4", ["daemon"])
+
+    def test_filter_by_single_tag(self):
+        """Scenario: Filter sessions by a single tag."""
+        sessions = self.manager.sessions_with_tag("ipython")
+        self.assertEqual(set(sessions), {"s1", "s3"})
+
+    def test_filter_by_any_tags(self):
+        """Scenario: Filter sessions matching ANY of multiple tags (OR)."""
+        sessions = self.manager.sessions_with_tags(["ipython", "ssh"], match_all=False)
+        self.assertEqual(set(sessions), {"s1", "s2", "s3"})
+
+    def test_filter_by_all_tags(self):
+        """Scenario: Filter sessions matching ALL of multiple tags (AND)."""
+        sessions = self.manager.sessions_with_tags(["ipython", "ssh"], match_all=True)
+        self.assertEqual(sessions, ["s3"])
+
+    def test_filter_returns_empty_for_nonexistent_tag(self):
+        """Scenario: Filter returns empty list for non-existent tag."""
+        sessions = self.manager.sessions_with_tag("nonexistent")
+        self.assertEqual(sessions, [])
+
+    def test_has_tag_check(self):
+        """Scenario: Check if session has a specific tag."""
+        self.assertTrue(self.manager.has_tag("s1", "ipython"))
+        self.assertFalse(self.manager.has_tag("s1", "ssh"))
+
+    def test_has_any_tags_check(self):
+        """Scenario: Check if session has any of specified tags."""
+        self.assertTrue(self.manager.has_any_tags("s1", ["ipython", "ssh"]))
+        self.assertFalse(self.manager.has_any_tags("s4", ["ipython", "ssh"]))
+
+    def test_has_all_tags_check(self):
+        """Scenario: Check if session has all specified tags."""
+        self.assertTrue(self.manager.has_all_tags("s3", ["ipython", "ssh"]))
+        self.assertFalse(self.manager.has_all_tags("s1", ["ipython", "ssh"]))
+
+
+class TestLockFiltering(unittest.TestCase):
+    """Tests for filtering sessions by lock status (Issue #52)."""
+
+    def setUp(self):
+        self.manager = SessionTagLockManager()
+        # Set up test sessions with various lock states
+        self.manager.lock_session("s1", "agent-a")
+        self.manager.lock_session("s2", "agent-a")
+        self.manager.lock_session("s3", "agent-b")
+        # s4 is unlocked
+
+    def test_get_locks_by_agent(self):
+        """Scenario: Get all locks held by a specific agent."""
+        locks = self.manager.get_locks_by_agent("agent-a")
+        self.assertEqual(set(locks), {"s1", "s2"})
+
+    def test_get_all_locks(self):
+        """Scenario: Get all locks as dict."""
+        locks = self.manager.get_all_locks()
+        self.assertEqual(locks, {
+            "s1": "agent-a",
+            "s2": "agent-a",
+            "s3": "agent-b"
+        })
+
+    def test_get_lock_info(self):
+        """Scenario: Get detailed lock info."""
+        lock_info = self.manager.get_lock_info("s1")
+        self.assertIsNotNone(lock_info)
+        self.assertEqual(lock_info.owner, "agent-a")
+        self.assertIsNotNone(lock_info.locked_at)
+
+    def test_get_lock_info_returns_none_for_unlocked(self):
+        """Scenario: get_lock_info returns None for unlocked session."""
+        lock_info = self.manager.get_lock_info("s4")
+        self.assertIsNone(lock_info)
+
+    def test_locked_at_timestamp(self):
+        """Scenario: Lock timestamp is recorded."""
+        locked_at = self.manager.get_locked_at("s1")
+        self.assertIsNotNone(locked_at)
+
+    def test_locked_at_returns_none_for_unlocked(self):
+        """Scenario: get_locked_at returns None for unlocked session."""
+        locked_at = self.manager.get_locked_at("s4")
+        self.assertIsNone(locked_at)
+
+
+class TestAccessRequests(unittest.TestCase):
+    """Tests for pending access request tracking (Issue #52)."""
+
+    def setUp(self):
+        self.manager = SessionTagLockManager()
+        self.manager.lock_session("s1", "agent-a")
+
+    def test_add_access_request(self):
+        """Scenario: Add pending access request."""
+        added = self.manager.add_access_request("s1", "agent-b")
+        self.assertTrue(added)
+        self.assertIn("agent-b", self.manager.get_pending_requests("s1"))
+
+    def test_add_access_request_to_own_lock_fails(self):
+        """Scenario: Owner cannot request access to own lock."""
+        added = self.manager.add_access_request("s1", "agent-a")
+        self.assertFalse(added)
+
+    def test_add_access_request_to_unlocked_fails(self):
+        """Scenario: Cannot request access to unlocked session."""
+        added = self.manager.add_access_request("s2", "agent-b")
+        self.assertFalse(added)
+
+    def test_remove_access_request(self):
+        """Scenario: Remove pending access request."""
+        self.manager.add_access_request("s1", "agent-b")
+        removed = self.manager.remove_access_request("s1", "agent-b")
+        self.assertTrue(removed)
+        self.assertNotIn("agent-b", self.manager.get_pending_requests("s1"))
+
+    def test_get_pending_request_count(self):
+        """Scenario: Get count of pending requests."""
+        self.manager.add_access_request("s1", "agent-b")
+        self.manager.add_access_request("s1", "agent-c")
+        count = self.manager.get_pending_request_count("s1")
+        self.assertEqual(count, 2)
+
+    def test_pending_requests_sorted(self):
+        """Scenario: Pending requests are returned sorted."""
+        self.manager.add_access_request("s1", "charlie")
+        self.manager.add_access_request("s1", "alice")
+        self.manager.add_access_request("s1", "bob")
+        requests = self.manager.get_pending_requests("s1")
+        self.assertEqual(requests, ["alice", "bob", "charlie"])
+
+    def test_describe_includes_pending_requests(self):
+        """Scenario: describe() includes pending access request count."""
+        self.manager.add_access_request("s1", "agent-b")
+        self.manager.add_access_request("s1", "agent-c")
+        info = self.manager.describe("s1")
+        self.assertEqual(info["pending_access_requests"], 2)
+
+
+class TestDescribeSession(unittest.TestCase):
+    """Tests for describe() method including all Issue #52 fields."""
+
+    def setUp(self):
+        self.manager = SessionTagLockManager()
+
+    def test_describe_unlocked_session(self):
+        """Scenario: describe() for unlocked session."""
+        self.manager.set_tags("s1", ["test"])
+        info = self.manager.describe("s1")
+        self.assertEqual(info["tags"], ["test"])
+        self.assertFalse(info["locked"])
+        self.assertIsNone(info["locked_by"])
+        self.assertIsNone(info["locked_at"])
+        self.assertEqual(info["pending_access_requests"], 0)
+
+    def test_describe_locked_session(self):
+        """Scenario: describe() for locked session with full info."""
+        self.manager.set_tags("s1", ["critical", "production"])
+        self.manager.lock_session("s1", "agent-a")
+        self.manager.add_access_request("s1", "agent-b")
+
+        info = self.manager.describe("s1")
+        self.assertEqual(info["tags"], ["critical", "production"])
+        self.assertTrue(info["locked"])
+        self.assertEqual(info["locked_by"], "agent-a")
+        self.assertIsNotNone(info["locked_at"])
+        self.assertEqual(info["pending_access_requests"], 1)
+
+    def test_describe_nonexistent_session(self):
+        """Scenario: describe() for session with no tags or locks."""
+        info = self.manager.describe("nonexistent")
+        self.assertEqual(info["tags"], [])
+        self.assertFalse(info["locked"])
+        self.assertIsNone(info["locked_by"])
+        self.assertIsNone(info["locked_at"])
+        self.assertEqual(info["pending_access_requests"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #52

## Changes

- Merge remote-tracking branch 'origin/main' into issue-52-add-tag-lock-visibility-in-ses
- Address Copilot review feedback for PR #68
- Add tag/lock visibility in session listings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)