### PR TITLE
fix(sessions): default layout to SINGLE on op=create

### DIFF
--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -749,13 +749,14 @@ class SessionsDispatcher(MethodDispatcher):
                 "CREATE": {
                     "aliases": ["create", "split"],
                     "params": [
-                        "layout", "sessions", "register_agents?", "shell?",
+                        "sessions", "layout?='SINGLE'", "register_agents?", "shell?",
                         "target='splits' + direction='below'|'above'|'left'|'right' + session_id",
                         "name?", "agent?", "team?", "register_agent?",
                     ],
                     "description": (
                         "Create sessions (no target) or split an existing "
-                        "session (target='splits')."
+                        "session (target='splits'). `layout` defaults to "
+                        "'SINGLE' when omitted."
                     ),
                 },
                 "SEND": {

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -970,10 +970,14 @@ class SessionsDispatcher(MethodDispatcher):
         # accepted by the tool signature for forward-compat but are not part
         # of the existing CreateSessionsRequest — they're ignored here and
         # will be wired up in a later task if needed.
-        create_request = CreateSessionsRequest.model_validate({
-            "layout": params["layout"],
-            "sessions": params["sessions"],
-        })
+        #
+        # `layout` is omitted when the caller doesn't pass one (the dispatcher
+        # strips None-valued kwargs); fall through to the model's default
+        # ("SINGLE") rather than raising a bare KeyError.
+        request_payload = {"sessions": params["sessions"]}
+        if "layout" in params:
+            request_payload["layout"] = params["layout"]
+        create_request = CreateSessionsRequest.model_validate(request_payload)
         result = await execute_create_sessions(
             create_request,
             terminal,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -979,6 +979,75 @@ class TestPatchAppearance(unittest.TestCase):
         self.assertFalse(parsed["ok"])
 
 
+class TestCreateSessionsDefaults(unittest.TestCase):
+    """Regression coverage for fb-20260424-157473f7 item #1.
+
+    Calling `sessions(op='POST', definer='CREATE', sessions=[...])` with no
+    `layout` parameter used to raise a bare `KeyError: 'layout'` because the
+    dispatcher's None-stripping filter removed the missing key before the
+    Pydantic model could supply its default. The request now defaults to a
+    single-pane layout, matching the CreateSessionsRequest model default.
+    """
+
+    def _ctx(self):
+        return _make_ctx(
+            layout_manager=MagicMock(),
+            profile_manager=MagicMock(),
+        )
+
+    def test_create_sessions_with_no_layout_does_not_raise_keyerror(self):
+        from core.models import CreateSessionsResponse
+        from iterm_mcpy.tools import sessions as mod
+
+        fake_response = CreateSessionsResponse(sessions=[])
+
+        async def go():
+            with patch.object(
+                mod, "execute_create_sessions",
+                new=AsyncMock(return_value=fake_response),
+            ) as mock_exec:
+                result = await sessions(
+                    ctx=self._ctx(),
+                    op="POST", definer="CREATE",
+                    sessions=[{"name": "x"}],
+                )
+                return mock_exec.call_args, result
+
+        call_args, result = asyncio.run(go())
+        parsed = json.loads(result)
+        self.assertTrue(
+            parsed["ok"],
+            f"Expected ok envelope, got error: {parsed.get('error')!r}",
+        )
+        self.assertNotIn("'layout'", str(parsed))
+        # The CreateSessionsRequest should have been built with the default.
+        create_request = call_args.args[0]
+        self.assertEqual(create_request.layout, "SINGLE")
+
+    def test_create_sessions_with_explicit_layout_preserved(self):
+        from core.models import CreateSessionsResponse
+        from iterm_mcpy.tools import sessions as mod
+
+        fake_response = CreateSessionsResponse(sessions=[])
+
+        async def go():
+            with patch.object(
+                mod, "execute_create_sessions",
+                new=AsyncMock(return_value=fake_response),
+            ) as mock_exec:
+                await sessions(
+                    ctx=self._ctx(),
+                    op="POST", definer="CREATE",
+                    layout="quad",
+                    sessions=[{"name": "a"}, {"name": "b"}, {"name": "c"}, {"name": "d"}],
+                )
+                return mock_exec.call_args
+
+        call_args = asyncio.run(go())
+        create_request = call_args.args[0]
+        self.assertEqual(create_request.layout, "quad")
+
+
 class TestOptionsAdvertises4e(unittest.TestCase):
     def test_options_lists_new_targets_and_verbs(self):
         parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1024,6 +1024,17 @@ class TestCreateSessionsDefaults(unittest.TestCase):
         create_request = call_args.args[0]
         self.assertEqual(create_request.layout, "SINGLE")
 
+    def test_options_schema_marks_layout_optional(self):
+        """OPTIONS must reflect that layout is optional, with its default value."""
+        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        create_params = parsed["data"]["methods"]["POST"]["definers"]["CREATE"]["params"]
+        layout_entries = [p for p in create_params if p.startswith("layout")]
+        self.assertEqual(len(layout_entries), 1, f"expected one layout entry, got {layout_entries}")
+        self.assertTrue(
+            layout_entries[0].startswith("layout?"),
+            f"expected layout to be advertised as optional ('layout?...'), got {layout_entries[0]!r}",
+        )
+
     def test_create_sessions_with_explicit_layout_preserved(self):
         from core.models import CreateSessionsResponse
         from iterm_mcpy.tools import sessions as mod


### PR DESCRIPTION
Resolves item #1 of feedback **fb-20260424-157473f7** ('First-hour UX: layout default … would be big wins').

## The bug

```
sessions(op='POST', definer='CREATE', sessions=[{name: 'x'}])
→ {\"ok\": false, \"error\": \"'layout'\"}
```

A bare \`KeyError('layout')\` leaked as the response error whenever a caller omitted the \`layout\` argument — the highest-friction sharp edge a first-hour user reported.

## Root cause

The sessions dispatcher entry filters \`None\`-valued kwargs at \`iterm_mcpy/tools/sessions.py:1701\` (\`{k: v for k, v in raw_params.items() if v is not None}\`). When the caller didn't pass \`layout\`, the key was stripped from \`params\`. \`_create_sessions\` then did \`params[\"layout\"]\` (line 974) and KeyErrored before the Pydantic \`CreateSessionsRequest\` model — which already defaults to \`\"SINGLE\"\` — could supply its default.

## Fix

Build the \`CreateSessionsRequest\` payload conditionally: only include \`layout\` when the caller provided one. The Pydantic model's existing \`\"SINGLE\"\` default takes effect otherwise. Explicit layouts (\`'quad'\`, \`'horizontal_split'\`, …) are preserved unchanged.

\`\`\`diff
- create_request = CreateSessionsRequest.model_validate({
-     \"layout\": params[\"layout\"],
-     \"sessions\": params[\"sessions\"],
- })
+ request_payload = {\"sessions\": params[\"sessions\"]}
+ if \"layout\" in params:
+     request_payload[\"layout\"] = params[\"layout\"]
+ create_request = CreateSessionsRequest.model_validate(request_payload)
\`\`\`

## Tests

New \`TestCreateSessionsDefaults\` class in \`tests/test_sessions.py\`:

- \`test_create_sessions_with_no_layout_does_not_raise_keyerror\` — regression on the exact symptom; reproduces the KeyError on \`main\` and is green with the fix.
- \`test_create_sessions_with_explicit_layout_preserved\` — guards against accidentally swallowing an explicit \`layout=\"quad\"\`.

\`\`\`
$ python -m unittest tests.test_sessions tests.test_dispatcher
Ran 79 tests in 0.027s
OK
\`\`\`

## Out of scope (separate work)

The same feedback entry asks for two more things tracked separately:

- **Structured errors** (\`{code, message, hint}\` envelope) — cross-cutting concern across all 15 tools; deserves its own PR.
- **Ignored \`sessions[].name\` field on create** — a different code path (the layout manager / iTerm session naming after creation); see helpers.py:204+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)