### PR TITLE
fix(sessions): preserve user-supplied name on create

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -373,17 +373,46 @@ class ItermSession:
         """
         self.logger = logger
     
-    async def set_name(self, name: str) -> None:
-        """Set the name of the session.
-        
+    async def set_name(self, name: str, max_attempts: int = 3, retry_delay: float = 0.2) -> None:
+        """Set the name of the session, retrying until iTerm2 agrees.
+
+        iterm2's `async_set_name` propagates asynchronously inside iTerm; on
+        a freshly-created session the first call can land before iTerm has
+        finished applying the profile default, and the rename gets clobbered.
+        We therefore set, sleep briefly, then re-read `session.name` to confirm.
+        See feedback fb-20260424-157473f7 item #2 for the user-visible bug
+        ("session created with name='x' came back named ' '").
+
         Args:
-            name: The new name for the session
+            name: The new name for the session.
+            max_attempts: How many times to call `async_set_name` before
+                giving up. Best-effort; we do not raise on final failure.
+            retry_delay: Seconds to wait between attempts.
         """
-        old_name = self._name
         self._name = name
-        await self.session.async_set_name(name)
-        
-        # Log the name change
+
+        # Fast path: iTerm already agrees, no need to call set_name at all.
+        if self.session.name == name:
+            if self.logger:
+                self.logger.log_session_renamed(name)
+            return
+
+        for attempt in range(max_attempts):
+            await self.session.async_set_name(name)
+            # Verify on the second-and-later attempts, and on the first attempt
+            # when we have more attempts left to use.
+            if attempt + 1 < max_attempts:
+                await asyncio.sleep(retry_delay)
+                if self.session.name == name:
+                    break
+            # Final attempt: don't sleep; if it didn't take, log and move on.
+
+        if self.session.name != name and self.logger:
+            # Best-effort warning; don't raise, the wrapper still reports `name`.
+            log = getattr(self.logger, "log_app_event", None)
+            if callable(log):
+                log("NAME_SET_FAILED", f"iterm2 did not apply name {name!r} after {max_attempts} attempts")
+
         if self.logger:
             self.logger.log_session_renamed(name)
     

--- a/core/terminal.py
+++ b/core/terminal.py
@@ -349,36 +349,15 @@ class ItermTerminal:
         
         # Create a new ItermSession with logger and add to the dictionary
         iterm_session = ItermSession(
-            session=new_session, 
+            session=new_session,
             name=name,
             max_lines=self.default_max_lines
         )
-        
-        # Try to set the name multiple times in case there's a race condition
+
+        # set_name retries internally until iTerm2 agrees (see ItermSession.set_name).
         if name:
-            # Set name and verify
-            for attempt in range(3):
-                await iterm_session.set_name(name)
-                await asyncio.sleep(0.2)  # Give iTerm2 time to set the name
-                
-                # Refresh the session object
-                new_session_name = new_session.name
-                if name in new_session_name:
-                    break
-                    
-                # Log retry attempt if logging is enabled
-                if self.enable_logging and hasattr(self, "log_manager"):
-                    self.log_manager.log_app_event(
-                        "NAME_SET_RETRY",
-                        f"Attempt {attempt+1}: Failed to set session name to '{name}', current name: '{new_session_name}'"
-                    )
-                # If we've tried multiple times and failed, log a warning
-                if attempt == 2 and self.enable_logging and hasattr(self, "log_manager"):
-                    self.log_manager.log_app_event(
-                        "NAME_SET_FAILED",
-                        f"Failed to set session name to '{name}' after 3 attempts"
-                    )
-        
+            await iterm_session.set_name(name)
+
         # Add logger if logging is enabled
         if self.enable_logging and hasattr(self, "log_manager"):
             session_logger = self.log_manager.get_session_logger(
@@ -387,7 +366,7 @@ class ItermTerminal:
                 persistent_id=iterm_session.persistent_id
             )
             iterm_session.set_logger(session_logger)
-            
+
             # Log split pane creation event
             split_type = "Vertical" if vertical else "Horizontal"
             self.log_manager.log_app_event(
@@ -474,30 +453,9 @@ class ItermTerminal:
             max_lines=self.default_max_lines
         )
 
-        # Try to set the name multiple times in case there's a race condition
+        # set_name retries internally until iTerm2 agrees (see ItermSession.set_name).
         if name:
