### PR TITLE
fix(sessions): default output reads to tail (last N lines)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -227,6 +227,10 @@ class ReadTarget(BaseModel):
     agent: Optional[str] = Field(default=None, description="Agent name")
     team: Optional[str] = Field(default=None, description="Team name (reads all members)")
     max_lines: Optional[int] = Field(default=None, description="Override default max lines")
+    from_end: bool = Field(
+        default=True,
+        description="Return last max_lines (tail). Set False for legacy top-of-buffer slice.",
+    )
 
 
 class ReadSessionsRequest(BaseModel):

--- a/core/session.py
+++ b/core/session.py
@@ -527,11 +527,20 @@ class ItermSession:
         })
 
     @trace_operation("session.get_screen_contents")
-    async def get_screen_contents(self, max_lines: Optional[int] = None) -> str:
+    async def get_screen_contents(
+        self,
+        max_lines: Optional[int] = None,
+        *,
+        from_end: bool = True,
+    ) -> str:
         """Get the contents of the session's screen.
 
         Args:
-            max_lines: Maximum number of lines to retrieve (defaults to session's max_lines)
+            max_lines: Maximum number of lines to retrieve (defaults to session's max_lines).
+            from_end: If True (default), return the last `max_lines` lines (tail);
+                if False, return the first `max_lines` (legacy top-of-buffer slice).
+                Tail is almost always what callers want when monitoring a long-running
+                session — see fb-20260424-157473f7 item #3.
 
         Returns:
             The text contents of the screen
@@ -540,6 +549,7 @@ class ItermSession:
             session_id=self.id,
             session_name=self._name,
             requested_max_lines=max_lines if max_lines is not None else self._max_lines,
+            from_end=from_end,
         )
 
         contents = await self.session.async_get_screen_contents()
@@ -549,9 +559,12 @@ class ItermSession:
         if max_lines is None:
             max_lines = self._max_lines
 
-        max_lines = min(max_lines, contents.number_of_lines)
+        total = contents.number_of_lines
+        max_lines = min(max_lines, total)
+        start = total - max_lines if from_end else 0
+        end = total if from_end else max_lines
 
-        for i in range(max_lines):
+        for i in range(start, end):
             line = contents.line(i)
             line_text = line.string
             if line_text:

--- a/iterm_mcpy/helpers.py
+++ b/iterm_mcpy/helpers.py
@@ -413,8 +413,10 @@ async def execute_read_request(
 
     outputs: List[SessionOutput] = []
 
-    async def read_from_session(session: ItermSession, max_lines: Optional[int]) -> SessionOutput:
-        content = await session.get_screen_contents(max_lines=max_lines)
+    async def read_from_session(
+        session: ItermSession, max_lines: Optional[int], from_end: bool = True
+    ) -> SessionOutput:
+        content = await session.get_screen_contents(max_lines=max_lines, from_end=from_end)
 
         if read_request.filter_pattern:
             try:
@@ -457,9 +459,9 @@ async def execute_read_request(
 
         for session in sessions:
             if read_request.parallel:
-                tasks.append(read_from_session(session, target.max_lines))
+                tasks.append(read_from_session(session, target.max_lines, target.from_end))
             else:
-                outputs.append(await read_from_session(session, target.max_lines))
+                outputs.append(await read_from_session(session, target.max_lines, target.from_end))
 
     if read_request.parallel and tasks:
         outputs.extend(await asyncio.gather(*tasks))

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -909,15 +909,16 @@ class SessionsDispatcher(MethodDispatcher):
                 val = params.get(key)
                 if val is not None:
                     target_spec[key] = val
+            # max_lines / from_end apply even when no target shortcut is given:
+            # the active-session resolution still honors per-target read options.
+            if params.get("max_lines") is not None:
+                target_spec["max_lines"] = params["max_lines"]
+            if params.get("from_end") is not None:
+                target_spec["from_end"] = params["from_end"]
             if target_spec:
-                # Allow per-shortcut max_lines / from_end override.
-                if params.get("max_lines") is not None:
-                    target_spec["max_lines"] = params["max_lines"]
-                if params.get("from_end") is not None:
-                    target_spec["from_end"] = params["from_end"]
                 targets = [target_spec]
             else:
-                # Fall through to the active-session case.
+                # No shortcut, no read options — pure active-session fallthrough.
                 targets = []
 
         coerced_targets = [

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -736,7 +736,7 @@ class SessionsDispatcher(MethodDispatcher):
                 "agents_only?",
                 "target?",
                 "targets?",
-                "max_lines?", "parallel?",
+                "max_lines?", "from_end?=true", "parallel?",
                 "target='status'",
             ],
             "description": (
@@ -910,9 +910,11 @@ class SessionsDispatcher(MethodDispatcher):
                 if val is not None:
                     target_spec[key] = val
             if target_spec:
-                # Allow per-shortcut max_lines override.
+                # Allow per-shortcut max_lines / from_end override.
                 if params.get("max_lines") is not None:
                     target_spec["max_lines"] = params["max_lines"]
+                if params.get("from_end") is not None:
+                    target_spec["from_end"] = params["from_end"]
                 targets = [target_spec]
             else:
                 # Fall through to the active-session case.
@@ -1580,6 +1582,7 @@ async def sessions(
     target: Optional[str] = None,
     targets: Optional[List[dict]] = None,
     max_lines: Optional[int] = None,
+    from_end: Optional[bool] = None,
     parallel: Optional[bool] = None,
     filter_pattern: Optional[str] = None,
     messages: Optional[List[dict]] = None,
@@ -1673,6 +1676,7 @@ async def sessions(
         "target": target,
         "targets": targets,
         "max_lines": max_lines,
+        "from_end": from_end,
         "parallel": parallel,
         "filter_pattern": filter_pattern,
         "messages": messages,

--- a/tests/test_session_output_direction.py
+++ b/tests/test_session_output_direction.py
@@ -1,0 +1,97 @@
+"""Regression coverage for fb-20260424-157473f7 item #3.
+
+`session.get_screen_contents(max_lines=N)` used to slice from the TOP of
+the buffer (`for i in range(max_lines)`). For monitoring long-running
+sessions the caller almost always wants the tail. This module verifies
+the new tail-by-default behavior and the opt-out via `from_end=False`.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from core.session import ItermSession
+
+
+def _fake_contents(line_strings):
+    """Build a fake iterm2 contents object that yields the given lines."""
+    contents = MagicMock()
+    contents.number_of_lines = len(line_strings)
+
+    def line(i):
+        line_obj = MagicMock()
+        line_obj.string = line_strings[i]
+        return line_obj
+
+    contents.line.side_effect = line
+    return contents
+
+
+def _session_with_buffer(line_strings):
+    """Build an ItermSession wrapper around a fake iterm2 session whose
+    `async_get_screen_contents` returns the given lines."""
+    fake_iterm2_session = MagicMock(spec=["name", "async_set_name", "session_id",
+                                          "async_get_screen_contents"])
+    fake_iterm2_session.session_id = "fake-id"
+    fake_iterm2_session.name = "fake"
+    fake_iterm2_session.async_set_name = AsyncMock()
+    fake_iterm2_session.async_get_screen_contents = AsyncMock(
+        return_value=_fake_contents(line_strings)
+    )
+    return ItermSession(session=fake_iterm2_session, name="fake", max_lines=50)
+
+
+class TestGetScreenContentsDirection(unittest.TestCase):
+    """Tail vs. top slicing for `get_screen_contents`."""
+
+    def setUp(self):
+        # 20 lines of known content; max_lines=5 lets us see which 5.
+        self.lines = [f"line-{i:02d}" for i in range(20)]
+
+    def test_default_returns_tail(self):
+        sess = _session_with_buffer(self.lines)
+        output = asyncio.run(sess.get_screen_contents(max_lines=5))
+        # The TAIL: lines 15..19 inclusive.
+        self.assertEqual(
+            output.split("\n"),
+            ["line-15", "line-16", "line-17", "line-18", "line-19"],
+        )
+
+    def test_from_end_false_returns_top_legacy_behavior(self):
+        sess = _session_with_buffer(self.lines)
+        output = asyncio.run(sess.get_screen_contents(max_lines=5, from_end=False))
+        self.assertEqual(
+            output.split("\n"),
+            ["line-00", "line-01", "line-02", "line-03", "line-04"],
+        )
+
+    def test_max_lines_larger_than_buffer_returns_full_buffer(self):
+        sess = _session_with_buffer(self.lines)
+        output = asyncio.run(sess.get_screen_contents(max_lines=100))
+        self.assertEqual(len(output.split("\n")), 20)
+        # Tail of 20 from a 20-line buffer = full buffer.
+        self.assertEqual(output.split("\n")[0], "line-00")
+        self.assertEqual(output.split("\n")[-1], "line-19")
+
+    def test_default_max_lines_uses_session_default(self):
+        sess = _session_with_buffer(self.lines)
+        sess._max_lines = 3
+        output = asyncio.run(sess.get_screen_contents())
+        # No max_lines arg → uses session default of 3 → tail of 3.
+        self.assertEqual(
+            output.split("\n"),
+            ["line-17", "line-18", "line-19"],
+        )
+
+    def test_empty_lines_are_skipped(self):
+        # Existing get_screen_contents skips empty-string lines (preserving
+        # current behavior). Verify the tail slice respects that.
+        lines = ["line-0", "", "line-2", "", "line-4", "line-5"]
+        sess = _session_with_buffer(lines)
+        output = asyncio.run(sess.get_screen_contents(max_lines=3))
+        # Tail of 3 of the buffer = lines 3, 4, 5 = ['', 'line-4', 'line-5']
+        # After empty skip = ['line-4', 'line-5'].
+        self.assertEqual(output.split("\n"), ["line-4", "line-5"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -180,6 +180,31 @@ class TestReadOutput(unittest.TestCase):
         self.assertTrue(parsed["ok"])
         self.assertIn("outputs", parsed["data"])
 
+    def test_read_with_active_session_honors_from_end(self):
+        """Regression for fb-20260424-157473f7 #3 / Codex P2 on PR #119:
+        when no shortcut target is given (active-session case), `from_end`
+        and `max_lines` must still propagate to the read request."""
+        async def go():
+            from iterm_mcpy.tools import sessions as mod
+            with patch.object(mod, "execute_read_request", new=AsyncMock()) as mock_read:
+                from core.models import ReadSessionsResponse
+                mock_read.return_value = ReadSessionsResponse(outputs=[], total_sessions=0)
+                await sessions(
+                    ctx=_make_ctx(),
+                    op="GET",
+                    target="output",
+                    # No session_id/agent/name/team — pure active-session call.
+                    from_end=False,
+                    max_lines=42,
+                )
+                return mock_read.call_args
+
+        call_args = asyncio.run(go())
+        request = call_args.args[0]
+        self.assertEqual(len(request.targets), 1)
+        self.assertEqual(request.targets[0].from_end, False)
+        self.assertEqual(request.targets[0].max_lines, 42)
+
     def test_read_with_explicit_targets_list(self):
         async def go():
             from iterm_mcpy.tools import sessions as mod

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1024,6 +1024,18 @@ class TestCreateSessionsDefaults(unittest.TestCase):
         create_request = call_args.args[0]
         self.assertEqual(create_request.layout, "SINGLE")
 
+    def test_options_schema_advertises_from_end(self):
+        """OPTIONS GET advertises from_end? for output reads (fb #3)."""
+        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        get_params = parsed["data"]["methods"]["GET"]["params"]
+        from_end_entries = [p for p in get_params if p.startswith("from_end")]
+        self.assertEqual(
+            len(from_end_entries), 1,
+            f"expected one from_end entry, got {from_end_entries}",
+        )
+        self.assertIn("true", from_end_entries[0],
+                      f"expected default to be advertised: {from_end_entries[0]!r}")
+
     def test_options_schema_marks_layout_optional(self):
         """OPTIONS must reflect that layout is optional, with its default value."""
         parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))


