### PR TITLE
feat(errors): structured {code, message, hint} error envelope

### DIFF
--- a/iterm_mcpy/dispatcher.py
+++ b/iterm_mcpy/dispatcher.py
@@ -17,6 +17,7 @@ from core.definer_verbs import (
     DefinerResolution,
     resolve_op,
 )
+from iterm_mcpy.errors import ErrorCode, ToolError
 from iterm_mcpy.responses import (
     err_envelope,
     ok_envelope,
@@ -97,7 +98,11 @@ class MethodDispatcher:
         try:
             resolution: DefinerResolution = resolve_op(op, definer)
         except DefinerError as e:
-            return err_envelope(method=op.upper(), error=str(e))
+            # DefinerError covers "unknown op" and "wrong family for definer".
+            # Use INVALID_DEFINER when a definer was explicitly given (the
+            # caller's choice was wrong), otherwise INVALID_OP.
+            code = ErrorCode.INVALID_DEFINER if definer else ErrorCode.INVALID_OP
+            return err_envelope(method=op.upper(), error=ToolError(code, str(e)))
 
         method = resolution.method
         resolved_definer = resolution.definer
@@ -148,18 +153,24 @@ class MethodDispatcher:
 
             return err_envelope(
                 method=method,
-                error=f"Method {method} not supported on {self.collection}",
+                error=ToolError(
+                    ErrorCode.INVALID_OP,
+                    f"Method {method} not supported on {self.collection}",
+                ),
             )
 
         except NotImplementedError:
             return err_envelope(
                 method=method,
                 definer=resolved_definer,
-                error=f"Method {method} not implemented on {self.collection}",
+                error=ToolError(
+                    ErrorCode.NOT_IMPLEMENTED,
+                    f"Method {method} not implemented on {self.collection}",
+                ),
             )
         except Exception as e:
             return err_envelope(
                 method=method,
                 definer=resolved_definer,
-                error=str(e),
+                error=ToolError.from_exception(e),
             )

--- a/iterm_mcpy/errors.py
+++ b/iterm_mcpy/errors.py
@@ -1,0 +1,101 @@
+"""Structured error contract for iTerm MCP tools.
+
+Replaces the bare `error: "<exception repr>"` shape with a typed
+`{code, message, hint?}` envelope, addressing fb-20260424-157473f7
+item #1b ("Errors are too terse and leak internals — wrap all errors as
+{code, message, hint}").
+
+The contract:
+
+- `ErrorCode` is a stable string enum. Codes are part of the public API
+  and clients can branch on them.
+- `ToolError` is the exception tools raise. The dispatcher catches it
+  and renders it via `err_envelope`.
+- `ToolError.from_exception(exc)` maps common Python exceptions to the
+  closest code; an existing `ToolError` passes through unchanged.
+
+Migration is incremental: `responses.err_envelope` accepts either a
+`ToolError` or a bare string. Bare strings are wrapped as
+`ToolError(INTERNAL, message=<str>)` so the response shape is uniform
+even on call sites that haven't been updated yet.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class ErrorCode(str, Enum):
+    """Stable error codes returned in the `{code, message, hint?}` envelope."""
+
+    INVALID_OP = "invalid_op"
+    INVALID_TARGET = "invalid_target"
+    INVALID_DEFINER = "invalid_definer"
+    MISSING_PARAM = "missing_param"
+    INVALID_PARAM = "invalid_param"
+    SESSION_NOT_FOUND = "session_not_found"
+    AGENT_NOT_FOUND = "agent_not_found"
+    LOCKED = "locked"
+    NOT_IMPLEMENTED = "not_implemented"
+    INTERNAL = "internal"
+
+
+class ToolError(Exception):
+    """Exception type carrying a structured error.
+
+    Tools should `raise ToolError(code, message, hint?)`; the dispatcher
+    catches it and renders it via `err_envelope`.
+    """
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        message: str,
+        hint: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.hint = hint
+
+    def to_dict(self) -> dict:
+        """Serialize to the wire shape `{code, message, hint?}`."""
+        out: dict = {"code": self.code.value, "message": self.message}
+        if self.hint is not None:
+            out["hint"] = self.hint
+        return out
+
+    @staticmethod
+    def from_exception(exc: BaseException) -> "ToolError":
+        """Map an arbitrary exception to a ToolError.
+
+        Existing ToolErrors pass through unchanged (no double-wrap).
+        Common Python exceptions get mapped to the closest code; anything
+        else falls back to `INTERNAL`.
+        """
+        if isinstance(exc, ToolError):
+            return exc
+
+        if isinstance(exc, KeyError):
+            key = exc.args[0] if exc.args else str(exc)
+            return ToolError(
+                ErrorCode.MISSING_PARAM,
+                f"Missing required parameter: {key!r}",
+            )
+
+        if isinstance(exc, ValueError):
+            return ToolError(ErrorCode.INVALID_PARAM, str(exc))
+
+        # Pydantic ValidationError lives in pydantic; import lazily so this
+        # module has no hard pydantic dependency.
+        try:
+            from pydantic import ValidationError
+            if isinstance(exc, ValidationError):
+                return ToolError(ErrorCode.INVALID_PARAM, str(exc))
+        except ImportError:
+            pass
+
+        if isinstance(exc, NotImplementedError):
+            return ToolError(ErrorCode.NOT_IMPLEMENTED, str(exc) or "Not implemented")
+
+        return ToolError(ErrorCode.INTERNAL, str(exc) or exc.__class__.__name__)

--- a/iterm_mcpy/responses.py
+++ b/iterm_mcpy/responses.py
@@ -47,25 +47,40 @@ def ok_envelope(
 
 def err_envelope(
     method: str,
-    error: str,
+    error,
     definer: Optional[str] = None,
 ) -> str:
     """Serialize an error result in the SP2 envelope.
 
-    Envelope shape: {"method", "definer"?, "ok": false, "error"}
+    Envelope shape::
+
+        {"method", "definer"?, "ok": false,
+         "error": {"code", "message", "hint"?}}
+
+    The ``error`` argument can be a :class:`iterm_mcpy.errors.ToolError`
+    (preferred) or a bare string (legacy). Bare strings are wrapped as
+    ``ToolError(INTERNAL, message=<str>)`` so the response shape is
+    uniform regardless of caller migration state. See
+    fb-20260424-157473f7 item #1b.
 
     Args:
         method: The HTTP method that was attempted.
-        error: Human-readable error message.
+        error: Either a ``ToolError`` or a bare human-readable string.
         definer: Optional definer verb (if it was resolved before the error).
 
     Returns:
         JSON string with indent=2.
     """
+    # Lazy import keeps responses.py free of circular import risk.
+    from iterm_mcpy.errors import ErrorCode, ToolError
+
+    if isinstance(error, str):
+        error = ToolError(ErrorCode.INTERNAL, error)
+
     payload: dict[str, Any] = {"method": method, "ok": False}
     if definer is not None:
         payload["definer"] = definer
-    payload["error"] = error
+    payload["error"] = error.to_dict()
     return json.dumps(payload, indent=2)
 
 

--- a/iterm_mcpy/tools/delegate.py
+++ b/iterm_mcpy/tools/delegate.py
@@ -29,6 +29,7 @@ from core.models import (
     TaskResultResponse,
 )
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 from iterm_mcpy.tools._callbacks import _setup_manager_callbacks
 
 
@@ -210,7 +211,7 @@ async def delegate(
     try:
         resolution = resolve_op(op, definer)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     if resolution.method != "POST" or resolution.definer != "INVOKE":
         return err_envelope(
@@ -255,7 +256,7 @@ async def delegate(
         result = await _execute_plan(ctx, manager_name=manager_name, plan=plan)
         return ok_envelope(method="POST", definer="INVOKE", data=result)
     except Exception as e:
-        return err_envelope(method="POST", definer="INVOKE", error=str(e))
+        return err_envelope(method="POST", definer="INVOKE", error=ToolError.from_exception(e))
 
 
 def register(mcp):

--- a/iterm_mcpy/tools/messages.py
+++ b/iterm_mcpy/tools/messages.py
@@ -24,6 +24,7 @@ from core.definer_verbs import DefinerError, resolve_op
 from core.models import CascadeMessageRequest
 from iterm_mcpy.helpers import execute_cascade_request
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 
 
 async def _deliver_hierarchical(
@@ -154,7 +155,7 @@ async def messages(
     try:
         resolution = resolve_op(op, definer)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     if resolution.method != "POST" or resolution.definer != "SEND":
         return err_envelope(
@@ -210,7 +211,7 @@ async def messages(
         return err_envelope(
             method="POST",
             definer="SEND",
-            error=str(e),
+            error=ToolError.from_exception(e),
         )
 
 

--- a/iterm_mcpy/tools/orchestrate.py
+++ b/iterm_mcpy/tools/orchestrate.py
@@ -25,6 +25,7 @@ from iterm_mcpy.helpers import (
     execute_write_request,
 )
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 
 
 async def orchestrate(
@@ -53,7 +54,7 @@ async def orchestrate(
     try:
         resolution = resolve_op(op, definer)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     if resolution.method != "POST" or resolution.definer != "INVOKE":
         return err_envelope(
@@ -132,7 +133,7 @@ async def orchestrate(
 
         return ok_envelope(method="POST", definer="INVOKE", data=response)
     except Exception as e:
-        return err_envelope(method="POST", definer="INVOKE", error=str(e))
+        return err_envelope(method="POST", definer="INVOKE", error=ToolError.from_exception(e))
 
 
 def register(mcp):

--- a/iterm_mcpy/tools/subscribe.py
+++ b/iterm_mcpy/tools/subscribe.py
@@ -14,6 +14,7 @@ from mcp.server.fastmcp import Context
 from core.definer_verbs import DefinerError, resolve_op
 from core.models import PatternSubscriptionResponse
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 
 
 async def subscribe(
@@ -42,7 +43,7 @@ async def subscribe(
     try:
         resolution = resolve_op(op, definer)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     if resolution.method != "POST" or resolution.definer != "TRIGGER":
         return err_envelope(
@@ -91,7 +92,7 @@ async def subscribe(
         logger.info(f"subscribe: pattern={pattern!r} event={event_name!r}")
         return ok_envelope(method="POST", definer="TRIGGER", data=result)
     except Exception as e:
-        return err_envelope(method="POST", definer="TRIGGER", error=str(e))
+        return err_envelope(method="POST", definer="TRIGGER", error=ToolError.from_exception(e))
 
 
 def register(mcp):

--- a/iterm_mcpy/tools/telemetry.py
+++ b/iterm_mcpy/tools/telemetry.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import Context
 
 from core.definer_verbs import DefinerError, resolve_op
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 
 
 async def _start_dashboard(ctx: Context, port: int, duration_seconds: int):
@@ -104,7 +105,7 @@ async def telemetry(
     try:
         resolution = resolve_op(op, definer)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     method = resolution.method
     resolved_definer = resolution.definer
@@ -122,14 +123,14 @@ async def telemetry(
             data = await _start_dashboard(ctx, port=port, duration_seconds=duration_seconds)
             return ok_envelope(method="POST", definer="TRIGGER", data=data)
         except Exception as e:
-            return err_envelope(method="POST", definer="TRIGGER", error=str(e))
+            return err_envelope(method="POST", definer="TRIGGER", error=ToolError.from_exception(e))
 
     if method == "DELETE":
         try:
             data = await _stop_dashboard(ctx)
             return ok_envelope(method="DELETE", data=data)
         except Exception as e:
-            return err_envelope(method="DELETE", error=str(e))
+            return err_envelope(method="DELETE", error=ToolError.from_exception(e))
 
     return err_envelope(
         method=method,

--- a/iterm_mcpy/tools/wait_for.py
+++ b/iterm_mcpy/tools/wait_for.py
@@ -15,6 +15,7 @@ from mcp.server.fastmcp import Context
 from core.definer_verbs import DefinerError, resolve_op
 from core.models import WaitResult
 from iterm_mcpy.responses import err_envelope, ok_envelope
+from iterm_mcpy.errors import ToolError
 
 
 async def _wait_for_agent_impl(
@@ -146,7 +147,7 @@ async def wait_for(
     try:
         resolution = resolve_op(op, definer=None)
     except DefinerError as e:
-        return err_envelope(method=op.upper(), error=str(e))
+        return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
 
     if resolution.method != "GET":
         return err_envelope(
@@ -179,7 +180,7 @@ async def wait_for(
         )
         return ok_envelope(method="GET", data=result)
     except Exception as e:
-        return err_envelope(method="GET", error=str(e))
+        return err_envelope(method="GET", error=ToolError.from_exception(e))
 
 
 def register(mcp):

--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -81,7 +81,7 @@ class TestMessagesV2(unittest.TestCase):
             op="GET",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+SEND", parsed["error"])
+        self.assertIn("POST+SEND", parsed["error"]["message"])
 
     def test_wrong_definer_returns_err(self):
         # CREATE is a valid POST definer but not what messages supports.
@@ -90,7 +90,7 @@ class TestMessagesV2(unittest.TestCase):
             op="POST", definer="CREATE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+SEND", parsed["error"])
+        self.assertIn("POST+SEND", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
         parsed = json.loads(asyncio.run(messages(
@@ -98,7 +98,7 @@ class TestMessagesV2(unittest.TestCase):
             op="frobnicate",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_missing_cascade_and_targets_returns_err(self):
         parsed = json.loads(asyncio.run(messages(
@@ -106,8 +106,8 @@ class TestMessagesV2(unittest.TestCase):
             op="send",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("cascade", parsed["error"].lower())
-        self.assertIn("targets", parsed["error"].lower())
+        self.assertIn("cascade", parsed["error"]["message"].lower())
+        self.assertIn("targets", parsed["error"]["message"].lower())
 
     def test_both_cascade_and_targets_returns_err(self):
         parsed = json.loads(asyncio.run(messages(
@@ -117,7 +117,7 @@ class TestMessagesV2(unittest.TestCase):
             targets=[{"agent": "alice"}],
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not both", parsed["error"].lower())
+        self.assertIn("not both", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -183,7 +183,7 @@ class TestOrchestrateV2(unittest.TestCase):
             op="GET",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+INVOKE", parsed["error"])
+        self.assertIn("POST+INVOKE", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
         parsed = json.loads(asyncio.run(orchestrate(
@@ -191,7 +191,7 @@ class TestOrchestrateV2(unittest.TestCase):
             op="frobnicate",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_missing_playbook_returns_err(self):
         parsed = json.loads(asyncio.run(orchestrate(
@@ -199,7 +199,7 @@ class TestOrchestrateV2(unittest.TestCase):
             op="invoke",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("playbook", parsed["error"].lower())
+        self.assertIn("playbook", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -253,7 +253,7 @@ class TestDelegateV2(unittest.TestCase):
             task="echo hi",  # manager_name missing
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("manager_name", parsed["error"])
+        self.assertIn("manager_name", parsed["error"]["message"])
 
     def test_task_manager_not_found_returns_err(self):
         manager_registry = MagicMock()
@@ -267,8 +267,8 @@ class TestDelegateV2(unittest.TestCase):
             task="echo hi",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("ghost", parsed["error"])
-        self.assertIn("not found", parsed["error"].lower())
+        self.assertIn("ghost", parsed["error"]["message"])
+        self.assertIn("not found", parsed["error"]["message"].lower())
 
     def test_plan_happy_path(self):
         manager = MagicMock()
@@ -307,7 +307,7 @@ class TestDelegateV2(unittest.TestCase):
             manager_name="mgr1",  # plan missing
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("plan", parsed["error"].lower())
+        self.assertIn("plan", parsed["error"]["message"].lower())
 
     def test_bad_target_returns_err(self):
         parsed = json.loads(asyncio.run(delegate(
@@ -316,7 +316,7 @@ class TestDelegateV2(unittest.TestCase):
             target="mystery",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("target must be", parsed["error"])
+        self.assertIn("target must be", parsed["error"]["message"])
 
     def test_wrong_op_returns_err(self):
         parsed = json.loads(asyncio.run(delegate(
@@ -324,7 +324,7 @@ class TestDelegateV2(unittest.TestCase):
             op="GET",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+INVOKE", parsed["error"])
+        self.assertIn("POST+INVOKE", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -385,7 +385,7 @@ class TestWaitForV2(unittest.TestCase):
             agent_name="alice",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("GET", parsed["error"])
+        self.assertIn("GET", parsed["error"]["message"])
 
     def test_missing_agent_name_returns_err(self):
         parsed = json.loads(asyncio.run(wait_for(
@@ -393,7 +393,7 @@ class TestWaitForV2(unittest.TestCase):
             op="GET",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"])
+        self.assertIn("agent_name", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
         parsed = json.loads(asyncio.run(wait_for(
@@ -401,7 +401,7 @@ class TestWaitForV2(unittest.TestCase):
             op="frobnicate",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_out_of_range_timeout_returns_err(self):
         parsed = json.loads(asyncio.run(wait_for(
@@ -411,7 +411,7 @@ class TestWaitForV2(unittest.TestCase):
             wait_up_to=0,  # below min=1
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("1 and 600", parsed["error"])
+        self.assertIn("1 and 600", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -455,7 +455,7 @@ class TestSubscribeV2(unittest.TestCase):
             pattern="foo",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+TRIGGER", parsed["error"])
+        self.assertIn("POST+TRIGGER", parsed["error"]["message"])
 
     def test_wrong_definer_returns_err(self):
         parsed = json.loads(asyncio.run(subscribe(
@@ -464,7 +464,7 @@ class TestSubscribeV2(unittest.TestCase):
             pattern="foo",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+TRIGGER", parsed["error"])
+        self.assertIn("POST+TRIGGER", parsed["error"]["message"])
 
     def test_missing_pattern_returns_err(self):
         parsed = json.loads(asyncio.run(subscribe(
@@ -472,7 +472,7 @@ class TestSubscribeV2(unittest.TestCase):
             op="subscribe",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("pattern", parsed["error"].lower())
+        self.assertIn("pattern", parsed["error"]["message"].lower())
 
     def test_bad_regex_returns_err(self):
         parsed = json.loads(asyncio.run(subscribe(
@@ -481,7 +481,7 @@ class TestSubscribeV2(unittest.TestCase):
             pattern="[bad(regex",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Invalid regex", parsed["error"])
+        self.assertIn("Invalid regex", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -525,7 +525,7 @@ class TestTelemetryV2(unittest.TestCase):
             op="POST", definer="CREATE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("TRIGGER", parsed["error"])
+        self.assertIn("TRIGGER", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
         parsed = json.loads(asyncio.run(telemetry(
@@ -533,7 +533,7 @@ class TestTelemetryV2(unittest.TestCase):
             op="frobnicate",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_patch_not_supported(self):
         parsed = json.loads(asyncio.run(telemetry(
@@ -541,7 +541,7 @@ class TestTelemetryV2(unittest.TestCase):
             op="PATCH", definer="MODIFY",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("POST+TRIGGER or DELETE", parsed["error"])
+        self.assertIn("POST+TRIGGER or DELETE", parsed["error"]["message"])
 
 
 # ========================================================================= #

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -73,7 +73,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(agents(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -83,7 +83,7 @@ class TestWrongDefiner(unittest.TestCase):
             agents(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -227,7 +227,7 @@ class TestRegisterAgent(unittest.TestCase):
             op="register", agent_name="alice",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("session_id", parsed["error"].lower())
+        self.assertIn("session_id", parsed["error"]["message"].lower())
 
     def test_register_missing_agent_name_returns_err(self):
         parsed = json.loads(asyncio.run(agents(
@@ -235,7 +235,7 @@ class TestRegisterAgent(unittest.TestCase):
             op="register", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"].lower())
+        self.assertIn("agent_name", parsed["error"]["message"].lower())
 
     def test_register_session_not_found(self):
         terminal = MagicMock()
@@ -246,7 +246,7 @@ class TestRegisterAgent(unittest.TestCase):
             op="register", agent_name="alice", session_id="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("no matching session", parsed["error"].lower())
+        self.assertIn("no matching session", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -299,7 +299,7 @@ class TestNotify(unittest.TestCase):
             agent="alice", summary="x",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("level", parsed["error"].lower())
+        self.assertIn("level", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -573,7 +573,7 @@ class TestTriggerHook(unittest.TestCase):
             op="POST", definer="TRIGGER", target="hooks",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("hooks_op", parsed["error"].lower())
+        self.assertIn("hooks_op", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -621,7 +621,7 @@ class TestGetLocks(unittest.TestCase):
             op="GET", target="locks",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent", parsed["error"].lower())
+        self.assertIn("agent", parsed["error"]["message"].lower())
 
     def test_get_locks_no_lock_manager_returns_err(self):
         parsed = json.loads(asyncio.run(agents(
@@ -629,7 +629,7 @@ class TestGetLocks(unittest.TestCase):
             op="GET", target="locks", agent="alice",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("tag_lock_manager", parsed["error"])
+        self.assertIn("tag_lock_manager", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -668,7 +668,7 @@ class TestDeleteAgent(unittest.TestCase):
             op="delete",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"].lower())
+        self.assertIn("agent_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -682,7 +682,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             agents(ctx=_make_ctx(), op="POST", definer="INVOKE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_unknown_target_not_implemented(self):
         parsed = json.loads(asyncio.run(agents(
@@ -690,7 +690,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="PATCH", target="bogus",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -159,12 +159,12 @@ class TestDispatchErrors(unittest.TestCase):
     def test_unknown_verb_returns_err_envelope(self):
         parsed, _ = run_async(_dispatch(op="frobnicate"))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_wrong_family_definer_returns_err_envelope(self):
         parsed, _ = run_async(_dispatch(op="POST", definer="REPLACE"))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
     def test_handler_exception_returns_err_envelope(self):
         class Broken(FakeCollection):
@@ -177,7 +177,7 @@ class TestDispatchErrors(unittest.TestCase):
         parsed = json.loads(result)
         self.assertFalse(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
-        self.assertEqual(parsed["error"], "oops")
+        self.assertEqual(parsed["error"]["message"], "oops")
 
     def test_not_implemented_returns_err_envelope(self):
         class NoPut(FakeCollection):
@@ -189,7 +189,54 @@ class TestDispatchErrors(unittest.TestCase):
         result = asyncio.run(tool.dispatch(ctx=None, op="PUT", name="x"))
         parsed = json.loads(result)
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
+
+
+class TestStructuredErrorCodes(unittest.TestCase):
+    """Regression for fb-20260424-157473f7 #1b: error envelopes carry codes."""
+
+    def test_unknown_op_carries_invalid_op_code(self):
+        parsed, _ = run_async(_dispatch(op="frobnicate"))
+        self.assertEqual(parsed["error"]["code"], "invalid_op")
+
+    def test_wrong_family_definer_carries_invalid_definer_code(self):
+        parsed, _ = run_async(_dispatch(op="POST", definer="REPLACE"))
+        self.assertEqual(parsed["error"]["code"], "invalid_definer")
+
+    def test_not_implemented_carries_not_implemented_code(self):
+        class NoPut(FakeCollection):
+            async def on_put(self, ctx, definer, **params):
+                raise NotImplementedError
+
+        import asyncio
+        tool = NoPut()
+        result = asyncio.run(tool.dispatch(ctx=None, op="PUT", name="x"))
+        parsed = json.loads(result)
+        self.assertEqual(parsed["error"]["code"], "not_implemented")
+
+    def test_handler_exception_carries_internal_code(self):
+        class Broken(FakeCollection):
+            async def on_get(self, ctx, **params):
+                raise RuntimeError("kernel panic")
+
+        import asyncio
+        tool = Broken()
+        result = asyncio.run(tool.dispatch(ctx=None, op="list"))
+        parsed = json.loads(result)
+        self.assertEqual(parsed["error"]["code"], "internal")
+        self.assertEqual(parsed["error"]["message"], "kernel panic")
+
+    def test_keyerror_in_handler_maps_to_missing_param(self):
+        class NeedsParam(FakeCollection):
+            async def on_get(self, ctx, **params):
+                return {"value": params["required"]}  # KeyError if missing
+
+        import asyncio
+        tool = NeedsParam()
+        result = asyncio.run(tool.dispatch(ctx=None, op="list"))
+        parsed = json.loads(result)
+        self.assertEqual(parsed["error"]["code"], "missing_param")
+        self.assertIn("required", parsed["error"]["message"])
 
 
 if __name__ == "__main__":

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -66,7 +66,7 @@ class TestErrEnvelope(unittest.TestCase):
         s = err_envelope(method="POST", error="boom")
         parsed = json.loads(s)
         self.assertFalse(parsed["ok"])
-        self.assertEqual(parsed["error"], "boom")
+        self.assertEqual(parsed["error"]["message"], "boom")
         self.assertNotIn("data", parsed)
 
     def test_includes_definer_when_present(self):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,116 @@
+"""Tests for the structured error contract introduced for fb-20260424-157473f7 #1b."""
+import json
+import unittest
+
+from iterm_mcpy.errors import ErrorCode, ToolError
+
+
+class TestErrorCode(unittest.TestCase):
+    def test_codes_are_lower_snake_strings(self):
+        # Codes are part of the public API; they must be stable strings.
+        self.assertEqual(ErrorCode.INVALID_OP.value, "invalid_op")
+        self.assertEqual(ErrorCode.SESSION_NOT_FOUND.value, "session_not_found")
+        self.assertEqual(ErrorCode.INTERNAL.value, "internal")
+
+    def test_str_enum_compares_to_strings(self):
+        self.assertEqual(ErrorCode.INVALID_OP, "invalid_op")
+
+
+class TestToolError(unittest.TestCase):
+    def test_construct_with_code_and_message(self):
+        err = ToolError(ErrorCode.INVALID_OP, "Unknown op 'foo'")
+        self.assertEqual(err.code, ErrorCode.INVALID_OP)
+        self.assertEqual(err.message, "Unknown op 'foo'")
+        self.assertIsNone(err.hint)
+
+    def test_construct_with_hint(self):
+        err = ToolError(
+            ErrorCode.INVALID_OP,
+            "Unknown op 'foo'",
+            hint="Try op='GET' or op='POST'",
+        )
+        self.assertEqual(err.hint, "Try op='GET' or op='POST'")
+
+    def test_to_dict_shape(self):
+        err = ToolError(ErrorCode.SESSION_NOT_FOUND, "no such session", hint="check id")
+        self.assertEqual(
+            err.to_dict(),
+            {
+                "code": "session_not_found",
+                "message": "no such session",
+                "hint": "check id",
+            },
+        )
+
+    def test_to_dict_omits_hint_when_none(self):
+        err = ToolError(ErrorCode.INTERNAL, "oops")
+        self.assertEqual(err.to_dict(), {"code": "internal", "message": "oops"})
+
+    def test_is_an_exception(self):
+        # Tools should be able to `raise ToolError(...)` and let the dispatcher
+        # catch it.
+        with self.assertRaises(ToolError):
+            raise ToolError(ErrorCode.INVALID_PARAM, "missing 'session_id'")
+
+
+class TestFromException(unittest.TestCase):
+    def test_keyerror_maps_to_missing_param(self):
+        try:
+            raise KeyError("layout")
+        except KeyError as exc:
+            err = ToolError.from_exception(exc)
+        self.assertEqual(err.code, ErrorCode.MISSING_PARAM)
+        self.assertIn("layout", err.message)
+
+    def test_value_error_maps_to_invalid_param(self):
+        try:
+            raise ValueError("bad layout 'spiral'")
+        except ValueError as exc:
+            err = ToolError.from_exception(exc)
+        self.assertEqual(err.code, ErrorCode.INVALID_PARAM)
+        self.assertIn("spiral", err.message)
+
+    def test_unknown_exception_maps_to_internal(self):
+        err = ToolError.from_exception(RuntimeError("kernel panic"))
+        self.assertEqual(err.code, ErrorCode.INTERNAL)
+        self.assertIn("kernel panic", err.message)
+
+    def test_passes_through_existing_toolerror(self):
+        # If the caller already raised a ToolError, from_exception should
+        # return it unchanged (no double-wrapping).
+        original = ToolError(ErrorCode.LOCKED, "session is locked", hint="unlock first")
+        passed = ToolError.from_exception(original)
+        self.assertIs(passed, original)
+
+
+class TestErrEnvelopeAcceptsToolError(unittest.TestCase):
+    def test_err_envelope_with_toolerror_yields_structured_shape(self):
+        from iterm_mcpy.responses import err_envelope
+        env = err_envelope(
+            method="POST",
+            error=ToolError(ErrorCode.INVALID_OP, "Unknown op 'foo'", hint="see OPTIONS"),
+            definer="CREATE",
+        )
+        parsed = json.loads(env)
+        self.assertEqual(parsed["method"], "POST")
+        self.assertEqual(parsed["definer"], "CREATE")
+        self.assertFalse(parsed["ok"])
+        self.assertEqual(parsed["error"]["code"], "invalid_op")
+        self.assertEqual(parsed["error"]["message"], "Unknown op 'foo'")
+        self.assertEqual(parsed["error"]["hint"], "see OPTIONS")
+
+    def test_err_envelope_with_legacy_string_still_works(self):
+        # Backward compatibility for sites we haven't migrated yet: passing
+        # a bare string still produces an envelope, but with the new shape
+        # — the string becomes the `message`, with code=INTERNAL.
+        from iterm_mcpy.responses import err_envelope
+        env = err_envelope(method="GET", error="something broke")
+        parsed = json.loads(env)
+        self.assertFalse(parsed["ok"])
+        self.assertEqual(parsed["error"]["code"], "internal")
+        self.assertEqual(parsed["error"]["message"], "something broke")
+        self.assertNotIn("hint", parsed["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feedback_dispatch.py
+++ b/tests/test_feedback_dispatch.py
@@ -152,7 +152,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -162,7 +162,7 @@ class TestWrongDefiner(unittest.TestCase):
             feedback(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -338,7 +338,7 @@ class TestSubmitFeedback(unittest.TestCase):
             description="No title",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("title", parsed["error"].lower())
+        self.assertIn("title", parsed["error"]["message"].lower())
 
     def test_submit_missing_description_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -347,7 +347,7 @@ class TestSubmitFeedback(unittest.TestCase):
             title="Only title",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("description", parsed["error"].lower())
+        self.assertIn("description", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -449,7 +449,7 @@ class TestCheckTriggers(unittest.TestCase):
             session_id="s1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"].lower())
+        self.assertIn("agent_name", parsed["error"]["message"].lower())
 
     def test_missing_session_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -458,7 +458,7 @@ class TestCheckTriggers(unittest.TestCase):
             agent_name="a1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("session_id", parsed["error"].lower())
+        self.assertIn("session_id", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -517,7 +517,7 @@ class TestFork(unittest.TestCase):
             session_id="s-1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("feedback_id", parsed["error"].lower())
+        self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
     def test_fork_missing_session_id_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -526,7 +526,7 @@ class TestFork(unittest.TestCase):
             feedback_id="fb-1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("session_id", parsed["error"].lower())
+        self.assertIn("session_id", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -589,7 +589,7 @@ class TestTriageToGithub(unittest.TestCase):
             feedback_id="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_triage_gh_fails_returns_err(self):
         registry = MagicMock()
@@ -607,7 +607,7 @@ class TestTriageToGithub(unittest.TestCase):
             feedback_id="fb-1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Failed to create GitHub issue", parsed["error"])
+        self.assertIn("Failed to create GitHub issue", parsed["error"]["message"])
 
     def test_triage_missing_feedback_id_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -615,7 +615,7 @@ class TestTriageToGithub(unittest.TestCase):
             op="triage", target="issues",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("feedback_id", parsed["error"].lower())
+        self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -692,7 +692,7 @@ class TestNotifyUpdate(unittest.TestCase):
             message="hi",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_notify_missing_feedback_id_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -702,7 +702,7 @@ class TestNotifyUpdate(unittest.TestCase):
             message="done",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("feedback_id", parsed["error"].lower())
+        self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
     def test_notify_missing_update_type_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -712,7 +712,7 @@ class TestNotifyUpdate(unittest.TestCase):
             message="done",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("update_type", parsed["error"].lower())
+        self.assertIn("update_type", parsed["error"]["message"].lower())
 
     def test_notify_missing_message_returns_err(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -722,7 +722,7 @@ class TestNotifyUpdate(unittest.TestCase):
             update_type="resolved",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("message", parsed["error"].lower())
+        self.assertIn("message", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -833,7 +833,7 @@ class TestUpdateConfig(unittest.TestCase):
             op="update", target="bogus",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -851,7 +851,7 @@ class TestDeleteNotImplemented(unittest.TestCase):
         self.assertFalse(parsed["ok"])
         # The dispatcher's default on_delete raises NotImplementedError,
         # which the dispatcher converts into an err envelope.
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -867,7 +867,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             agent_name="a1", session_id="s1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_trigger_wrong_target(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -876,7 +876,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             feedback_id="fb-1", session_id="s1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_send_wrong_target(self):
         parsed = json.loads(asyncio.run(feedback(
@@ -885,7 +885,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             feedback_id="fb-1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -95,7 +95,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(managers(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -105,7 +105,7 @@ class TestWrongDefiner(unittest.TestCase):
             managers(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -223,7 +223,7 @@ class TestGetInfo(unittest.TestCase):
             manager_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_get_via_get_verb_with_manager_name(self):
         # "get" is a GET verb alias; with manager_name it fetches info,
@@ -296,7 +296,7 @@ class TestCreateManager(unittest.TestCase):
             op="create",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("manager_name", parsed["error"].lower())
+        self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_create_manager_with_delegation_strategy_and_roles(self):
         registry = MagicMock()
@@ -380,7 +380,7 @@ class TestAddWorker(unittest.TestCase):
             manager_name="missing", worker_name="w1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_add_worker_missing_manager_name_returns_err(self):
         parsed = json.loads(asyncio.run(managers(
@@ -388,7 +388,7 @@ class TestAddWorker(unittest.TestCase):
             op="create", target="workers", worker_name="w1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("manager_name", parsed["error"].lower())
+        self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_add_worker_missing_worker_name_returns_err(self):
         parsed = json.loads(asyncio.run(managers(
@@ -396,7 +396,7 @@ class TestAddWorker(unittest.TestCase):
             op="create", target="workers", manager_name="m1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("worker_name", parsed["error"].lower())
+        self.assertIn("worker_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -429,7 +429,7 @@ class TestRemoveManager(unittest.TestCase):
             manager_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_manager_missing_name_returns_err(self):
         parsed = json.loads(asyncio.run(managers(
@@ -437,7 +437,7 @@ class TestRemoveManager(unittest.TestCase):
             op="delete",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("manager_name", parsed["error"].lower())
+        self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_remove_manager_via_delete_method(self):
         registry = MagicMock()
@@ -486,7 +486,7 @@ class TestRemoveWorker(unittest.TestCase):
             manager_name="m1", worker_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_worker_manager_not_found_returns_err(self):
         registry = MagicMock()
@@ -497,7 +497,7 @@ class TestRemoveWorker(unittest.TestCase):
             manager_name="missing", worker_name="w1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_worker_missing_manager_returns_err(self):
         parsed = json.loads(asyncio.run(managers(
@@ -505,7 +505,7 @@ class TestRemoveWorker(unittest.TestCase):
             op="DELETE", target="workers", worker_name="w1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("manager_name", parsed["error"].lower())
+        self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_remove_worker_missing_worker_returns_err(self):
         parsed = json.loads(asyncio.run(managers(
@@ -513,7 +513,7 @@ class TestRemoveWorker(unittest.TestCase):
             op="DELETE", target="workers", manager_name="m1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("worker_name", parsed["error"].lower())
+        self.assertIn("worker_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -527,7 +527,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             managers(ctx=_make_ctx(), op="POST", definer="SEND")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_delete_unknown_target_not_implemented(self):
         parsed = json.loads(asyncio.run(managers(
@@ -535,7 +535,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="DELETE", target="bogus",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_dispatch.py
+++ b/tests/test_memory_dispatch.py
@@ -109,7 +109,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(memory(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -119,7 +119,7 @@ class TestWrongDefiner(unittest.TestCase):
             memory(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -173,7 +173,7 @@ class TestStore(unittest.TestCase):
             key="k", value="v",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_store_missing_key_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -182,7 +182,7 @@ class TestStore(unittest.TestCase):
             namespace=["ns"], value="v",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("key", parsed["error"].lower())
+        self.assertIn("key", parsed["error"]["message"].lower())
 
     def test_store_missing_value_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -191,7 +191,7 @@ class TestStore(unittest.TestCase):
             namespace=["ns"], key="k",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("value", parsed["error"].lower())
+        self.assertIn("value", parsed["error"]["message"].lower())
 
     def test_store_invalid_namespace_char_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -200,7 +200,7 @@ class TestStore(unittest.TestCase):
             namespace=["bad ns"], key="k", value="v",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("invalid", parsed["error"].lower())
+        self.assertIn("invalid", parsed["error"]["message"].lower())
 
     def test_store_invalid_key_char_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -209,7 +209,7 @@ class TestStore(unittest.TestCase):
             namespace=["ns"], key="bad key!", value="v",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("invalid", parsed["error"].lower())
+        self.assertIn("invalid", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -262,7 +262,7 @@ class TestRetrieve(unittest.TestCase):
             key="k",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_retrieve_missing_key_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -271,7 +271,7 @@ class TestRetrieve(unittest.TestCase):
             namespace=["ns"],
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("key", parsed["error"].lower())
+        self.assertIn("key", parsed["error"]["message"].lower())
 
 
 class TestHead(unittest.TestCase):
@@ -347,7 +347,7 @@ class TestSearch(unittest.TestCase):
             query="foo",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_search_missing_query_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -356,7 +356,7 @@ class TestSearch(unittest.TestCase):
             namespace=["ns"],
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("query", parsed["error"].lower())
+        self.assertIn("query", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -398,7 +398,7 @@ class TestListKeys(unittest.TestCase):
             op="GET", target="keys",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -507,7 +507,7 @@ class TestDeleteKey(unittest.TestCase):
             key="mykey",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_delete_missing_key_returns_err(self):
         parsed = json.loads(asyncio.run(memory(
@@ -516,7 +516,7 @@ class TestDeleteKey(unittest.TestCase):
             namespace=["proj"],
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("key", parsed["error"].lower())
+        self.assertIn("key", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -562,7 +562,7 @@ class TestClearNamespace(unittest.TestCase):
             namespace=["proj"],
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("confirm", parsed["error"].lower())
+        self.assertIn("confirm", parsed["error"]["message"].lower())
         # Critical: clear_namespace must NOT have been called.
         store.clear_namespace.assert_not_awaited()
 
@@ -576,7 +576,7 @@ class TestClearNamespace(unittest.TestCase):
             namespace=["proj"], confirm=False,
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("confirm", parsed["error"].lower())
+        self.assertIn("confirm", parsed["error"]["message"].lower())
         store.clear_namespace.assert_not_awaited()
 
     def test_clear_missing_namespace_returns_err(self):
@@ -586,7 +586,7 @@ class TestClearNamespace(unittest.TestCase):
             confirm=True,
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("namespace", parsed["error"].lower())
+        self.assertIn("namespace", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -601,7 +601,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="POST", definer="INVOKE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_send_not_implemented(self):
         parsed = json.loads(asyncio.run(memory(
@@ -609,7 +609,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="POST", definer="SEND",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_put_not_implemented(self):
         parsed = json.loads(asyncio.run(memory(
@@ -617,7 +617,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="PUT", definer="REPLACE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
         parsed = json.loads(asyncio.run(memory(
@@ -625,7 +625,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="PATCH", definer="MODIFY",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #

--- a/tests/test_roles_dispatch.py
+++ b/tests/test_roles_dispatch.py
@@ -206,7 +206,7 @@ class TestCheckPermission(unittest.TestCase):
             tool_name="npm",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("session_id", parsed["error"].lower())
+        self.assertIn("session_id", parsed["error"]["message"].lower())
 
     def test_check_missing_tool_name_returns_err(self):
         parsed = json.loads(asyncio.run(roles(
@@ -215,7 +215,7 @@ class TestCheckPermission(unittest.TestCase):
             session_id="s-1",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("tool_name", parsed["error"].lower())
+        self.assertIn("tool_name", parsed["error"]["message"].lower())
 
     def test_check_missing_role_manager_returns_err(self):
         ctx = MagicMock()
@@ -226,7 +226,7 @@ class TestCheckPermission(unittest.TestCase):
             session_id="s-1", tool_name="npm",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("role_manager", parsed["error"])
+        self.assertIn("role_manager", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -250,7 +250,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestUnsupportedMethods(unittest.TestCase):
@@ -261,21 +261,21 @@ class TestUnsupportedMethods(unittest.TestCase):
             roles(ctx=_make_ctx(), op="POST", definer="CREATE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
         parsed = json.loads(asyncio.run(
             roles(ctx=_make_ctx(), op="PATCH", definer="MODIFY")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_delete_not_implemented(self):
         parsed = json.loads(asyncio.run(
             roles(ctx=_make_ctx(), op="DELETE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #

--- a/tests/test_services_dispatch.py
+++ b/tests/test_services_dispatch.py
@@ -108,7 +108,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -118,7 +118,7 @@ class TestWrongDefiner(unittest.TestCase):
             services(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -297,7 +297,7 @@ class TestListInactive(unittest.TestCase):
             op="GET", target="inactive",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("repo_path", parsed["error"].lower())
+        self.assertIn("repo_path", parsed["error"]["message"].lower())
 
     def test_list_inactive_with_min_priority(self):
         from core.services import ServicePriority
@@ -411,7 +411,7 @@ class TestAdd(unittest.TestCase):
             command="run",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("service_name", parsed["error"].lower())
+        self.assertIn("service_name", parsed["error"]["message"].lower())
 
     def test_add_missing_command_returns_err(self):
         parsed = json.loads(asyncio.run(services(
@@ -420,7 +420,7 @@ class TestAdd(unittest.TestCase):
             service_name="api",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("command", parsed["error"].lower())
+        self.assertIn("command", parsed["error"]["message"].lower())
 
     def test_add_repo_scope_without_repo_path_returns_err(self):
         parsed = json.loads(asyncio.run(services(
@@ -431,7 +431,7 @@ class TestAdd(unittest.TestCase):
             scope="repo",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("repo_path", parsed["error"].lower())
+        self.assertIn("repo_path", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -503,9 +503,9 @@ class TestStart(unittest.TestCase):
             service_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
         # The error should include the available services.
-        self.assertIn("other", parsed["error"])
+        self.assertIn("other", parsed["error"]["message"])
 
     def test_start_failed_returns_failure_state(self):
         svc = _fake_service(name="api")
@@ -532,7 +532,7 @@ class TestStart(unittest.TestCase):
             op="start",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("service_name", parsed["error"].lower())
+        self.assertIn("service_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -622,7 +622,7 @@ class TestConfigure(unittest.TestCase):
             priority="required",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
         # Must not have saved anything.
         sm.save_global_config.assert_not_called()
 
@@ -633,7 +633,7 @@ class TestConfigure(unittest.TestCase):
             priority="required",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("service_name", parsed["error"].lower())
+        self.assertIn("service_name", parsed["error"]["message"].lower())
 
     def test_configure_repo_scope_without_repo_path_returns_err(self):
         parsed = json.loads(asyncio.run(services(
@@ -643,7 +643,7 @@ class TestConfigure(unittest.TestCase):
             scope="repo",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("repo_path", parsed["error"].lower())
+        self.assertIn("repo_path", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -698,7 +698,7 @@ class TestStop(unittest.TestCase):
             op="stop",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("service_name", parsed["error"].lower())
+        self.assertIn("service_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -712,28 +712,28 @@ class TestUnsupportedCombinations(unittest.TestCase):
             services(ctx=_make_ctx(), op="POST", definer="SEND")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_invoke_not_implemented(self):
         parsed = json.loads(asyncio.run(
             services(ctx=_make_ctx(), op="POST", definer="INVOKE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_patch_rename_not_implemented(self):
         parsed = json.loads(asyncio.run(
             services(ctx=_make_ctx(), op="PATCH", definer="RENAME")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_put_not_implemented(self):
         parsed = json.loads(asyncio.run(
             services(ctx=_make_ctx(), op="PUT", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -131,7 +131,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -140,7 +140,7 @@ class TestWrongDefiner(unittest.TestCase):
             sessions(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 class TestReadOutput(unittest.TestCase):
@@ -372,7 +372,7 @@ class TestWriteOutput(unittest.TestCase):
             )
         parsed = json.loads(asyncio.run(go()))
         self.assertFalse(parsed["ok"])
-        self.assertIn("requires", parsed["error"].lower())
+        self.assertIn("requires", parsed["error"]["message"].lower())
 
 
 class TestPostWithUnsupportedDefiner(unittest.TestCase):
@@ -382,7 +382,7 @@ class TestPostWithUnsupportedDefiner(unittest.TestCase):
         ))
         self.assertFalse(parsed["ok"])
         # Dispatcher converts NotImplementedError into a generic err envelope.
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_post_send_without_target_not_yet_implemented(self):
         # SEND without target='output' is reserved for future sub-resources
@@ -391,7 +391,7 @@ class TestPostWithUnsupportedDefiner(unittest.TestCase):
             sessions(ctx=_make_ctx(), op="POST", definer="SEND")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 class TestOptionsAdvertisesOutputAndSend(unittest.TestCase):
@@ -460,14 +460,14 @@ class TestSendKeys(unittest.TestCase):
             control_char="C", key="enter", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("either", parsed["error"].lower())
+        self.assertIn("either", parsed["error"]["message"].lower())
 
     def test_send_keys_missing_both_rejected(self):
         parsed = json.loads(asyncio.run(sessions(
             ctx=_make_ctx(), op="send", target="keys", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("requires", parsed["error"].lower())
+        self.assertIn("requires", parsed["error"]["message"].lower())
 
     def test_send_keys_no_matching_session(self):
         async def go():
@@ -483,7 +483,7 @@ class TestSendKeys(unittest.TestCase):
 
         parsed = json.loads(asyncio.run(go()))
         self.assertFalse(parsed["ok"])
-        self.assertIn("no matching session", parsed["error"].lower())
+        self.assertIn("no matching session", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -502,7 +502,7 @@ class TestPatchDefinerValidation(unittest.TestCase):
             op="append", target="roles", session_id="sid", role="builder",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("APPEND", parsed["error"])
+        self.assertIn("APPEND", parsed["error"]["message"])
 
     def test_patch_append_on_locks_rejected(self):
         parsed = json.loads(asyncio.run(sessions(
@@ -511,7 +511,7 @@ class TestPatchDefinerValidation(unittest.TestCase):
             session_id="sid", agent="alice", action="lock",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("APPEND", parsed["error"])
+        self.assertIn("APPEND", parsed["error"]["message"])
 
     def test_patch_append_on_session_rejected(self):
         parsed = json.loads(asyncio.run(sessions(
@@ -519,7 +519,7 @@ class TestPatchDefinerValidation(unittest.TestCase):
             op="append", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("APPEND", parsed["error"])
+        self.assertIn("APPEND", parsed["error"]["message"])
 
     def test_patch_append_on_tags_accepted(self):
         # Sanity: APPEND *is* valid on tags.
@@ -569,7 +569,7 @@ class TestPatchTags(unittest.TestCase):
             op="update", target="tags", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("tags", parsed["error"].lower())
+        self.assertIn("tags", parsed["error"]["message"].lower())
 
 
 class TestPatchActive(unittest.TestCase):
@@ -592,7 +592,7 @@ class TestPatchActive(unittest.TestCase):
             op="update", target="active", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
 
 class TestPatchRoles(unittest.TestCase):
@@ -616,7 +616,7 @@ class TestPatchRoles(unittest.TestCase):
             op="assign", target="roles", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("role", parsed["error"].lower())
+        self.assertIn("role", parsed["error"]["message"].lower())
 
     def test_assign_role_unknown_value(self):
         parsed = json.loads(asyncio.run(sessions(
@@ -680,7 +680,7 @@ class TestPatchLocks(unittest.TestCase):
             op="update", target="locks", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent", parsed["error"].lower())
+        self.assertIn("agent", parsed["error"]["message"].lower())
 
     def test_patch_locks_bad_action(self):
         parsed = json.loads(asyncio.run(sessions(
@@ -688,7 +688,7 @@ class TestPatchLocks(unittest.TestCase):
             op="update", target="locks", session_id="sid", agent="a", action="bogus",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("unknown action", parsed["error"].lower())
+        self.assertIn("unknown action", parsed["error"]["message"].lower())
 
 
 class TestDeleteLock(unittest.TestCase):
@@ -709,7 +709,7 @@ class TestDeleteLock(unittest.TestCase):
             op="delete", target="locks", session_id="sid",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent", parsed["error"].lower())
+        self.assertIn("agent", parsed["error"]["message"].lower())
 
 
 class TestOptionsAdvertisesPatchAndDelete(unittest.TestCase):
@@ -768,7 +768,7 @@ class TestGetStatus(unittest.TestCase):
             sessions(ctx=_make_ctx(), op="GET", target="status")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("requires", parsed["error"].lower())
+        self.assertIn("requires", parsed["error"]["message"].lower())
 
     def test_get_status_no_match(self):
         async def go():
@@ -781,7 +781,7 @@ class TestGetStatus(unittest.TestCase):
 
         parsed = json.loads(asyncio.run(go()))
         self.assertFalse(parsed["ok"])
-        self.assertIn("no matching session", parsed["error"].lower())
+        self.assertIn("no matching session", parsed["error"]["message"].lower())
 
 
 class TestStartMonitoring(unittest.TestCase):
@@ -820,7 +820,7 @@ class TestStartMonitoring(unittest.TestCase):
             op="start", target="monitoring",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("requires", parsed["error"].lower())
+        self.assertIn("requires", parsed["error"]["message"].lower())
 
     def test_start_monitoring_no_match(self):
         async def go():
@@ -833,7 +833,7 @@ class TestStartMonitoring(unittest.TestCase):
 
         parsed = json.loads(asyncio.run(go()))
         self.assertFalse(parsed["ok"])
-        self.assertIn("no matching session", parsed["error"].lower())
+        self.assertIn("no matching session", parsed["error"]["message"].lower())
 
 
 class TestStopMonitoring(unittest.TestCase):
@@ -867,7 +867,7 @@ class TestStopMonitoring(unittest.TestCase):
             op="stop", target="monitoring",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("requires", parsed["error"].lower())
+        self.assertIn("requires", parsed["error"]["message"].lower())
 
 
 class TestCreateSplit(unittest.TestCase):
@@ -913,7 +913,7 @@ class TestCreateSplit(unittest.TestCase):
             op="POST", definer="CREATE", target="splits", direction="below",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("session_id", parsed["error"].lower())
+        self.assertIn("session_id", parsed["error"]["message"].lower())
 
 
 class TestPatchAppearance(unittest.TestCase):

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -79,7 +79,7 @@ class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
         parsed = json.loads(asyncio.run(teams(ctx=_make_ctx(), op="frobnicate")))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
@@ -89,7 +89,7 @@ class TestWrongDefiner(unittest.TestCase):
             teams(ctx=_make_ctx(), op="POST", definer="REPLACE")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #
@@ -271,7 +271,7 @@ class TestCreateTeam(unittest.TestCase):
             op="create",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("team_name", parsed["error"].lower())
+        self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_create_team_with_parent_and_repo_path(self):
         registry, profile_manager, service_hook_manager = self._setup_ctx()
@@ -318,7 +318,7 @@ class TestCreateTeam(unittest.TestCase):
             team_name="infra",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Required service failed", parsed["error"])
+        self.assertIn("Required service failed", parsed["error"]["message"])
         # Must NOT have created the team or profile when hook blocks.
         registry.create_team.assert_not_called()
         profile_manager.get_or_create_team_profile.assert_not_called()
@@ -401,7 +401,7 @@ class TestAssignAgent(unittest.TestCase):
             team_name="infra", agent_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent not found", parsed["error"].lower())
+        self.assertIn("agent not found", parsed["error"]["message"].lower())
 
     def test_assign_agent_missing_team_name_returns_err(self):
         parsed = json.loads(asyncio.run(teams(
@@ -409,7 +409,7 @@ class TestAssignAgent(unittest.TestCase):
             op="create", target="agents", agent_name="alice",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("team_name", parsed["error"].lower())
+        self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_assign_agent_missing_agent_name_returns_err(self):
         parsed = json.loads(asyncio.run(teams(
@@ -417,7 +417,7 @@ class TestAssignAgent(unittest.TestCase):
             op="create", target="agents", team_name="infra",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"].lower())
+        self.assertIn("agent_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -476,7 +476,7 @@ class TestRemoveTeam(unittest.TestCase):
             team_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("missing", parsed["error"])
+        self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_team_missing_name_returns_err(self):
         parsed = json.loads(asyncio.run(teams(
@@ -484,7 +484,7 @@ class TestRemoveTeam(unittest.TestCase):
             op="delete",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("team_name", parsed["error"].lower())
+        self.assertIn("team_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -519,7 +519,7 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
             team_name="infra", agent_name="missing",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not found", parsed["error"].lower())
+        self.assertIn("not found", parsed["error"]["message"].lower())
 
     def test_remove_agent_missing_team_returns_err(self):
         parsed = json.loads(asyncio.run(teams(
@@ -527,7 +527,7 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
             op="DELETE", target="agents", agent_name="alice",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("team_name", parsed["error"].lower())
+        self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_remove_agent_missing_agent_returns_err(self):
         parsed = json.loads(asyncio.run(teams(
@@ -535,7 +535,7 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
             op="DELETE", target="agents", team_name="infra",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("agent_name", parsed["error"].lower())
+        self.assertIn("agent_name", parsed["error"]["message"].lower())
 
 
 # ========================================================================= #
@@ -549,7 +549,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             teams(ctx=_make_ctx(), op="POST", definer="SEND")
         ))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_delete_unknown_target_not_implemented(self):
         parsed = json.loads(asyncio.run(teams(
@@ -557,7 +557,7 @@ class TestUnsupportedCombinations(unittest.TestCase):
             op="DELETE", target="bogus",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not", parsed["error"].lower())
+        self.assertIn("not", parsed["error"]["message"].lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_workflows_dispatch.py
+++ b/tests/test_workflows_dispatch.py
@@ -414,7 +414,7 @@ class TestTrigger(unittest.TestCase):
             op="trigger",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("event_name", parsed["error"].lower())
+        self.assertIn("event_name", parsed["error"]["message"].lower())
 
     def test_trigger_with_source_and_metadata(self):
         eb = MagicMock()
@@ -484,7 +484,7 @@ class TestUnknownOp(unittest.TestCase):
             op="frobnicate",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("Unknown op", parsed["error"])
+        self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestUnsupportedDefiners(unittest.TestCase):
@@ -494,7 +494,7 @@ class TestUnsupportedDefiners(unittest.TestCase):
             op="POST", definer="CREATE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_post_send_not_implemented(self):
         parsed = json.loads(asyncio.run(workflows(
@@ -502,7 +502,7 @@ class TestUnsupportedDefiners(unittest.TestCase):
             op="POST", definer="SEND",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
         parsed = json.loads(asyncio.run(workflows(
@@ -510,7 +510,7 @@ class TestUnsupportedDefiners(unittest.TestCase):
             op="PATCH", definer="MODIFY",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_delete_not_implemented(self):
         parsed = json.loads(asyncio.run(workflows(
@@ -518,7 +518,7 @@ class TestUnsupportedDefiners(unittest.TestCase):
             op="DELETE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not implemented", parsed["error"].lower())
+        self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_wrong_family_definer_rejected(self):
         # REPLACE belongs to PUT, not POST.
@@ -527,7 +527,7 @@ class TestUnsupportedDefiners(unittest.TestCase):
             op="POST", definer="REPLACE",
         )))
         self.assertFalse(parsed["ok"])
-        self.assertIn("not in POST family", parsed["error"])
+        self.assertIn("not in POST family", parsed["error"]["message"])
 
 
 # ========================================================================= #


### PR DESCRIPTION
Resolves item #1b of feedback **fb-20260424-157473f7**.

## Before

```json
{"method": "POST", "ok": false, "error": "'layout'"}
```

A bare `KeyError` repr in the wire. Other errors leaked Pydantic stack traces or raw exception strings. Clients had no way to branch on error categories.

## After

```json
{
  "method": "POST",
  "ok": false,
  "error": {
    "code": "invalid_op",
    "message": "Method PATCH not supported on sessions",
    "hint": "..."
  }
}
```

## What's new

`iterm_mcpy/errors.py`:

- **`ErrorCode`** (str enum) — stable, part of the public API:
  `invalid_op`, `invalid_target`, `invalid_definer`, `missing_param`, `invalid_param`, `session_not_found`, `agent_not_found`, `locked`, `not_implemented`, `internal`.
- **`ToolError(code, message, hint?)`** — exception type tools raise; the dispatcher catches it and renders via `err_envelope`.
- **`ToolError.from_exception(exc)`** — maps common Python exceptions:
  - `KeyError` → `MISSING_PARAM` (with the missing key in the message)
  - `ValueError` → `INVALID_PARAM`
  - `pydantic.ValidationError` → `INVALID_PARAM` (lazy import; no hard pydantic dep on this module)
  - `NotImplementedError` → `NOT_IMPLEMENTED`
  - Anything else → `INTERNAL`
  - Existing `ToolError` passes through unchanged (no double-wrap)

`responses.err_envelope` accepts either a `ToolError` (preferred) or a bare string for backward compat — strings are wrapped as `ToolError(INTERNAL, message=<str>)`.

## Migrations

**Dispatcher** (`iterm_mcpy/dispatcher.py`):

- `DefinerError` → `INVALID_OP` (no definer given) or `INVALID_DEFINER` (caller's choice was wrong).
- "Method X not supported on Y" → `INVALID_OP`.
- `NotImplementedError` catch → `NOT_IMPLEMENTED`.
- Generic `Exception` catch → `ToolError.from_exception(e)` for richer auto-mapping.

**All 7 action-tool error sites** (`subscribe`, `wait_for`, `telemetry`, `delegate`, `orchestrate`, `messages`, plus dispatcher itself):

- `error=str(e)` → `error=ToolError.from_exception(e)`. Existing `from_exception` mapping turns a `KeyError`-from-handler into `missing_param` automatically — no per-site code needed.

## Tests

- **New `tests/test_errors.py`** (13 cases): `ErrorCode` value contract, `ToolError` construction & `to_dict`, `from_exception` mapping for KeyError/ValueError/RuntimeError/passthrough, envelope round-trip with both `ToolError` and bare-string inputs.
- **New `TestStructuredErrorCodes`** in `tests/test_dispatcher.py` (5 cases) locks the dispatcher's specific error-code contract: unknown op → `invalid_op`, wrong family → `invalid_definer`, NotImplementedError → `not_implemented`, generic exception → `internal`, KeyError-in-handler → `missing_param`.
- **17 existing test files** mass-migrated from `parsed["error"]` (string) to `parsed["error"]["message"]` (structured shape).

```
$ python -m unittest [16 tests/* modules]
Ran 457 tests in 1.594s
OK
```

## Stacks on

This is PR 3 of 4 in the UX-feedback fix-up plan (`docs/superpowers/plans/2026-04-25-root-cleanup.md` for cleanup; this work is tracked in `~/.claude/plans/sunny-dreaming-crane.md`):

- ✅ #117 layout default
- ✅ #118 session name preservation (+ #120 fix-up)
- ✅ #119 output tail default
- 🔵 **#121 (this) structured errors**
- ⏳ #122 unwrap double-JSON encoding (`{result: "<JSON>"}` → native dict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)