-            # Set name and verify
-            for attempt in range(3):
-                await iterm_session.set_name(name)
-                await asyncio.sleep(0.2)  # Give iTerm2 time to set the name
-
-                # Refresh the session object
-                new_session_name = new_session.name
-                if name in new_session_name:
-                    break
-
-                # Log retry attempt if logging is enabled
-                if self.enable_logging and hasattr(self, "log_manager"):
-                    self.log_manager.log_app_event(
-                        "NAME_SET_RETRY",
-                        f"Attempt {attempt+1}: Failed to set session name to '{name}', current name: '{new_session_name}'"
-                    )
-                # If we've tried multiple times and failed, log a warning
-                if attempt == 2 and self.enable_logging and hasattr(self, "log_manager"):
-                    self.log_manager.log_app_event(
-                        "NAME_SET_FAILED",
-                        f"Failed to set session name to '{name}' after 3 attempts"
-                    )
+            await iterm_session.set_name(name)
 
         # Add logger if logging is enabled
         if self.enable_logging and hasattr(self, "log_manager"):

--- a/tests/test_iterm_session_naming.py
+++ b/tests/test_iterm_session_naming.py
@@ -1,0 +1,101 @@
+"""Regression coverage for fb-20260424-157473f7 item #2.
+
+Submitting `sessions=[{"name": "x"}]` on `op=create` used to return a
+session named " " instead of "x". Root cause: iterm2's `async_set_name`
+propagates the new name asynchronously inside iTerm. `ItermSession.__init__`
+seeds `_name` from the underlying `session.name`. When the create flow
+later runs `terminal.get_session_by_id(...)`, that calls
+`_refresh_sessions()`, which rebuilds every `ItermSession` wrapper from
+scratch (no `name=` kwarg) — so the fresh wrapper reads whatever iterm2
+currently has, which can still be the profile default if the rename has
+not yet propagated. The fix pushes a retry+verify loop into
+`ItermSession.set_name`, so set_name does not return until iTerm itself
+agrees the name has changed.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from core.session import ItermSession
+
+
+def _fake_iterm2_session(initial_name: str = " ", apply_after: int = 1):
+    """Build a fake iterm2.Session whose name updates only after `apply_after`
+    calls to `async_set_name`. Defaults: name starts as a single space (matches
+    the user-reported symptom) and the rename takes one retry to land.
+    """
+    state = {"name": initial_name, "calls": 0}
+
+    async def async_set_name(new_name: str) -> None:
+        state["calls"] += 1
+        if state["calls"] >= apply_after:
+            state["name"] = new_name
+
+    fake = MagicMock(spec=["name", "async_set_name", "session_id"])
+    fake.session_id = "fake-id"
+    fake.async_set_name = AsyncMock(side_effect=async_set_name)
+    type(fake).name = property(lambda self: state["name"])  # dynamic getter
+    fake._state = state
+    return fake
+
+
+class TestSetNameRetriesUntilApplied(unittest.TestCase):
+    def test_set_name_returns_only_after_iterm_agrees(self):
+        """The race scenario: iterm2 needs >1 set_name call before it sticks.
+        set_name must keep trying until session.name reports the new value."""
+        fake = _fake_iterm2_session(initial_name=" ", apply_after=2)
+        sess = ItermSession(session=fake, max_lines=50)
+
+        asyncio.run(sess.set_name("alpha"))
+
+        # Wrapper-cached name reflects the request.
+        self.assertEqual(sess.name, "alpha")
+        # iterm2 was called more than once (retry happened).
+        self.assertGreaterEqual(fake.async_set_name.await_count, 2)
+        # Underlying iterm2 session now agrees.
+        self.assertEqual(fake.name, "alpha")
+
+    def test_fresh_wrapper_after_set_name_reads_correct_name(self):
+        """After set_name returns, recreating the wrapper from scratch (the
+        path _refresh_sessions takes) must pick up the new name."""
+        fake = _fake_iterm2_session(initial_name=" ", apply_after=2)
+        original = ItermSession(session=fake, max_lines=50)
+        asyncio.run(original.set_name("alpha"))
+
+        rebuilt = ItermSession(session=fake, max_lines=50)
+        # No `name=` kwarg passed, so _name = None or session.name.
+        # If set_name had returned too early, this would still be " ".
+        self.assertEqual(rebuilt.name, "alpha")
+
+    def test_set_name_logs_warning_and_returns_when_iterm_never_applies(self):
+        """If iterm2 silently drops every set_name call, set_name must log a
+        warning and return rather than hang the caller."""
+        fake = _fake_iterm2_session(initial_name=" ", apply_after=999)
+        sess = ItermSession(session=fake, max_lines=50)
+        sess.logger = MagicMock()
+
+        asyncio.run(sess.set_name("alpha"))
+
+        # Wrapper still reflects the requested name (best-effort).
+        self.assertEqual(sess.name, "alpha")
+        # iterm2 was retried the expected number of times.
+        self.assertGreaterEqual(fake.async_set_name.await_count, 3)
+        # No exception raised.
+        # (We don't assert on a specific logger method — set_name uses the
+        # session logger if attached; the contract is "do not raise".)
+
+    def test_set_name_no_op_when_iterm_already_agrees(self):
+        """If the iterm2 session already has the requested name, retry must
+        not fire — keeps the fast path fast."""
+        fake = _fake_iterm2_session(initial_name="alpha", apply_after=1)
+        sess = ItermSession(session=fake, max_lines=50)
+
+        asyncio.run(sess.set_name("alpha"))
+
+        # Either zero calls (early return) or exactly one (single set+verify).
+        # Both are acceptable; we just want to ensure no retry loop ran.
+        self.assertLessEqual(fake.async_set_name.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves item #2 of feedback **fb-20260424-157473f7** ('First-hour UX').

## Symptom

Submitting `sessions=[{\"name\": \"x\"}]` via `op=create` returned a session named `\" \"` (single space) instead of `\"x\"`.

## Root cause (deeper than the surface report)

iterm2's `async_set_name` propagates asynchronously inside iTerm. `ItermSession.__init__` (`core/session.py:204`) seeds `_name = name or session.name`. The create flow runs:

1. `LayoutManager._create_single_layout` → `terminal.create_window()` → `set_name(\"x\")` *(fire-and-forget; no verify)*
2. `iterm_mcpy/helpers.py:210` → `terminal.get_session_by_id(...)` → `_refresh_sessions()` → **rebuilds every wrapper from scratch**, no `name=` kwarg, so `_name = None or session.name`
3. If iterm2 hadn't applied the rename by step 2, the fresh wrapper read the iterm2 profile default — often a single space — and `helpers.py:272` returned that as `CreatedSession.name`.

## Fix

Push retry+verify into `ItermSession.set_name`:

```python
async def set_name(self, name, max_attempts=3, retry_delay=0.2):
    self._name = name
    if self.session.name == name:        # fast path
        return
    for attempt in range(max_attempts):
        await self.session.async_set_name(name)
        if attempt + 1 < max_attempts:
            await asyncio.sleep(retry_delay)
            if self.session.name == name:
                break
    # best-effort warning on total failure; do not raise
```

- \`set_name\` does not return until iTerm itself agrees the name has changed.
- Subsequent \`_refresh_sessions()\` cycles read the right name.
- Collapsed the two **duplicate** retry loops in \`core/terminal.py::create_split_pane\` and \`split_session_directional\` — they were working around the same bug at the wrapper-creation layer (~60 lines of duplication removed).

## Tests

\`tests/test_iterm_session_naming.py\` — 4 unit tests against a fake iterm2 session that simulates propagation delay:

- \`test_set_name_returns_only_after_iterm_agrees\` — race scenario, 2-call apply.
- \`test_fresh_wrapper_after_set_name_reads_correct_name\` — the actual original-symptom regression: rebuilding the wrapper post-set_name reads the new name.
- \`test_set_name_logs_warning_and_returns_when_iterm_never_applies\` — silent-failure path: best-effort, no exception.
- \`test_set_name_no_op_when_iterm_already_agrees\` — fast path; no retry loop fires.

\`\`\`
\$ python -m unittest tests.test_iterm_session_naming tests.test_sessions tests.test_split_session
Ran 86 tests in 1.244s
OK
\`\`\`

## Out of scope (separate work)

- The surrounding \`core/layouts.py::_create_horizontal_split_layout\` cleanup (debug \`print\`s + a 1-second sleep + a duplicate set_name pair). Those are workarounds for the same race that are now redundant — but the cleanup is bigger than this PR's scope. Will follow up.
- Items #3 (output tail), #1b (structured errors), and #13 (unwrap JSON) — tracked in plan \`~/.claude/plans/sunny-dreaming-crane.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)