### PR DESCRIPTION
Resolves item #3 of feedback **fb-20260424-157473f7**.

## The bug

```python
sessions(op='GET', target='output', max_lines=15)
```

…used to return the **first 15 lines** of the screen buffer, not the last. For monitoring a long-running session that's printed 500+ lines, you got 500-lines-ago — useless.

## Root cause

`core/session.py::get_screen_contents`:

```python
for i in range(max_lines):           # walks 0..max_lines from the top
    line = contents.line(i)
```

## Fix

Flip the default to tail; add a `from_end` knob so legacy top-of-buffer behavior is still available:

```python
async def get_screen_contents(
    self,
    max_lines: Optional[int] = None,
    *,
    from_end: bool = True,
) -> str:
    ...
    total = contents.number_of_lines
    max_lines = min(max_lines, total)
    start = total - max_lines if from_end else 0
    end = total if from_end else max_lines
    for i in range(start, end):
        ...
```

Threaded through:
- `core/models.py::ReadTarget` — new `from_end: bool = True` field.
- `iterm_mcpy/helpers.py::execute_read_request` — passes `target.from_end` to `get_screen_contents`.
- `iterm_mcpy/tools/sessions.py::sessions` — accepts `from_end: Optional[bool] = None` and forwards via the shortcut-target builder.
- OPTIONS schema for GET — advertises `from_end?=true` so schema-driven clients see the new knob.

## Note: wait_for.py NOT changed

The plan considered dropping the `lines[-3:]` workaround in `iterm_mcpy/tools/wait_for.py`. On second look it's not actually a workaround — it's "give me the last 3 lines to summarize," which is correct under both top and tail defaults. Left untouched.

## Tests

`tests/test_session_output_direction.py` (new) — 5 unit cases against a mocked iterm2 contents object:

- `test_default_returns_tail` — buffer of 20 lines, `max_lines=5` → lines 15-19.
- `test_from_end_false_returns_top_legacy_behavior` — opt-out path returns lines 0-4.
- `test_max_lines_larger_than_buffer_returns_full_buffer` — guard against off-by-one.
- `test_default_max_lines_uses_session_default` — falls through to `self._max_lines`.
- `test_empty_lines_are_skipped` — preserves the existing empty-line skip behavior in the new tail-slice window.

Plus `test_options_schema_advertises_from_end` in `tests/test_sessions.py` to lock the schema contract.

```
$ python -m unittest tests.test_session_output_direction tests.test_sessions tests.test_dispatcher tests.test_models
Ran 143 tests in 0.029s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)