### PR TITLE
Fix #98: Clean up unused imports in test_wait_for_agent.py

### DIFF
--- a/tests/test_wait_for_agent.py
+++ b/tests/test_wait_for_agent.py
@@ -4,10 +4,14 @@ This module tests the wait_for_agent MCP tool that allows orchestrators
 to wait for subagents to complete with graceful timeout handling.
 """
 
+import asyncio
 import json
 import shutil
 import tempfile
 import unittest
+from datetime import datetime
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from core.models import WaitForAgentRequest, WaitResult
 from core.agents import AgentRegistry
@@ -406,6 +410,361 @@ class TestWaitForAgentIntegration(unittest.TestCase):
         # Total wait time
         total_time = sum(r.elapsed_seconds for r in results)
         self.assertEqual(total_time, 75.0)  # 30 + 30 + 15
+
+
+class TestWaitForAgentRealImplementation(unittest.IsolatedAsyncioTestCase):
+    """Async integration tests that call the real wait_for_agent function."""
+
+    async def asyncSetUp(self):
+        """Set up mocks for each test."""
+        # Import here to avoid module-level import issues
+        from iterm_mcpy.fastmcp_server import wait_for_agent
+        self.wait_for_agent = wait_for_agent
+        
+        # Create temp directory for agent registry
+        self.temp_dir = tempfile.mkdtemp()
+        self.agent_registry = AgentRegistry(data_dir=self.temp_dir)
+        
+        # Create mock terminal and session
+        self.mock_session = AsyncMock()
+        self.mock_terminal = AsyncMock()
+        self.mock_terminal.get_session_by_id = AsyncMock(return_value=self.mock_session)
+        
+        # Create mock notification manager
+        self.mock_notification_manager = AsyncMock()
+        
+        # Create mock logger
+        self.mock_logger = MagicMock()
+        
+        # Create mock context
+        self.mock_ctx = MagicMock()
+        self.mock_ctx.request_context.lifespan_context = {
+            "terminal": self.mock_terminal,
+            "agent_registry": self.agent_registry,
+            "notification_manager": self.mock_notification_manager,
+            "logger": self.mock_logger,
+        }
+
+    async def asyncTearDown(self):
+        """Clean up temp directory."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def test_agent_not_found(self):
+        """Test behavior when agent doesn't exist."""
+        request = WaitForAgentRequest(
+            agent="nonexistent-agent",
+            wait_up_to=5
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        self.assertFalse(result.completed)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.elapsed_seconds, 0)
+        self.assertEqual(result.status, "unknown")
+        self.assertIn("not found", result.summary)
+        self.assertFalse(result.can_continue_waiting)
+
+    async def test_session_not_found(self):
+        """Test behavior when agent exists but session doesn't."""
+        # Register agent with a session ID
+        self.agent_registry.register_agent(
+            name="orphan-agent",
+            session_id="missing-session",
+            teams=[],
+            metadata={}
+        )
+        
+        # Make terminal return None for this session
+        self.mock_terminal.get_session_by_id = AsyncMock(return_value=None)
+        
+        request = WaitForAgentRequest(
+            agent="orphan-agent",
+            wait_up_to=5
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        self.assertFalse(result.completed)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.elapsed_seconds, 0)
+        self.assertEqual(result.status, "unknown")
+        self.assertIn("Session", result.summary)
+        self.assertFalse(result.can_continue_waiting)
+
+    async def test_quick_completion_idle_detection(self):
+        """Test idle detection when agent completes quickly."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="quick-agent",
+            session_id="session-123",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session behavior - not processing and stable output
+        self.mock_session.is_processing = False
+        self.mock_session.get_screen_contents = AsyncMock(
+            return_value="$ echo 'hello'\nhello\n$ "
+        )
+        
+        request = WaitForAgentRequest(
+            agent="quick-agent",
+            wait_up_to=5,
+            return_output=True,
+            summary_on_timeout=True
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        # Verify completion
+        self.assertTrue(result.completed)
+        self.assertFalse(result.timed_out)
+        self.assertLess(result.elapsed_seconds, 2)  # Should detect idle quickly
+        self.assertEqual(result.status, "idle")
+        self.assertIn("hello", result.output)
+        self.assertEqual(result.summary, "Agent completed successfully")
+        self.assertFalse(result.can_continue_waiting)
+        
+        # Verify notification was added
+        self.mock_notification_manager.add_simple.assert_called_once()
+        call_args = self.mock_notification_manager.add_simple.call_args
+        self.assertEqual(call_args.kwargs["agent"], "quick-agent")
+        self.assertEqual(call_args.kwargs["level"], "success")
+
+    async def test_timeout_with_summary_generation(self):
+        """Test timeout behavior with summary generation."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="long-agent",
+            session_id="session-456",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session behavior - always processing
+        self.mock_session.is_processing = True
+        
+        # Simulate changing output over time
+        outputs = [
+            "Building...\n[1/5] Installing dependencies",
+            "Building...\n[2/5] Compiling sources",
+            "Building...\n[3/5] Linking binaries",
+        ]
+        output_index = 0
+        
+        async def get_output():
+            nonlocal output_index
+            result = outputs[min(output_index, len(outputs) - 1)]
+            output_index += 1
+            return result
+        
+        self.mock_session.get_screen_contents = get_output
+        
+        request = WaitForAgentRequest(
+            agent="long-agent",
+            wait_up_to=2,  # Short timeout to test timeout behavior
+            return_output=True,
+            summary_on_timeout=True
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        # Verify timeout
+        self.assertFalse(result.completed)
+        self.assertTrue(result.timed_out)
+        self.assertGreaterEqual(result.elapsed_seconds, 2.0)
+        self.assertEqual(result.status, "running")
+        self.assertIsNotNone(result.output)
+        self.assertIsNotNone(result.summary)
+        self.assertIn("Still running", result.summary)
+        self.assertTrue(result.can_continue_waiting)
+        
+        # Verify notification was added
+        self.mock_notification_manager.add_simple.assert_called_once()
+        call_args = self.mock_notification_manager.add_simple.call_args
+        self.assertEqual(call_args.kwargs["agent"], "long-agent")
+        self.assertEqual(call_args.kwargs["level"], "info")
+        self.assertIn("timed out", call_args.kwargs["summary"])
+
+    async def test_timeout_without_output_change(self):
+        """Test timeout when output hasn't changed."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="stuck-agent",
+            session_id="session-789",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session - always processing, output never changes
+        self.mock_session.is_processing = True
+        self.mock_session.get_screen_contents = AsyncMock(
+            return_value="Waiting for input..."
+        )
+        
+        request = WaitForAgentRequest(
+            agent="stuck-agent",
+            wait_up_to=2,
+            return_output=True,
+            summary_on_timeout=True
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        self.assertFalse(result.completed)
+        self.assertTrue(result.timed_out)
+        self.assertEqual(result.summary, "No output change detected during wait period")
+
+    async def test_return_output_false(self):
+        """Test that output is not returned when return_output=False."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="test-agent",
+            session_id="session-abc",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session - completes quickly
+        self.mock_session.is_processing = False
+        self.mock_session.get_screen_contents = AsyncMock(
+            return_value="Some output"
+        )
+        
+        request = WaitForAgentRequest(
+            agent="test-agent",
+            wait_up_to=5,
+            return_output=False,  # Don't return output
+            summary_on_timeout=True
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        self.assertTrue(result.completed)
+        self.assertIsNone(result.output)  # Output should be None
+
+    async def test_summary_on_timeout_false(self):
+        """Test that summary is not generated when summary_on_timeout=False."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="timeout-agent",
+            session_id="session-def",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session - always processing
+        self.mock_session.is_processing = True
+        self.mock_session.get_screen_contents = AsyncMock(
+            return_value="Processing..."
+        )
+        
+        request = WaitForAgentRequest(
+            agent="timeout-agent",
+            wait_up_to=2,
+            return_output=True,
+            summary_on_timeout=False  # Don't generate summary
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        self.assertFalse(result.completed)
+        self.assertTrue(result.timed_out)
+        self.assertIsNone(result.summary)  # Summary should be None
+
+    async def test_polling_interval_and_output_stabilization(self):
+        """Test that polling detects output stabilization correctly."""
+        # Register agent
+        self.agent_registry.register_agent(
+            name="stabilizing-agent",
+            session_id="session-ghi",
+            teams=[],
+            metadata={}
+        )
+        
+        # Mock session - not processing, but output changes then stabilizes
+        self.mock_session.is_processing = False
+        
+        call_count = 0
+        async def get_changing_output():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return f"Output changing {call_count}"
+            else:
+                # Stabilizes after 2 calls
+                return "Output stable"
+        
+        self.mock_session.get_screen_contents = get_changing_output
+        
+        request = WaitForAgentRequest(
+            agent="stabilizing-agent",
+            wait_up_to=5,
+            return_output=True
+        )
+        
+        result_json = await self.wait_for_agent(request, self.mock_ctx)
+        result = WaitResult.model_validate_json(result_json)
+        
+        # Should complete when output stabilizes
+        self.assertTrue(result.completed)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.status, "idle")
+        self.assertIn("stable", result.output)
+        
+        # Should have called get_screen_contents multiple times
+        self.assertGreater(call_count, 2)
+
+    async def test_notification_side_effects(self):
+        """Test that notifications are properly added for different scenarios."""
+        # Test 1: Completion notification
+        self.agent_registry.register_agent(
+            name="complete-agent",
+            session_id="session-1",
+            teams=[],
+            metadata={}
+        )
+        self.mock_session.is_processing = False
+        self.mock_session.get_screen_contents = AsyncMock(return_value="done")
+        
+        request = WaitForAgentRequest(agent="complete-agent", wait_up_to=5)
+        await self.wait_for_agent(request, self.mock_ctx)
+        
+        # Verify success notification
+        self.mock_notification_manager.add_simple.assert_called()
+        last_call = self.mock_notification_manager.add_simple.call_args
+        self.assertEqual(last_call.kwargs["level"], "success")
+        self.assertEqual(last_call.kwargs["agent"], "complete-agent")
+        
+        # Reset mock for next test
+        self.mock_notification_manager.reset_mock()
+        
+        # Test 2: Timeout notification
+        self.agent_registry.register_agent(
+            name="timeout-agent",
+            session_id="session-2",
+            teams=[],
+            metadata={}
+        )
+        self.mock_session.is_processing = True
+        self.mock_session.get_screen_contents = AsyncMock(return_value="still working")
+        
+        request = WaitForAgentRequest(agent="timeout-agent", wait_up_to=1)
+        await self.wait_for_agent(request, self.mock_ctx)
+        
+        # Verify info notification for timeout
+        self.mock_notification_manager.add_simple.assert_called()
+        last_call = self.mock_notification_manager.add_simple.call_args
+        self.assertEqual(last_call.kwargs["level"], "info")
+        self.assertEqual(last_call.kwargs["agent"], "timeout-agent")
 
 
 if __name__ == "__main__":

--- a/tests/test_wait_for_agent.py
+++ b/tests/test_wait_for_agent.py
@@ -4,14 +4,11 @@ This module tests the wait_for_agent MCP tool that allows orchestrators
 to wait for subagents to complete with graceful timeout handling.
 """
 
-import asyncio
 import json
 import shutil
 import tempfile
 import unittest
-from datetime import datetime
-from typing import Optional
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock
 
 from core.models import WaitForAgentRequest, WaitResult
 from core.agents import AgentRegistry


### PR DESCRIPTION
## Summary
- Remove unused `asyncio` import
- Remove unused `datetime` import  
- Remove unused `Optional` from typing
- Remove unused `Mock` from unittest.mock (only `AsyncMock` and `MagicMock` are used)

These imports were added in PR #97 but are never used in the test code.

Closes #98

## Test plan
- [x] All 29 tests in `test_wait_for_agent.py` pass with `python -m unittest tests.test_wait_for_agent -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)