### PR TITLE
feat(envelope): return native dict, drop double-JSON encoding

### DIFF
--- a/iterm_mcpy/dispatcher.py
+++ b/iterm_mcpy/dispatcher.py
@@ -83,7 +83,7 @@ class MethodDispatcher:
         op: str,
         definer: Optional[str] = None,
         **params,
-    ) -> str:
+    ) -> dict[str, Any]:
         """Entry point invoked by the MCP tool wrapper.
 
         Args:

--- a/iterm_mcpy/responses.py
+++ b/iterm_mcpy/responses.py
@@ -1,10 +1,11 @@
 """Centralized response serialization for MCP tools.
 
 SP1 shipped `ok_json()` for token-efficient model serialization.
-SP2 adds the envelope format used by method-semantic tools.
+SP2 adds the envelope format used by method-semantic tools. As of the
+fb-20260424-157473f7 item #13 fix, the envelope helpers return native
+``dict`` so FastMCP can produce structured tool output (no double JSON).
 """
-import json
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -25,10 +26,17 @@ def ok_envelope(
     method: str,
     data: Any,
     definer: Optional[str] = None,
-) -> str:
-    """Serialize a successful tool result in the SP2 envelope.
+) -> dict[str, Any]:
+    """Build a successful tool result in the SP2 envelope.
 
-    Envelope shape: {"method", "definer"?, "ok": true, "data"}
+    Envelope shape: ``{"method", "definer"?, "ok": true, "data"}``
+
+    Returns a native ``dict``; FastMCP serializes it for the wire as
+    ``structuredContent`` plus a JSON-stringified ``TextContent`` block.
+    Returning ``dict`` (as opposed to a stringified envelope) avoids the
+    double-encoded ``{"result": "<JSON>"}`` shape MCP clients surface
+    when tool functions are typed ``-> str``. See fb-20260424-157473f7
+    item #13.
 
     Args:
         method: The HTTP method that ran (normalized uppercase).
@@ -36,21 +44,21 @@ def ok_envelope(
         definer: Optional definer verb (for POST/PUT/PATCH). Omitted if None.
 
     Returns:
-        JSON string with indent=2.
+        Envelope dict (not a JSON string).
     """
     payload: dict[str, Any] = {"method": method, "ok": True}
     if definer is not None:
         payload["definer"] = definer
     payload["data"] = _to_jsonable(data)
-    return json.dumps(payload, indent=2)
+    return payload
 
 
 def err_envelope(
     method: str,
     error,
     definer: Optional[str] = None,
-) -> str:
-    """Serialize an error result in the SP2 envelope.
+) -> dict[str, Any]:
+    """Build an error result in the SP2 envelope.
 
     Envelope shape::
 
@@ -63,15 +71,16 @@ def err_envelope(
     uniform regardless of caller migration state. See
     fb-20260424-157473f7 item #1b.
 
+    Returns a native ``dict``; FastMCP handles serialization.
+
     Args:
         method: The HTTP method that was attempted.
         error: Either a ``ToolError`` or a bare human-readable string.
         definer: Optional definer verb (if it was resolved before the error).
 
     Returns:
-        JSON string with indent=2.
+        Envelope dict (not a JSON string).
     """
-    # Lazy import keeps responses.py free of circular import risk.
     from iterm_mcpy.errors import ErrorCode, ToolError
 
     if isinstance(error, str):
@@ -81,7 +90,7 @@ def err_envelope(
     if definer is not None:
         payload["definer"] = definer
     payload["error"] = error.to_dict()
-    return json.dumps(payload, indent=2)
+    return payload
 
 
 def project_head(model_or_list: Any) -> Any:

--- a/iterm_mcpy/tools/agents.py
+++ b/iterm_mcpy/tools/agents.py
@@ -13,7 +13,7 @@ Collection tool implementing the WebSpec agent surface. Replaces 8 SP1 tools:
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -28,7 +28,7 @@ from core.models import (
 from iterm_mcpy.dispatcher import MethodDispatcher
 
 
-async def _manage_agent_hooks(request: ManageAgentHooksRequest, ctx: Context) -> str:
+async def _manage_agent_hooks(request: ManageAgentHooksRequest, ctx: Context) -> dict[str, Any]:
     """Unified agent hooks management (module-local helper).
 
     Ported from the SP1 ``manage_agent_hooks`` tool. Kept as a JSON-returning
@@ -725,7 +725,7 @@ async def agents(
     new_path: Optional[str] = None,
     variable_name: Optional[str] = None,
     variable_value: Optional[str] = None,
-) -> str:
+) -> dict[str, Any]:
     """Agent operations: list, register, remove, notify, status, notifications,
     hooks, locks, HEAD, OPTIONS.
 

--- a/iterm_mcpy/tools/delegate.py
+++ b/iterm_mcpy/tools/delegate.py
@@ -178,7 +178,7 @@ async def delegate(
     timeout_seconds: Optional[int] = None,
     retry_count: int = 0,
     plan: Optional[Dict[str, Any]] = None,
-) -> str:
+) -> dict[str, Any]:
     """Delegate a task or execute a multi-step plan through a manager.
 
     Replaces the legacy ``delegate_task`` and ``execute_plan`` tools. The

--- a/iterm_mcpy/tools/feedback.py
+++ b/iterm_mcpy/tools/feedback.py
@@ -17,7 +17,7 @@ legacy feedback tools; the cutover (rename to ``feedback`` and unregister
 the legacy tools) happens at the end of SP2.
 """
 import os
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -654,7 +654,7 @@ async def feedback(
     periodic_tool_call_count: Optional[int] = None,
     add_pattern: Optional[str] = None,
     remove_pattern: Optional[str] = None,
-) -> str:
+) -> dict[str, Any]:
     """Feedback lifecycle: submit, query, fork, triage, notify, config.
 
     Use op="query" (or op="GET") (+ status?/category?/agent_name?/limit?) to

--- a/iterm_mcpy/tools/managers.py
+++ b/iterm_mcpy/tools/managers.py
@@ -18,7 +18,7 @@ Note: ``delegate_task`` and ``execute_plan`` (other tools in the legacy
 ``managers`` module) are action tools and are handled by Task 14, not
 this task.
 """
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -331,7 +331,7 @@ async def managers(
     worker_roles: Optional[Dict[str, str]] = None,
     worker_role: Optional[str] = None,
     metadata: Optional[Dict[str, str]] = None,
-) -> str:
+) -> dict[str, Any]:
     """Manager agent management: list, get info, create, remove, add/remove
     workers, HEAD, OPTIONS.
 

--- a/iterm_mcpy/tools/memory.py
+++ b/iterm_mcpy/tools/memory.py
@@ -422,7 +422,7 @@ async def memory(
     query: Optional[str] = None,
     limit: int = 10,
     confirm: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Memory store ops: retrieve, store, search, list, delete, clear, stats.
 
     Use op="retrieve" (or op="GET") + namespace + key to fetch one value.

--- a/iterm_mcpy/tools/messages.py
+++ b/iterm_mcpy/tools/messages.py
@@ -121,7 +121,7 @@ async def messages(
     broadcast: Optional[str] = None,
     skip_duplicates: bool = True,
     execute: bool = True,
-) -> str:
+) -> dict[str, Any]:
     """Send messages to sessions using cascade or hierarchical targeting.
 
     Unifies the legacy ``send_cascade_message`` and

--- a/iterm_mcpy/tools/orchestrate.py
+++ b/iterm_mcpy/tools/orchestrate.py
@@ -33,7 +33,7 @@ async def orchestrate(
     op: str = "POST",
     definer: Optional[str] = None,
     playbook: Optional[Dict[str, Any]] = None,
-) -> str:
+) -> dict[str, Any]:
     """Orchestrate a playbook (layout + commands + cascade + reads).
 
     Replaces the legacy ``orchestrate_playbook`` tool. A playbook bundles

--- a/iterm_mcpy/tools/roles.py
+++ b/iterm_mcpy/tools/roles.py
@@ -20,7 +20,7 @@ Registered under the provisional name ``roles`` to coexist with the
 legacy per-verb tools; the cutover (rename to ``roles`` and unregister
 the legacy tools) happens at the end of SP2.
 """
-from typing import Optional
+from typing import Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -168,7 +168,7 @@ async def roles(
     target: Optional[str] = None,
     session_id: Optional[str] = None,
     tool_name: Optional[str] = None,
-) -> str:
+) -> dict[str, Any]:
     """Roles catalog: list role definitions, check tool permissions.
 
     Use op="list" (or op="GET") to list all available role definitions —

--- a/iterm_mcpy/tools/services.py
+++ b/iterm_mcpy/tools/services.py
@@ -15,7 +15,7 @@ Registered under the provisional name ``services`` to coexist with the
 legacy ``manage_services`` tool; the cutover (rename to ``services`` and
 unregister the legacy tool) happens at the end of SP2.
 """
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -436,7 +436,7 @@ async def services(
     working_directory: Optional[str] = None,
     repo_patterns: Optional[List[str]] = None,
     scope: str = "global",
-) -> str:
+) -> dict[str, Any]:
     """Service management: list, start, stop, add, configure, list_inactive.
 
     Use op="list" (or op="GET") to list configured services. Pass repo_path

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -1619,7 +1619,7 @@ async def sessions(
     suspend_by: Optional[str] = None,
     set_active: Optional[bool] = None,
     reset: Optional[bool] = None,
-) -> str:
+) -> dict[str, Any]:
     """Session operations: list, read, write, send keys, create, split, monitor,
     modify, patch, delete, HEAD, OPTIONS.
 

--- a/iterm_mcpy/tools/subscribe.py
+++ b/iterm_mcpy/tools/subscribe.py
@@ -23,7 +23,7 @@ async def subscribe(
     definer: Optional[str] = None,
     pattern: Optional[str] = None,
     event_name: Optional[str] = None,
-) -> str:
+) -> dict[str, Any]:
     """Subscribe to terminal output matching a regex pattern.
 
     Replaces the legacy ``subscribe_to_output_pattern`` tool. When terminal

--- a/iterm_mcpy/tools/teams.py
+++ b/iterm_mcpy/tools/teams.py
@@ -13,7 +13,7 @@ Registered under the provisional name ``teams`` to coexist with the
 legacy ``manage_teams`` tool; the cutover (rename to ``teams`` and
 unregister the legacy tool) happens at the end of SP2.
 """
-from typing import Optional
+from typing import Optional, Any
 
 from mcp.server.fastmcp import Context
 
@@ -328,7 +328,7 @@ async def teams(
     description: Optional[str] = None,
     parent_team: Optional[str] = None,
     repo_path: Optional[str] = None,
-) -> str:
+) -> dict[str, Any]:
     """Team management: list, create, remove, assign agent, remove agent.
 
     Use op="list" (or op="GET") to list all teams with member counts.

--- a/iterm_mcpy/tools/telemetry.py
+++ b/iterm_mcpy/tools/telemetry.py
@@ -11,7 +11,7 @@ dashboard lifecycle as a method-semantic action:
 
 Any other (op, definer) pair returns an err envelope.
 """
-from typing import Optional
+from typing import Any, Optional
 
 from mcp.server.fastmcp import Context
 
@@ -82,7 +82,7 @@ async def telemetry(
     definer: Optional[str] = None,
     port: int = 9999,
     duration_seconds: int = 300,
-) -> str:
+) -> dict[str, Any]:
     """Telemetry dashboard lifecycle.
 
     POST+TRIGGER (or op="start"): start the dashboard. Mirrors the legacy

--- a/iterm_mcpy/tools/wait_for.py
+++ b/iterm_mcpy/tools/wait_for.py
@@ -6,6 +6,7 @@ until an agent's session becomes idle or the timeout elapses.
 Only GET is supported (no state change). Any other (op, definer) pair
 returns an err envelope.
 """
+from typing import Any
 import asyncio
 import time
 from typing import Optional
@@ -129,7 +130,7 @@ async def wait_for(
     wait_up_to: int = 30,
     return_output: bool = True,
     summary_on_timeout: bool = True,
-) -> str:
+) -> dict[str, Any]:
     """Long-poll until an agent becomes idle or the timeout elapses.
 
     Replaces the legacy ``wait_for_agent`` tool. Only GET is supported —

--- a/iterm_mcpy/tools/workflows.py
+++ b/iterm_mcpy/tools/workflows.py
@@ -291,7 +291,7 @@ async def workflows(
     immediate: bool = False,
     limit: int = 100,
     success_only: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Workflow event bus: list events, trigger events, get event history.
 
     Use op="list" (or op="GET") to list registered workflow events. Returns

--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -64,11 +64,11 @@ class TestMessagesV2(unittest.TestCase):
             "iterm_mcpy.tools.messages.execute_cascade_request",
             side_effect=fake_cascade,
         ):
-            parsed = json.loads(asyncio.run(messages(
+            parsed = asyncio.run(messages(
                 ctx=_make_ctx(),
                 op="send",
                 cascade={"broadcast": "hello"},
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
@@ -76,46 +76,46 @@ class TestMessagesV2(unittest.TestCase):
 
     def test_wrong_op_returns_err(self):
         # GET is the wrong family for messages.
-        parsed = json.loads(asyncio.run(messages(
+        parsed = asyncio.run(messages(
             ctx=_make_ctx(),
             op="GET",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+SEND", parsed["error"]["message"])
 
     def test_wrong_definer_returns_err(self):
         # CREATE is a valid POST definer but not what messages supports.
-        parsed = json.loads(asyncio.run(messages(
+        parsed = asyncio.run(messages(
             ctx=_make_ctx(),
             op="POST", definer="CREATE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+SEND", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
-        parsed = json.loads(asyncio.run(messages(
+        parsed = asyncio.run(messages(
             ctx=_make_ctx(),
             op="frobnicate",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_missing_cascade_and_targets_returns_err(self):
-        parsed = json.loads(asyncio.run(messages(
+        parsed = asyncio.run(messages(
             ctx=_make_ctx(),
             op="send",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("cascade", parsed["error"]["message"].lower())
         self.assertIn("targets", parsed["error"]["message"].lower())
 
     def test_both_cascade_and_targets_returns_err(self):
-        parsed = json.loads(asyncio.run(messages(
+        parsed = asyncio.run(messages(
             ctx=_make_ctx(),
             op="send",
             cascade={"broadcast": "hi"},
             targets=[{"agent": "alice"}],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not both", parsed["error"]["message"].lower())
 
@@ -133,11 +133,11 @@ class TestOrchestrateV2(unittest.TestCase):
         )
 
     def test_happy_path_empty_playbook(self):
-        parsed = json.loads(asyncio.run(orchestrate(
+        parsed = asyncio.run(orchestrate(
             ctx=self._ctx(),
             op="invoke",
             playbook={},  # no layout/commands/cascade/reads
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "INVOKE")
@@ -156,7 +156,7 @@ class TestOrchestrateV2(unittest.TestCase):
             "iterm_mcpy.tools.orchestrate.execute_write_request",
             side_effect=fake_write,
         ):
-            parsed = json.loads(asyncio.run(orchestrate(
+            parsed = asyncio.run(orchestrate(
                 ctx=self._ctx(),
                 op="POST", definer="INVOKE",
                 playbook={
@@ -172,32 +172,32 @@ class TestOrchestrateV2(unittest.TestCase):
                         },
                     ],
                 },
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(len(parsed["data"]["commands"]), 1)
         self.assertEqual(parsed["data"]["commands"][0]["name"], "step1")
 
     def test_wrong_op_returns_err(self):
-        parsed = json.loads(asyncio.run(orchestrate(
+        parsed = asyncio.run(orchestrate(
             ctx=self._ctx(),
             op="GET",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+INVOKE", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
-        parsed = json.loads(asyncio.run(orchestrate(
+        parsed = asyncio.run(orchestrate(
             ctx=self._ctx(),
             op="frobnicate",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_missing_playbook_returns_err(self):
-        parsed = json.loads(asyncio.run(orchestrate(
+        parsed = asyncio.run(orchestrate(
             ctx=self._ctx(),
             op="invoke",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("playbook", parsed["error"]["message"].lower())
 
@@ -232,13 +232,13 @@ class TestDelegateV2(unittest.TestCase):
 
         # Also patch _setup_manager_callbacks (it's fine as a no-op here).
         with patch("iterm_mcpy.tools.delegate._setup_manager_callbacks"):
-            parsed = json.loads(asyncio.run(delegate(
+            parsed = asyncio.run(delegate(
                 ctx=self._ctx(manager_registry=manager_registry),
                 op="delegate",
                 target="task",
                 manager_name="mgr1",
                 task="echo hi",
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "INVOKE")
@@ -246,12 +246,12 @@ class TestDelegateV2(unittest.TestCase):
         self.assertEqual(parsed["data"]["worker"], "alice")
 
     def test_task_missing_manager_returns_err(self):
-        parsed = json.loads(asyncio.run(delegate(
+        parsed = asyncio.run(delegate(
             ctx=self._ctx(),
             op="delegate",
             target="task",
             task="echo hi",  # manager_name missing
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("manager_name", parsed["error"]["message"])
 
@@ -259,13 +259,13 @@ class TestDelegateV2(unittest.TestCase):
         manager_registry = MagicMock()
         manager_registry.get_manager.return_value = None
 
-        parsed = json.loads(asyncio.run(delegate(
+        parsed = asyncio.run(delegate(
             ctx=self._ctx(manager_registry=manager_registry),
             op="delegate",
             target="task",
             manager_name="ghost",
             task="echo hi",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("ghost", parsed["error"]["message"])
         self.assertIn("not found", parsed["error"]["message"].lower())
@@ -284,7 +284,7 @@ class TestDelegateV2(unittest.TestCase):
         manager_registry.get_manager.return_value = manager
 
         with patch("iterm_mcpy.tools.delegate._setup_manager_callbacks"):
-            parsed = json.loads(asyncio.run(delegate(
+            parsed = asyncio.run(delegate(
                 ctx=self._ctx(manager_registry=manager_registry),
                 op="POST", definer="INVOKE",
                 target="plan",
@@ -295,34 +295,34 @@ class TestDelegateV2(unittest.TestCase):
                         {"id": "s1", "task": "echo hello"},
                     ],
                 },
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["plan_name"], "p1")
 
     def test_plan_missing_plan_returns_err(self):
-        parsed = json.loads(asyncio.run(delegate(
+        parsed = asyncio.run(delegate(
             ctx=self._ctx(),
             op="delegate",
             target="plan",
             manager_name="mgr1",  # plan missing
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("plan", parsed["error"]["message"].lower())
 
     def test_bad_target_returns_err(self):
-        parsed = json.loads(asyncio.run(delegate(
+        parsed = asyncio.run(delegate(
             ctx=self._ctx(),
             op="delegate",
             target="mystery",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("target must be", parsed["error"]["message"])
 
     def test_wrong_op_returns_err(self):
-        parsed = json.loads(asyncio.run(delegate(
+        parsed = asyncio.run(delegate(
             ctx=self._ctx(),
             op="GET",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+INVOKE", parsed["error"]["message"])
 
@@ -349,7 +349,7 @@ class TestWaitForV2(unittest.TestCase):
         notification_manager = MagicMock()
         notification_manager.add_simple = AsyncMock()
 
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(
                 agent_registry=agent_registry,
                 terminal=terminal,
@@ -358,7 +358,7 @@ class TestWaitForV2(unittest.TestCase):
             op="GET",
             agent_name="alice",
             wait_up_to=5,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["data"]["completed"])
@@ -368,48 +368,48 @@ class TestWaitForV2(unittest.TestCase):
         agent_registry = MagicMock()
         agent_registry.get_agent.return_value = None
 
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="GET",
             agent_name="ghost",
-        )))
+        ))
         self.assertTrue(parsed["ok"])  # envelope is ok; payload carries the error.
         self.assertFalse(parsed["data"]["completed"])
         self.assertEqual(parsed["data"]["status"], "unknown")
         self.assertIn("ghost", parsed["data"]["summary"])
 
     def test_wrong_op_returns_err(self):
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(),
             op="POST",
             agent_name="alice",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("GET", parsed["error"]["message"])
 
     def test_missing_agent_name_returns_err(self):
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(),
             op="GET",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(),
             op="frobnicate",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_out_of_range_timeout_returns_err(self):
-        parsed = json.loads(asyncio.run(wait_for(
+        parsed = asyncio.run(wait_for(
             ctx=_make_ctx(),
             op="GET",
             agent_name="alice",
             wait_up_to=0,  # below min=1
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("1 and 600", parsed["error"]["message"])
 
@@ -424,12 +424,12 @@ class TestSubscribeV2(unittest.TestCase):
         event_bus = MagicMock()
         event_bus.subscribe_to_pattern = AsyncMock(return_value="sub-123")
 
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(event_bus=event_bus),
             op="subscribe",
             pattern=r"error:\s",
             event_name="error_event",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
@@ -441,45 +441,45 @@ class TestSubscribeV2(unittest.TestCase):
         event_bus = MagicMock()
         event_bus.subscribe_to_pattern = AsyncMock(return_value="sub-1")
 
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(event_bus=event_bus),
             op="POST", definer="TRIGGER",
             pattern="foo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
 
     def test_wrong_op_returns_err(self):
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(),
             op="GET",
             pattern="foo",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+TRIGGER", parsed["error"]["message"])
 
     def test_wrong_definer_returns_err(self):
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(),
             op="POST", definer="CREATE",
             pattern="foo",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+TRIGGER", parsed["error"]["message"])
 
     def test_missing_pattern_returns_err(self):
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(),
             op="subscribe",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("pattern", parsed["error"]["message"].lower())
 
     def test_bad_regex_returns_err(self):
-        parsed = json.loads(asyncio.run(subscribe(
+        parsed = asyncio.run(subscribe(
             ctx=_make_ctx(),
             op="subscribe",
             pattern="[bad(regex",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Invalid regex", parsed["error"]["message"])
 
@@ -497,12 +497,12 @@ class TestTelemetryV2(unittest.TestCase):
         )
         # Patch start_dashboard where it's imported — inside _start_dashboard.
         with patch("core.dashboard.start_dashboard", new=AsyncMock(return_value="running on 9999")):
-            parsed = json.loads(asyncio.run(telemetry(
+            parsed = asyncio.run(telemetry(
                 ctx=ctx,
                 op="start",
                 port=9999,
                 duration_seconds=10,
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
@@ -511,35 +511,35 @@ class TestTelemetryV2(unittest.TestCase):
 
     def test_stop_happy_path(self):
         with patch("core.dashboard.stop_dashboard", new=AsyncMock()):
-            parsed = json.loads(asyncio.run(telemetry(
+            parsed = asyncio.run(telemetry(
                 ctx=_make_ctx(),
                 op="stop",
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "DELETE")
         self.assertEqual(parsed["data"]["status"], "stopped")
 
     def test_wrong_definer_returns_err(self):
-        parsed = json.loads(asyncio.run(telemetry(
+        parsed = asyncio.run(telemetry(
             ctx=_make_ctx(),
             op="POST", definer="CREATE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("TRIGGER", parsed["error"]["message"])
 
     def test_unknown_verb_returns_err(self):
-        parsed = json.loads(asyncio.run(telemetry(
+        parsed = asyncio.run(telemetry(
             ctx=_make_ctx(),
             op="frobnicate",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
     def test_patch_not_supported(self):
-        parsed = json.loads(asyncio.run(telemetry(
+        parsed = asyncio.run(telemetry(
             ctx=_make_ctx(),
             op="PATCH", definer="MODIFY",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("POST+TRIGGER or DELETE", parsed["error"]["message"])
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -43,7 +43,7 @@ class TestOptions(unittest.TestCase):
             return await agents(ctx=_make_ctx(), op="OPTIONS")
 
         result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "agents")
@@ -57,21 +57,21 @@ class TestOptions(unittest.TestCase):
             self.assertIn(name, subs)
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(agents(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(agents(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
         self.assertIn("SEND", post["definers"])
         self.assertIn("TRIGGER", post["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(agents(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(agents(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(agents(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(agents(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -79,9 +79,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE is in the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             agents(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -101,10 +101,10 @@ class TestListAgents(unittest.TestCase):
             Agent(name="bob", session_id="s2", teams=[]),
         ]
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="list",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(len(parsed["data"]), 2)
@@ -119,10 +119,10 @@ class TestListAgents(unittest.TestCase):
         agent_registry.list_agents.return_value = [
             Agent(name="alice", session_id="s1", teams=["backend"]),
         ]
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="list", team="backend",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         agent_registry.list_agents.assert_called_once_with(team="backend")
 
@@ -140,10 +140,10 @@ class TestHead(unittest.TestCase):
                 metadata={"key": "value"},
             ),
         ]
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
         # HEAD_FIELDS = {name, session_id, teams}; metadata must be excluded.
@@ -176,13 +176,13 @@ class TestRegisterAgent(unittest.TestCase):
             name="alice", session_id="sid-1", teams=["backend"],
         )
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(terminal=terminal, agent_registry=agent_registry),
             op="register",  # -> POST + CREATE
             agent_name="alice",
             session_id="sid-1",
             team="backend",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -210,30 +210,30 @@ class TestRegisterAgent(unittest.TestCase):
             name="alice", session_id="sid-1", teams=["a", "b"],
         )
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(terminal=terminal, agent_registry=agent_registry),
             op="POST", definer="CREATE",
             agent_name="alice", session_id="sid-1",
             teams=["a", "b"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         agent_registry.register_agent.assert_called_once_with(
             name="alice", session_id="sid-1", teams=["a", "b"], metadata={},
         )
 
     def test_register_missing_session_id_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="register", agent_name="alice",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("session_id", parsed["error"]["message"].lower())
 
     def test_register_missing_agent_name_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="register", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"].lower())
 
@@ -241,10 +241,10 @@ class TestRegisterAgent(unittest.TestCase):
         terminal = MagicMock()
         terminal.get_session_by_id = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(terminal=terminal),
             op="register", agent_name="alice", session_id="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("no matching session", parsed["error"]["message"].lower())
 
@@ -259,11 +259,11 @@ class TestNotify(unittest.TestCase):
         notification_manager = MagicMock()
         notification_manager.add_simple = AsyncMock()
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(notification_manager=notification_manager),
             op="notify", target="notifications",
             agent="alice", level="info", summary="task done",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
         self.assertTrue(parsed["ok"])
@@ -280,12 +280,12 @@ class TestNotify(unittest.TestCase):
         notification_manager = MagicMock()
         notification_manager.add_simple = AsyncMock()
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(notification_manager=notification_manager),
             op="POST", definer="SEND", target="notifications",
             agent="alice", level="warning", summary="watch out",
             context="x failed", action_hint="restart",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         notification_manager.add_simple.assert_awaited_once_with(
             agent="alice", level="warning", summary="watch out",
@@ -293,11 +293,11 @@ class TestNotify(unittest.TestCase):
         )
 
     def test_notify_missing_level_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="notify", target="notifications",
             agent="alice", summary="x",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("level", parsed["error"]["message"].lower())
 
@@ -320,10 +320,10 @@ class TestGetNotifications(unittest.TestCase):
             ),
         ])
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(notification_manager=notification_manager),
             op="GET", target="notifications", agent="alice",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 1)
@@ -336,11 +336,11 @@ class TestGetNotifications(unittest.TestCase):
         notification_manager = MagicMock()
         notification_manager.get = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(notification_manager=notification_manager),
             op="GET", target="notifications",
             level="error", limit=5,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         call_kwargs = notification_manager.get.await_args.kwargs
         self.assertEqual(call_kwargs["level"], "error")
@@ -377,14 +377,14 @@ class TestGetStatusSummary(unittest.TestCase):
         lock_manager = MagicMock()
         lock_manager.get_locks_by_agent.return_value = []
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(
                 notification_manager=notification_manager,
                 agent_registry=agent_registry,
                 lock_manager=lock_manager,
             ),
             op="GET", target="status",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         # The data is the formatted string the legacy tool produced.
         self.assertIsInstance(parsed["data"], str)
@@ -400,13 +400,13 @@ class TestGetStatusSummary(unittest.TestCase):
         agent_registry = MagicMock()
         agent_registry.list_agents.return_value = []
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(
                 notification_manager=notification_manager,
                 agent_registry=agent_registry,
             ),
             op="GET", target="status",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"], "━━━ No notifications ━━━")
 
@@ -437,7 +437,7 @@ class TestGetHooks(unittest.TestCase):
                 return mock_legacy.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
         # Legacy tool was called with ManageAgentHooksRequest(operation="get_config").
         request = call_args.args[0]
@@ -466,7 +466,7 @@ class TestGetHooks(unittest.TestCase):
                 return mock_legacy.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
         request = call_args.args[0]
         self.assertEqual(request.operation, "get_stats")
@@ -494,7 +494,7 @@ class TestPatchHooks(unittest.TestCase):
                 return mock_legacy.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
         self.assertTrue(parsed["ok"])
@@ -525,7 +525,7 @@ class TestPatchHooks(unittest.TestCase):
                 return mock_legacy.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
         request = call_args.args[0]
         self.assertEqual(request.operation, "set_variable")
@@ -556,7 +556,7 @@ class TestTriggerHook(unittest.TestCase):
                 return mock_legacy.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
         self.assertTrue(parsed["ok"])
@@ -568,10 +568,10 @@ class TestTriggerHook(unittest.TestCase):
         self.assertEqual(request.agent_name, "alice")
 
     def test_trigger_hook_missing_op_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="POST", definer="TRIGGER", target="hooks",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("hooks_op", parsed["error"]["message"].lower())
 
@@ -599,10 +599,10 @@ class TestGetLocks(unittest.TestCase):
         terminal = MagicMock()
         terminal.get_session_by_id = AsyncMock(return_value=fake_session)
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(terminal=terminal, lock_manager=lock_manager),
             op="GET", target="locks", agent="alice",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["agent"], "alice")
         self.assertEqual(parsed["data"]["lock_count"], 2)
@@ -616,18 +616,18 @@ class TestGetLocks(unittest.TestCase):
         lock_manager.get_locks_by_agent.assert_called_once_with("alice")
 
     def test_get_locks_missing_agent_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="GET", target="locks",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent", parsed["error"]["message"].lower())
 
     def test_get_locks_no_lock_manager_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),  # lock_manager=None
             op="GET", target="locks", agent="alice",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("tag_lock_manager", parsed["error"]["message"])
 
@@ -642,10 +642,10 @@ class TestDeleteAgent(unittest.TestCase):
         agent_registry = MagicMock()
         agent_registry.remove_agent.return_value = True
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="delete", agent_name="alice",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["removed"])
@@ -655,18 +655,18 @@ class TestDeleteAgent(unittest.TestCase):
         agent_registry = MagicMock()
         agent_registry.remove_agent.return_value = False
 
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(agent_registry=agent_registry),
             op="DELETE", agent_name="missing",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["removed"])
 
     def test_delete_missing_agent_name_returns_err(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="delete",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"].lower())
 
@@ -678,17 +678,17 @@ class TestDeleteAgent(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_invoke_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             agents(ctx=_make_ctx(), op="POST", definer="INVOKE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_unknown_target_not_implemented(self):
-        parsed = json.loads(asyncio.run(agents(
+        parsed = asyncio.run(agents(
             ctx=_make_ctx(),
             op="PATCH", target="bogus",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -58,7 +58,7 @@ async def _dispatch(**kwargs):
     import asyncio
     tool = FakeCollection()
     result = await tool.dispatch(ctx=None, **kwargs)
-    return json.loads(result), tool
+    return result, tool
 
 
 def run_async(coro):
@@ -174,7 +174,7 @@ class TestDispatchErrors(unittest.TestCase):
         import asyncio
         tool = Broken()
         result = asyncio.run(tool.dispatch(ctx=None, op="list"))
-        parsed = json.loads(result)
+        parsed = result
         self.assertFalse(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["error"]["message"], "oops")
@@ -187,7 +187,7 @@ class TestDispatchErrors(unittest.TestCase):
         import asyncio
         tool = NoPut()
         result = asyncio.run(tool.dispatch(ctx=None, op="PUT", name="x"))
-        parsed = json.loads(result)
+        parsed = result
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
@@ -211,7 +211,7 @@ class TestStructuredErrorCodes(unittest.TestCase):
         import asyncio
         tool = NoPut()
         result = asyncio.run(tool.dispatch(ctx=None, op="PUT", name="x"))
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["error"]["code"], "not_implemented")
 
     def test_handler_exception_carries_internal_code(self):
@@ -222,7 +222,7 @@ class TestStructuredErrorCodes(unittest.TestCase):
         import asyncio
         tool = Broken()
         result = asyncio.run(tool.dispatch(ctx=None, op="list"))
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["error"]["code"], "internal")
         self.assertEqual(parsed["error"]["message"], "kernel panic")
 
@@ -234,7 +234,7 @@ class TestStructuredErrorCodes(unittest.TestCase):
         import asyncio
         tool = NeedsParam()
         result = asyncio.run(tool.dispatch(ctx=None, op="list"))
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["error"]["code"], "missing_param")
         self.assertIn("required", parsed["error"]["message"])
 

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -24,7 +24,7 @@ class PydanticContainer(BaseModel):
 class TestOkEnvelope(unittest.TestCase):
     def test_basic_shape(self):
         s = ok_envelope(method="GET", data={"count": 3})
-        parsed = json.loads(s)
+        parsed = s
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 3)
@@ -32,51 +32,51 @@ class TestOkEnvelope(unittest.TestCase):
 
     def test_includes_definer_when_present(self):
         s = ok_envelope(method="POST", definer="CREATE", data={"id": "x"})
-        parsed = json.loads(s)
+        parsed = s
         self.assertEqual(parsed["definer"], "CREATE")
 
     def test_omits_definer_when_none(self):
         s = ok_envelope(method="GET", data={"count": 3})
-        parsed = json.loads(s)
+        parsed = s
         self.assertNotIn("definer", parsed)
 
     def test_serializes_pydantic_model(self):
         item = Item(id="a", name="Alpha", description="full")
         s = ok_envelope(method="GET", data=item)
-        parsed = json.loads(s)
+        parsed = s
         self.assertEqual(parsed["data"]["id"], "a")
         self.assertEqual(parsed["data"]["description"], "full")
 
     def test_serializes_list_of_pydantic_models(self):
         items = [Item(id="a", name="Alpha"), Item(id="b", name="Bravo")]
         s = ok_envelope(method="GET", data=items)
-        parsed = json.loads(s)
+        parsed = s
         self.assertEqual(len(parsed["data"]), 2)
         self.assertEqual(parsed["data"][0]["id"], "a")
 
     def test_excludes_none_from_pydantic(self):
         item = Item(id="a", name="Alpha")  # description is None
         s = ok_envelope(method="GET", data=item)
-        parsed = json.loads(s)
+        parsed = s
         self.assertNotIn("description", parsed["data"])
 
 
 class TestErrEnvelope(unittest.TestCase):
     def test_basic_shape(self):
         s = err_envelope(method="POST", error="boom")
-        parsed = json.loads(s)
+        parsed = s
         self.assertFalse(parsed["ok"])
         self.assertEqual(parsed["error"]["message"], "boom")
         self.assertNotIn("data", parsed)
 
     def test_includes_definer_when_present(self):
         s = err_envelope(method="POST", definer="CREATE", error="boom")
-        parsed = json.loads(s)
+        parsed = s
         self.assertEqual(parsed["definer"], "CREATE")
 
     def test_omits_definer_when_none(self):
         s = err_envelope(method="POST", error="boom")
-        parsed = json.loads(s)
+        parsed = s
         self.assertNotIn("definer", parsed)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -91,7 +91,7 @@ class TestErrEnvelopeAcceptsToolError(unittest.TestCase):
             error=ToolError(ErrorCode.INVALID_OP, "Unknown op 'foo'", hint="see OPTIONS"),
             definer="CREATE",
         )
-        parsed = json.loads(env)
+        parsed = env
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertFalse(parsed["ok"])
@@ -105,7 +105,7 @@ class TestErrEnvelopeAcceptsToolError(unittest.TestCase):
         # — the string becomes the `message`, with code=INTERNAL.
         from iterm_mcpy.responses import err_envelope
         env = err_envelope(method="GET", error="something broke")
-        parsed = json.loads(env)
+        parsed = env
         self.assertFalse(parsed["ok"])
         self.assertEqual(parsed["error"]["code"], "internal")
         self.assertEqual(parsed["error"]["message"], "something broke")

--- a/tests/test_feedback_dispatch.py
+++ b/tests/test_feedback_dispatch.py
@@ -118,7 +118,7 @@ def _fake_entry(
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "feedback")
@@ -130,7 +130,7 @@ class TestOptions(unittest.TestCase):
             self.assertIn(sub, parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
         self.assertIn("INVOKE", post["definers"])
@@ -138,19 +138,19 @@ class TestOptions(unittest.TestCase):
         self.assertIn("SEND", post["definers"])
 
     def test_options_lists_patch_modify(self):
-        parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(feedback(ctx=_make_ctx(), op="OPTIONS"))
         patch_schema = parsed["data"]["methods"]["PATCH"]
         self.assertIn("MODIFY", patch_schema["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(feedback(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(feedback(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(feedback(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -158,9 +158,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE belongs to the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             feedback(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -182,10 +182,10 @@ class TestQuery(unittest.TestCase):
             ),
         ]
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="query",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
@@ -205,14 +205,14 @@ class TestQuery(unittest.TestCase):
         registry = MagicMock()
         registry.query.return_value = []
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="GET",
             status="triaged",
             category="bug",
             agent_name="agent1",
             limit=5,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         kwargs = registry.query.call_args.kwargs
         self.assertEqual(kwargs["status"], FeedbackStatus.TRIAGED)
@@ -224,21 +224,21 @@ class TestQuery(unittest.TestCase):
         registry = MagicMock()
         registry.query.return_value = []
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="query",
             status="bogus_status",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertIsNone(registry.query.call_args.kwargs["status"])
 
     def test_query_empty(self):
         registry = MagicMock()
         registry.query.return_value = []
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="query",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
         self.assertEqual(parsed["data"]["entries"], [])
@@ -251,10 +251,10 @@ class TestHead(unittest.TestCase):
         # unchanged — the HEAD envelope still gets ok=true.
         registry = MagicMock()
         registry.query.return_value = []
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -288,7 +288,7 @@ class TestSubmitFeedback(unittest.TestCase):
             "core.feedback.FeedbackCollector.capture_context",
             new=AsyncMock(return_value=_fake_context()),
         ):
-            parsed = json.loads(asyncio.run(feedback(
+            parsed = asyncio.run(feedback(
                 ctx=_make_ctx(
                     feedback_registry=registry,
                     agent_registry=agent_registry,
@@ -297,7 +297,7 @@ class TestSubmitFeedback(unittest.TestCase):
                 title="Something is broken",
                 description="Deep description",
                 category="bug",
-            )))
+            ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
@@ -317,7 +317,7 @@ class TestSubmitFeedback(unittest.TestCase):
             "core.feedback.FeedbackCollector.capture_context",
             new=AsyncMock(return_value=_fake_context()),
         ):
-            parsed = json.loads(asyncio.run(feedback(
+            parsed = asyncio.run(feedback(
                 ctx=_make_ctx(
                     feedback_registry=registry,
                     agent_registry=agent_registry,
@@ -326,26 +326,26 @@ class TestSubmitFeedback(unittest.TestCase):
                 title="T", description="D",
                 agent_name="alice",
                 session_id="s-1",
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "CREATE")
         registry.add.assert_called_once()
 
     def test_submit_missing_title_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="submit",
             description="No title",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("title", parsed["error"]["message"].lower())
 
     def test_submit_missing_description_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="submit",
             title="Only title",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("description", parsed["error"]["message"].lower())
 
@@ -367,12 +367,12 @@ class TestCheckTriggers(unittest.TestCase):
         }
         hook_manager.record_error.return_value = FeedbackTriggerType.ERROR_THRESHOLD
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="invoke", target="triggers",
             agent_name="a1", session_id="s1",
             error_message="Something failed",
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "INVOKE")
@@ -395,12 +395,12 @@ class TestCheckTriggers(unittest.TestCase):
         hook_manager.record_error.return_value = None
         hook_manager.check_pattern.return_value = None
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="POST", definer="INVOKE", target="triggers",
             agent_name="a1", session_id="s1",
             tool_call_name="some_tool",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         triggers = parsed["data"]["triggers_fired"]
         self.assertEqual(len(triggers), 1)
@@ -416,12 +416,12 @@ class TestCheckTriggers(unittest.TestCase):
         }
         hook_manager.check_pattern.return_value = FeedbackTriggerType.PATTERN_DETECTED
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="invoke", target="triggers",
             agent_name="a1", session_id="s1",
             output_text="it would be better if...",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["triggers_fired"][0]["trigger"], "pattern")
 
@@ -433,30 +433,30 @@ class TestCheckTriggers(unittest.TestCase):
             "has_pending_trigger": False, "pending_trigger_type": None,
         }
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="invoke", target="triggers",
             agent_name="a1", session_id="s1",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["should_collect_feedback"])
         self.assertEqual(parsed["data"]["triggers_fired"], [])
 
     def test_missing_agent_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="invoke", target="triggers",
             session_id="s1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"].lower())
 
     def test_missing_session_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="invoke", target="triggers",
             agent_name="a1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("session_id", parsed["error"]["message"].lower())
 
@@ -479,14 +479,14 @@ class TestFork(unittest.TestCase):
         agent_obj.name = "alice"
         agent_registry.get_agent_by_session.return_value = agent_obj
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(
                 feedback_forker=forker,
                 agent_registry=agent_registry,
             ),
             op="fork", target="worktrees",
             feedback_id="fb-1", session_id="s-1",
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
@@ -502,29 +502,29 @@ class TestFork(unittest.TestCase):
         forker.create_worktree = AsyncMock(return_value="/tmp/ws/fb-1")
         forker.get_fork_command.return_value = "claude --fork"
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_forker=forker),
             op="POST", definer="TRIGGER", target="worktrees",
             feedback_id="fb-1", session_id="s-1",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "TRIGGER")
 
     def test_fork_missing_feedback_id_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="fork", target="worktrees",
             session_id="s-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
     def test_fork_missing_session_id_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="fork", target="worktrees",
             feedback_id="fb-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("session_id", parsed["error"]["message"].lower())
 
@@ -545,7 +545,7 @@ class TestTriageToGithub(unittest.TestCase):
             return_value="https://github.com/owner/repo/issues/42"
         )
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(
                 feedback_registry=registry,
                 github_integration=gh,
@@ -554,7 +554,7 @@ class TestTriageToGithub(unittest.TestCase):
             feedback_id="fb-1",
             labels=["p1", "urgent"],
             assignee="maintainer",
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
@@ -583,11 +583,11 @@ class TestTriageToGithub(unittest.TestCase):
         registry = MagicMock()
         registry.get.return_value = None
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="triage", target="issues",
             feedback_id="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
@@ -598,22 +598,22 @@ class TestTriageToGithub(unittest.TestCase):
         gh = MagicMock()
         gh.create_issue = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(
                 feedback_registry=registry,
                 github_integration=gh,
             ),
             op="triage", target="issues",
             feedback_id="fb-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Failed to create GitHub issue", parsed["error"]["message"])
 
     def test_triage_missing_feedback_id_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="triage", target="issues",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
@@ -635,14 +635,14 @@ class TestNotifyUpdate(unittest.TestCase):
         )
         registry.update.return_value = updated
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="notify", target="notifications",
             feedback_id="fb-1",
             update_type="ready_for_testing",
             message="PR is ready",
             pr_url="https://github.com/owner/repo/pull/7",
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
@@ -670,13 +670,13 @@ class TestNotifyUpdate(unittest.TestCase):
             id_="fb-1", agent_name="alice", status_value="resolved"
         )
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="POST", definer="SEND", target="notifications",
             feedback_id="fb-1",
             update_type="resolved",
             message="All done",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["new_status"], "resolved")
 
@@ -684,43 +684,43 @@ class TestNotifyUpdate(unittest.TestCase):
         registry = MagicMock()
         registry.get.return_value = None
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_registry=registry),
             op="notify", target="notifications",
             feedback_id="missing",
             update_type="acknowledged",
             message="hi",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_notify_missing_feedback_id_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="notify", target="notifications",
             update_type="resolved",
             message="done",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("feedback_id", parsed["error"]["message"].lower())
 
     def test_notify_missing_update_type_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="notify", target="notifications",
             feedback_id="fb-1",
             message="done",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("update_type", parsed["error"]["message"].lower())
 
     def test_notify_missing_message_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="notify", target="notifications",
             feedback_id="fb-1",
             update_type="resolved",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("message", parsed["error"]["message"].lower())
 
@@ -741,10 +741,10 @@ class TestGetConfig(unittest.TestCase):
             github_labels=["agent-feedback"],
         )
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="GET", target="config",
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
@@ -758,10 +758,10 @@ class TestGetConfig(unittest.TestCase):
     def test_get_config_via_get_verb(self):
         hook_manager = MagicMock()
         hook_manager.config = _fake_config()
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="get", target="config",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
 
@@ -776,11 +776,11 @@ class TestUpdateConfig(unittest.TestCase):
         hook_manager = MagicMock()
         hook_manager.config = _fake_config(error_threshold_count=3)
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="update", target="config",
             error_threshold_count=7,
-        )))
+        ))
 
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
@@ -793,11 +793,11 @@ class TestUpdateConfig(unittest.TestCase):
         hook_manager = MagicMock()
         hook_manager.config = _fake_config(periodic_count=100)
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="PATCH", definer="MODIFY", target="config",
             periodic_tool_call_count=250,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["periodic"]["tool_call_count"], 250)
 
@@ -805,11 +805,11 @@ class TestUpdateConfig(unittest.TestCase):
         hook_manager = MagicMock()
         hook_manager.config = _fake_config(patterns=["existing"])
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="update", target="config",
             add_pattern="new_pattern",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertIn("new_pattern", parsed["data"]["pattern"]["patterns"])
         self.assertIn("existing", parsed["data"]["pattern"]["patterns"])
@@ -818,20 +818,20 @@ class TestUpdateConfig(unittest.TestCase):
         hook_manager = MagicMock()
         hook_manager.config = _fake_config(patterns=["keep", "drop"])
 
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(feedback_hook_manager=hook_manager),
             op="update", target="config",
             remove_pattern="drop",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertIn("keep", parsed["data"]["pattern"]["patterns"])
         self.assertNotIn("drop", parsed["data"]["pattern"]["patterns"])
 
     def test_update_unknown_target_returns_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="update", target="bogus",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
@@ -843,11 +843,11 @@ class TestUpdateConfig(unittest.TestCase):
 
 class TestDeleteNotImplemented(unittest.TestCase):
     def test_delete_returns_not_implemented_err(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="DELETE",
             feedback_id="fb-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         # The dispatcher's default on_delete raises NotImplementedError,
         # which the dispatcher converts into an err envelope.
@@ -861,29 +861,29 @@ class TestDeleteNotImplemented(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_invoke_wrong_target(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="POST", definer="INVOKE", target="bogus",
             agent_name="a1", session_id="s1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_trigger_wrong_target(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="POST", definer="TRIGGER", target="bogus",
             feedback_id="fb-1", session_id="s1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_send_wrong_target(self):
-        parsed = json.loads(asyncio.run(feedback(
+        parsed = asyncio.run(feedback(
             ctx=_make_ctx(),
             op="POST", definer="SEND", target="bogus",
             feedback_id="fb-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -70,7 +70,7 @@ def _fake_manager(
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(managers(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(managers(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "managers")
@@ -81,19 +81,19 @@ class TestOptions(unittest.TestCase):
         self.assertIn("workers", parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(managers(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(managers(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(managers(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(managers(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(managers(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(managers(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -101,9 +101,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE is in the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             managers(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -129,10 +129,10 @@ class TestList(unittest.TestCase):
             ),
         ]
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="list",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
@@ -148,10 +148,10 @@ class TestList(unittest.TestCase):
     def test_list_empty(self):
         registry = MagicMock()
         registry.list_managers.return_value = []
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="list",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
         self.assertEqual(parsed["data"]["managers"], [])
@@ -159,10 +159,10 @@ class TestList(unittest.TestCase):
     def test_list_via_get_verb(self):
         registry = MagicMock()
         registry.list_managers.return_value = []
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="GET",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
 
@@ -174,10 +174,10 @@ class TestHead(unittest.TestCase):
         # HEAD envelope still gets ok=true with the dict data.
         registry = MagicMock()
         registry.list_managers.return_value = []
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -198,11 +198,11 @@ class TestGetInfo(unittest.TestCase):
             metadata={"team": "backend"},
         )
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="GET",
             manager_name="m1",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         data = parsed["data"]
@@ -217,11 +217,11 @@ class TestGetInfo(unittest.TestCase):
     def test_get_info_not_found_returns_err(self):
         registry = MagicMock()
         registry.get_manager.return_value = None
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="GET",
             manager_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
@@ -230,11 +230,11 @@ class TestGetInfo(unittest.TestCase):
         # without manager_name it lists.
         registry = MagicMock()
         registry.get_manager.return_value = _fake_manager(name="m1")
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="get",
             manager_name="m1",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["data"]["name"], "m1")
@@ -257,12 +257,12 @@ class TestCreateManager(unittest.TestCase):
 
         # Patch _setup_manager_callbacks to isolate from real callback wiring.
         with patch("iterm_mcpy.tools._callbacks._setup_manager_callbacks") as mock_setup:
-            parsed = json.loads(asyncio.run(managers(
+            parsed = asyncio.run(managers(
                 ctx=_make_ctx(manager_registry=registry),
                 op="create",
                 manager_name="m1",
                 workers=["w1", "w2"],
-            )))
+            ))
 
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
@@ -281,20 +281,20 @@ class TestCreateManager(unittest.TestCase):
             name="m1", workers=[], strategy_value="role_based"
         )
         with patch("iterm_mcpy.tools._callbacks._setup_manager_callbacks"):
-            parsed = json.loads(asyncio.run(managers(
+            parsed = asyncio.run(managers(
                 ctx=_make_ctx(manager_registry=registry),
                 op="POST",
                 definer="CREATE",
                 manager_name="m1",
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "CREATE")
 
     def test_create_manager_missing_name_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="create",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("manager_name", parsed["error"]["message"].lower())
 
@@ -306,7 +306,7 @@ class TestCreateManager(unittest.TestCase):
             strategy_value="round_robin",
         )
         with patch("iterm_mcpy.tools._callbacks._setup_manager_callbacks"):
-            parsed = json.loads(asyncio.run(managers(
+            parsed = asyncio.run(managers(
                 ctx=_make_ctx(manager_registry=registry),
                 op="create",
                 manager_name="m1",
@@ -314,7 +314,7 @@ class TestCreateManager(unittest.TestCase):
                 delegation_strategy="round_robin",
                 worker_roles={"builder-1": "builder", "tester-1": "tester"},
                 metadata={"team": "backend"},
-            )))
+            ))
         self.assertTrue(parsed["ok"])
         # Verify create_manager was called with enum-converted values.
         kwargs = registry.create_manager.call_args.kwargs
@@ -342,11 +342,11 @@ class TestAddWorker(unittest.TestCase):
         manager_mock = _fake_manager(name="m1")
         registry.get_manager.return_value = manager_mock
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="POST", definer="CREATE", target="workers",
             manager_name="m1", worker_name="w1",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -360,12 +360,12 @@ class TestAddWorker(unittest.TestCase):
         manager_mock = _fake_manager(name="m1")
         registry.get_manager.return_value = manager_mock
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="create", target="workers",
             manager_name="m1", worker_name="w1",
             worker_role="builder",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["role"], "builder")
         from core.manager import SessionRole
@@ -374,27 +374,27 @@ class TestAddWorker(unittest.TestCase):
     def test_add_worker_manager_not_found_returns_err(self):
         registry = MagicMock()
         registry.get_manager.return_value = None
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="create", target="workers",
             manager_name="missing", worker_name="w1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_add_worker_missing_manager_name_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="create", target="workers", worker_name="w1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_add_worker_missing_worker_name_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="create", target="workers", manager_name="m1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("worker_name", parsed["error"]["message"].lower())
 
@@ -409,11 +409,11 @@ class TestRemoveManager(unittest.TestCase):
         registry = MagicMock()
         registry.remove_manager.return_value = True
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="delete",
             manager_name="m1",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["removed"])
@@ -423,30 +423,30 @@ class TestRemoveManager(unittest.TestCase):
     def test_remove_manager_not_found_returns_err(self):
         registry = MagicMock()
         registry.remove_manager.return_value = False
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="delete",
             manager_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_manager_missing_name_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="delete",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_remove_manager_via_delete_method(self):
         registry = MagicMock()
         registry.remove_manager.return_value = True
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="DELETE",
             manager_name="m1",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
 
 
@@ -462,11 +462,11 @@ class TestRemoveWorker(unittest.TestCase):
         manager_mock.remove_worker.return_value = True
         registry.get_manager.return_value = manager_mock
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="delete", target="workers",
             manager_name="m1", worker_name="w1",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["removed"])
@@ -480,38 +480,38 @@ class TestRemoveWorker(unittest.TestCase):
         manager_mock.remove_worker.return_value = False
         registry.get_manager.return_value = manager_mock
 
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="delete", target="workers",
             manager_name="m1", worker_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_worker_manager_not_found_returns_err(self):
         registry = MagicMock()
         registry.get_manager.return_value = None
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(manager_registry=registry),
             op="delete", target="workers",
             manager_name="missing", worker_name="w1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_worker_missing_manager_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="DELETE", target="workers", worker_name="w1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("manager_name", parsed["error"]["message"].lower())
 
     def test_remove_worker_missing_worker_returns_err(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="DELETE", target="workers", manager_name="m1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("worker_name", parsed["error"]["message"].lower())
 
@@ -523,17 +523,17 @@ class TestRemoveWorker(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_send_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             managers(ctx=_make_ctx(), op="POST", definer="SEND")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_delete_unknown_target_not_implemented(self):
-        parsed = json.loads(asyncio.run(managers(
+        parsed = asyncio.run(managers(
             ctx=_make_ctx(),
             op="DELETE", target="bogus",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 

--- a/tests/test_memory_dispatch.py
+++ b/tests/test_memory_dispatch.py
@@ -84,7 +84,7 @@ def _fake_search_result(
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(memory(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(memory(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "memory")
@@ -95,19 +95,19 @@ class TestOptions(unittest.TestCase):
             self.assertIn(sub, parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(memory(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(memory(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(memory(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(memory(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(memory(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(memory(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -115,9 +115,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE belongs to the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             memory(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -132,14 +132,14 @@ class TestStore(unittest.TestCase):
         store = MagicMock()
         store.store = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="store",
             namespace=["proj", "agent"],
             key="mykey",
             value={"foo": "bar"},
             metadata={"tag": "test"},
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -157,57 +157,57 @@ class TestStore(unittest.TestCase):
         store = MagicMock()
         store.store = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="POST", definer="CREATE",
             namespace=["ns"], key="k", value="v",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertEqual(parsed["data"]["metadata"], {})
 
     def test_store_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="store",
             key="k", value="v",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_store_missing_key_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="store",
             namespace=["ns"], value="v",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("key", parsed["error"]["message"].lower())
 
     def test_store_missing_value_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="store",
             namespace=["ns"], key="k",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("value", parsed["error"]["message"].lower())
 
     def test_store_invalid_namespace_char_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="store",
             namespace=["bad ns"], key="k", value="v",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("invalid", parsed["error"]["message"].lower())
 
     def test_store_invalid_key_char_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="store",
             namespace=["ns"], key="bad key!", value="v",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("invalid", parsed["error"]["message"].lower())
 
@@ -227,11 +227,11 @@ class TestRetrieve(unittest.TestCase):
             metadata={"tag": "test"},
         ))
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="retrieve",
             namespace=["proj", "agent"], key="mykey",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["found"])
@@ -245,31 +245,31 @@ class TestRetrieve(unittest.TestCase):
         store = MagicMock()
         store.retrieve = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET",
             namespace=["proj"], key="missing",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["found"])
         self.assertEqual(parsed["data"]["namespace"], ["proj"])
         self.assertEqual(parsed["data"]["key"], "missing")
 
     def test_retrieve_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="retrieve",
             key="k",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_retrieve_missing_key_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="retrieve",
             namespace=["ns"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("key", parsed["error"]["message"].lower())
 
@@ -281,11 +281,11 @@ class TestHead(unittest.TestCase):
         store = MagicMock()
         store.retrieve = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="HEAD",
             namespace=["ns"], key="k",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -311,11 +311,11 @@ class TestSearch(unittest.TestCase):
             ),
         ])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET", target="search",
             namespace=["proj", "agent"], query="hello", limit=5,
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["query"], "hello")
@@ -330,31 +330,31 @@ class TestSearch(unittest.TestCase):
         store = MagicMock()
         store.search = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="search", target="search",
             namespace=["proj"], query="foo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
         # limit defaults to 10 in the tool wrapper
         store.search.assert_awaited_once_with(("proj",), "foo", 10)
 
     def test_search_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="GET", target="search",
             query="foo",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_search_missing_query_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="GET", target="search",
             namespace=["ns"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("query", parsed["error"]["message"].lower())
 
@@ -369,11 +369,11 @@ class TestListKeys(unittest.TestCase):
         store = MagicMock()
         store.list_keys = AsyncMock(return_value=["a", "b", "c"])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET", target="keys",
             namespace=["proj"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 3)
         self.assertEqual(parsed["data"]["keys"], ["a", "b", "c"])
@@ -384,19 +384,19 @@ class TestListKeys(unittest.TestCase):
         store = MagicMock()
         store.list_keys = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="list", target="keys",
             namespace=["empty"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
 
     def test_list_keys_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="GET", target="keys",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
@@ -414,10 +414,10 @@ class TestListNamespaces(unittest.TestCase):
             ("other",),
         ])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET", target="namespaces",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
         self.assertIn(["proj", "agent"], parsed["data"]["namespaces"])
@@ -429,11 +429,11 @@ class TestListNamespaces(unittest.TestCase):
         store = MagicMock()
         store.list_namespaces = AsyncMock(return_value=[("proj", "agent")])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET", target="namespaces",
             namespace=["proj"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["prefix"], ["proj"])
         store.list_namespaces.assert_awaited_once_with(("proj",))
@@ -454,10 +454,10 @@ class TestStats(unittest.TestCase):
             "db_path": "/tmp/memories.db",
         })
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="GET", target="stats",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_memories"], 42)
         self.assertEqual(parsed["data"]["total_namespaces"], 5)
@@ -474,11 +474,11 @@ class TestDeleteKey(unittest.TestCase):
         store = MagicMock()
         store.delete = AsyncMock(return_value=True)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="delete",
             namespace=["proj"], key="mykey",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["deleted"])
@@ -491,30 +491,30 @@ class TestDeleteKey(unittest.TestCase):
         store = MagicMock()
         store.delete = AsyncMock(return_value=False)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="DELETE",
             namespace=["proj"], key="missing",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["deleted"])
         self.assertEqual(parsed["data"]["message"], "Memory not found")
 
     def test_delete_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="delete",
             key="mykey",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
     def test_delete_missing_key_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="delete",
             namespace=["proj"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("key", parsed["error"]["message"].lower())
 
@@ -529,11 +529,11 @@ class TestClearNamespace(unittest.TestCase):
         store = MagicMock()
         store.clear_namespace = AsyncMock(return_value=7)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="DELETE", target="namespace",
             namespace=["proj", "old"], confirm=True,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["cleared"])
         self.assertEqual(parsed["data"]["namespace"], ["proj", "old"])
@@ -544,11 +544,11 @@ class TestClearNamespace(unittest.TestCase):
         store = MagicMock()
         store.clear_namespace = AsyncMock(return_value=3)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="clear", target="namespace",
             namespace=["proj"], confirm=True,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["deleted_count"], 3)
 
@@ -556,11 +556,11 @@ class TestClearNamespace(unittest.TestCase):
         store = MagicMock()
         store.clear_namespace = AsyncMock(return_value=0)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="DELETE", target="namespace",
             namespace=["proj"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("confirm", parsed["error"]["message"].lower())
         # Critical: clear_namespace must NOT have been called.
@@ -570,21 +570,21 @@ class TestClearNamespace(unittest.TestCase):
         store = MagicMock()
         store.clear_namespace = AsyncMock(return_value=0)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="DELETE", target="namespace",
             namespace=["proj"], confirm=False,
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("confirm", parsed["error"]["message"].lower())
         store.clear_namespace.assert_not_awaited()
 
     def test_clear_missing_namespace_returns_err(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="DELETE", target="namespace",
             confirm=True,
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("namespace", parsed["error"]["message"].lower())
 
@@ -596,34 +596,34 @@ class TestClearNamespace(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_invoke_not_implemented(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="POST", definer="INVOKE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_send_not_implemented(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="POST", definer="SEND",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_put_not_implemented(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="PUT", definer="REPLACE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(),
             op="PATCH", definer="MODIFY",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
@@ -640,11 +640,11 @@ class TestLegacyOpInterop(unittest.TestCase):
         store = MagicMock()
         store.list_keys = AsyncMock(return_value=["a", "b"])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="list_keys",
             namespace=["proj"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["data"]["count"], 2)
@@ -653,10 +653,10 @@ class TestLegacyOpInterop(unittest.TestCase):
         store = MagicMock()
         store.list_namespaces = AsyncMock(return_value=[("proj",)])
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="list_namespaces",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["data"]["count"], 1)
@@ -665,10 +665,10 @@ class TestLegacyOpInterop(unittest.TestCase):
         store = MagicMock()
         store.get_stats = AsyncMock(return_value={"total_memories": 0})
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="stats",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["data"]["total_memories"], 0)
@@ -679,11 +679,11 @@ class TestLegacyOpInterop(unittest.TestCase):
         store = MagicMock()
         store.store = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="store",
             namespace=["ns"], key="k", value="v",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
@@ -693,20 +693,20 @@ class TestLegacyOpInterop(unittest.TestCase):
         store.clear_namespace = AsyncMock(return_value=0)
 
         # No confirm -> err, no side effect.
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="clear",
             namespace=["proj"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         store.clear_namespace.assert_not_awaited()
 
         # With confirm -> cleared.
-        parsed = json.loads(asyncio.run(memory(
+        parsed = asyncio.run(memory(
             ctx=_make_ctx(memory_store=store),
             op="clear",
             namespace=["proj"], confirm=True,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "DELETE")
 

--- a/tests/test_roles_dispatch.py
+++ b/tests/test_roles_dispatch.py
@@ -47,7 +47,7 @@ def _make_assignment(role_value="devops"):
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "roles")
@@ -62,7 +62,7 @@ class TestOptions(unittest.TestCase):
         self.assertIn("permissions", parsed["data"]["sub_resources"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
@@ -75,7 +75,7 @@ class TestOptions(unittest.TestCase):
 class TestListAvailable(unittest.TestCase):
     def test_list_returns_role_catalog(self):
         # Uses real DEFAULT_ROLE_CONFIGS / SessionRole — no mocking needed.
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="list")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="list"))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
 
@@ -92,7 +92,7 @@ class TestListAvailable(unittest.TestCase):
         self.assertIn("custom", role_names)
 
     def test_list_includes_config_fields(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="list")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="list"))
         self.assertTrue(parsed["ok"])
 
         devops = next(r for r in parsed["data"]["roles"] if r["role"] == "devops")
@@ -109,7 +109,7 @@ class TestListAvailable(unittest.TestCase):
         self.assertTrue(orch["can_spawn_agents"])
 
     def test_list_via_get(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="GET")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="GET"))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertGreater(parsed["data"]["count"], 0)
@@ -119,7 +119,7 @@ class TestListAvailable(unittest.TestCase):
         # Verify it works even with an empty lifespan context.
         ctx = MagicMock()
         ctx.request_context.lifespan_context = {}
-        parsed = json.loads(asyncio.run(roles(ctx=ctx, op="list")))
+        parsed = asyncio.run(roles(ctx=ctx, op="list"))
         self.assertTrue(parsed["ok"])
         self.assertGreater(parsed["data"]["count"], 0)
 
@@ -135,11 +135,11 @@ class TestCheckPermission(unittest.TestCase):
         rm.is_tool_allowed.return_value = (True, None)
         rm.get_role.return_value = _make_assignment(role_value="builder")
 
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(role_manager=rm),
             op="GET", target="permissions",
             session_id="s-1", tool_name="npm",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["session_id"], "s-1")
@@ -158,11 +158,11 @@ class TestCheckPermission(unittest.TestCase):
         )
         rm.get_role.return_value = _make_assignment(role_value="researcher")
 
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(role_manager=rm),
             op="GET", target="permissions",
             session_id="s-2", tool_name="rm",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["allowed"])
         self.assertIn("restricted", parsed["data"]["reason"])
@@ -175,11 +175,11 @@ class TestCheckPermission(unittest.TestCase):
         rm.is_tool_allowed.return_value = (True, None)
         rm.get_role.return_value = None
 
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(role_manager=rm),
             op="GET", target="permissions",
             session_id="s-3", tool_name="ls",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["allowed"])
         self.assertFalse(parsed["data"]["has_role"])
@@ -190,41 +190,41 @@ class TestCheckPermission(unittest.TestCase):
         rm.is_tool_allowed.return_value = (True, None)
         rm.get_role.return_value = None
 
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(role_manager=rm),
             op="check", target="permissions",
             session_id="s-1", tool_name="git",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["allowed"])
 
     def test_check_missing_session_id_returns_err(self):
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(),
             op="GET", target="permissions",
             tool_name="npm",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("session_id", parsed["error"]["message"].lower())
 
     def test_check_missing_tool_name_returns_err(self):
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=_make_ctx(),
             op="GET", target="permissions",
             session_id="s-1",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("tool_name", parsed["error"]["message"].lower())
 
     def test_check_missing_role_manager_returns_err(self):
         ctx = MagicMock()
         ctx.request_context.lifespan_context = {}
-        parsed = json.loads(asyncio.run(roles(
+        parsed = asyncio.run(roles(
             ctx=ctx,
             op="GET", target="permissions",
             session_id="s-1", tool_name="npm",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("role_manager", parsed["error"]["message"])
 
@@ -236,7 +236,7 @@ class TestCheckPermission(unittest.TestCase):
 
 class TestHead(unittest.TestCase):
     def test_head_returns_compact_envelope(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="HEAD")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="HEAD"))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -248,7 +248,7 @@ class TestHead(unittest.TestCase):
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(roles(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(roles(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -257,23 +257,23 @@ class TestUnsupportedMethods(unittest.TestCase):
     """Roles is read-only — POST/PATCH/PUT/DELETE must not be implemented."""
 
     def test_post_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             roles(ctx=_make_ctx(), op="POST", definer="CREATE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             roles(ctx=_make_ctx(), op="PATCH", definer="MODIFY")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_delete_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             roles(ctx=_make_ctx(), op="DELETE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 

--- a/tests/test_services_dispatch.py
+++ b/tests/test_services_dispatch.py
@@ -76,7 +76,7 @@ def _fake_registry(services=None):
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(services(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "services")
@@ -88,25 +88,25 @@ class TestOptions(unittest.TestCase):
         self.assertIn("inactive", parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(services(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
         self.assertIn("TRIGGER", post["definers"])
 
     def test_options_lists_patch_definers(self):
-        parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(services(ctx=_make_ctx(), op="OPTIONS"))
         patch_meta = parsed["data"]["methods"]["PATCH"]
         self.assertIn("MODIFY", patch_meta["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(services(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(services(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(services(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -114,9 +114,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE belongs to the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             services(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -136,10 +136,10 @@ class TestList(unittest.TestCase):
         ])
         sm.check_service_running = AsyncMock(return_value=False)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
@@ -161,11 +161,11 @@ class TestList(unittest.TestCase):
         ]
         sm.check_service_running = AsyncMock(return_value=True)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 1)
         self.assertEqual(parsed["data"]["services"][0]["name"], "db")
@@ -180,11 +180,11 @@ class TestList(unittest.TestCase):
         ])
         sm.check_service_running = AsyncMock(return_value=False)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list",
             include_status=False,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         # is_running field should NOT be present when include_status=False.
         self.assertNotIn("is_running", parsed["data"]["services"][0])
@@ -215,11 +215,11 @@ class TestList(unittest.TestCase):
         ])
         sm.check_service_running = AsyncMock(return_value=False)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list",
             min_priority="preferred",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         # Only 'api' (required) should pass the preferred+ filter.
         self.assertEqual(parsed["data"]["count"], 1)
@@ -229,10 +229,10 @@ class TestList(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
         self.assertEqual(parsed["data"]["services"], [])
@@ -243,10 +243,10 @@ class TestHead(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -264,11 +264,11 @@ class TestListInactive(unittest.TestCase):
             _fake_service(name="cache", priority_value="preferred", command="redis"),
         ])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="GET", target="inactive",
             repo_path="/repo",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
@@ -282,20 +282,20 @@ class TestListInactive(unittest.TestCase):
         sm = MagicMock()
         sm.get_inactive_services = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list_inactive",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
         self.assertEqual(parsed["data"]["count"], 0)
 
     def test_list_inactive_missing_repo_path_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="GET", target="inactive",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("repo_path", parsed["error"]["message"].lower())
 
@@ -305,12 +305,12 @@ class TestListInactive(unittest.TestCase):
         sm = MagicMock()
         sm.get_inactive_services = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list_inactive",
             repo_path="/repo",
             min_priority="preferred",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         # min_priority should have been converted to ServicePriority and passed through.
         args, kwargs = sm.get_inactive_services.call_args
@@ -329,14 +329,14 @@ class TestAdd(unittest.TestCase):
         registry = _fake_registry(services=[])
         sm.load_global_config.return_value = registry
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="add",
             service_name="api",
             command="uvicorn api:app",
             priority="required",
             port=8000,
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -353,12 +353,12 @@ class TestAdd(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="POST", definer="CREATE",
             service_name="api",
             command="uvicorn api:app",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "CREATE")
         # priority defaults to 'optional' when unspecified.
@@ -369,14 +369,14 @@ class TestAdd(unittest.TestCase):
         registry = _fake_registry(services=[])
         sm.load_repo_config.return_value = registry
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="add",
             service_name="db",
             command="postgres",
             scope="repo",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["scope"], "repo")
         sm.save_repo_config.assert_called_once_with("/repo", registry)
@@ -392,12 +392,12 @@ class TestAdd(unittest.TestCase):
         registry = _fake_registry(services=[existing])
         sm.load_global_config.return_value = registry
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="add",
             service_name="api",
             command="new-cmd",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         # Replacement should leave exactly one entry with the new command.
         self.assertEqual(len(registry.services), 1)
@@ -405,31 +405,31 @@ class TestAdd(unittest.TestCase):
         self.assertEqual(registry.services[0].command, "new-cmd")
 
     def test_add_missing_service_name_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="add",
             command="run",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("service_name", parsed["error"]["message"].lower())
 
     def test_add_missing_command_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="add",
             service_name="api",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("command", parsed["error"]["message"].lower())
 
     def test_add_repo_scope_without_repo_path_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="add",
             service_name="api",
             command="run",
             scope="repo",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("repo_path", parsed["error"]["message"].lower())
 
@@ -448,11 +448,11 @@ class TestStart(unittest.TestCase):
             is_running=True, session_id="s-1",
         ))
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="start",
             service_name="api",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
         self.assertTrue(parsed["ok"])
@@ -467,11 +467,11 @@ class TestStart(unittest.TestCase):
         sm.load_global_config.return_value = _fake_registry(services=[svc])
         sm.start_service = AsyncMock(return_value=_fake_service_state())
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="POST", definer="TRIGGER",
             service_name="api",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "TRIGGER")
 
@@ -481,12 +481,12 @@ class TestStart(unittest.TestCase):
         sm.get_merged_services.return_value = [svc]
         sm.start_service = AsyncMock(return_value=_fake_service_state())
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="start",
             service_name="db",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         sm.get_merged_services.assert_called_once_with("/repo")
         sm.load_global_config.assert_not_called()
@@ -497,11 +497,11 @@ class TestStart(unittest.TestCase):
             _fake_service(name="other"),
         ])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="start",
             service_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
         # The error should include the available services.
@@ -515,11 +515,11 @@ class TestStart(unittest.TestCase):
             is_running=False, session_id=None, error_message="port in use",
         ))
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="start",
             service_name="api",
-        )))
+        ))
         # Envelope is ok=true (handler completed); the data payload reports
         # started=false and the error_message. This mirrors legacy behavior.
         self.assertTrue(parsed["ok"])
@@ -527,10 +527,10 @@ class TestStart(unittest.TestCase):
         self.assertEqual(parsed["data"]["error"], "port in use")
 
     def test_start_missing_service_name_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="start",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("service_name", parsed["error"]["message"].lower())
 
@@ -551,14 +551,14 @@ class TestConfigure(unittest.TestCase):
         registry = _fake_registry(services=[existing])
         sm.load_global_config.return_value = registry
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="configure",
             service_name="api",
             priority="required",
             port=8080,
             command="new-cmd",
-        )))
+        ))
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
         self.assertTrue(parsed["ok"])
@@ -581,12 +581,12 @@ class TestConfigure(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[existing])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="PATCH", definer="MODIFY",
             service_name="api",
             priority="preferred",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "MODIFY")
 
@@ -598,14 +598,14 @@ class TestConfigure(unittest.TestCase):
         registry = _fake_registry(services=[existing])
         sm.load_repo_config.return_value = registry
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="configure",
             service_name="db",
             command="postgres --new-flag",
             scope="repo",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["scope"], "repo")
         sm.save_repo_config.assert_called_once_with("/repo", registry)
@@ -615,33 +615,33 @@ class TestConfigure(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="configure",
             service_name="missing",
             priority="required",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
         # Must not have saved anything.
         sm.save_global_config.assert_not_called()
 
     def test_configure_missing_service_name_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="configure",
             priority="required",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("service_name", parsed["error"]["message"].lower())
 
     def test_configure_repo_scope_without_repo_path_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="configure",
             service_name="api",
             scope="repo",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("repo_path", parsed["error"]["message"].lower())
 
@@ -656,11 +656,11 @@ class TestStop(unittest.TestCase):
         sm = MagicMock()
         sm.stop_service = AsyncMock(return_value=True)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="stop",
             service_name="api",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["service"], "api")
@@ -671,11 +671,11 @@ class TestStop(unittest.TestCase):
         sm = MagicMock()
         sm.stop_service = AsyncMock(return_value=True)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="DELETE",
             service_name="api",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["stopped"])
 
@@ -683,20 +683,20 @@ class TestStop(unittest.TestCase):
         sm = MagicMock()
         sm.stop_service = AsyncMock(return_value=False)
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="stop",
             service_name="api",
-        )))
+        ))
         # Envelope is ok=true (handler completed); data reports stopped=false.
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["stopped"])
 
     def test_stop_missing_service_name_returns_err(self):
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(),
             op="stop",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("service_name", parsed["error"]["message"].lower())
 
@@ -708,30 +708,30 @@ class TestStop(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_send_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             services(ctx=_make_ctx(), op="POST", definer="SEND")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_post_invoke_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             services(ctx=_make_ctx(), op="POST", definer="INVOKE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_patch_rename_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             services(ctx=_make_ctx(), op="PATCH", definer="RENAME")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_put_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             services(ctx=_make_ctx(), op="PUT", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
@@ -751,12 +751,12 @@ class TestLegacyOpInterop(unittest.TestCase):
         sm = MagicMock()
         sm.load_global_config.return_value = _fake_registry(services=[existing])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="configure",
             service_name="api",
             priority="required",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
@@ -765,11 +765,11 @@ class TestLegacyOpInterop(unittest.TestCase):
         sm = MagicMock()
         sm.get_inactive_services = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(services(
+        parsed = asyncio.run(services(
             ctx=_make_ctx(service_manager=sm),
             op="list_inactive",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "GET")
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -30,7 +30,7 @@ class TestOptions(unittest.TestCase):
         async def go():
             return await sessions(ctx=_make_ctx(), op="OPTIONS")
         result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "sessions")
@@ -43,7 +43,7 @@ class TestVerbResolution(unittest.TestCase):
     def test_schema_verb_works(self):
         async def go():
             return await sessions(ctx=_make_ctx(), op="schema")
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
@@ -55,7 +55,7 @@ class TestHead(unittest.TestCase):
         terminal = MagicMock()
         terminal.sessions = {}
         ctx = _make_ctx(terminal=terminal)
-        parsed = json.loads(asyncio.run(sessions(ctx=ctx, op="HEAD")))
+        parsed = asyncio.run(sessions(ctx=ctx, op="HEAD"))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -101,7 +101,7 @@ class TestHead(unittest.TestCase):
             terminal=terminal,
             agent_registry=self._empty_agent_registry(),
         )
-        parsed = json.loads(asyncio.run(sessions(ctx=ctx, op="HEAD")))
+        parsed = asyncio.run(sessions(ctx=ctx, op="HEAD"))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
         self.assertEqual(len(parsed["data"]), 1)
@@ -120,7 +120,7 @@ class TestHead(unittest.TestCase):
             terminal=terminal,
             agent_registry=self._empty_agent_registry(),
         )
-        parsed = json.loads(asyncio.run(sessions(ctx=ctx, op="GET")))
+        parsed = asyncio.run(sessions(ctx=ctx, op="GET"))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         session.get_cwd.assert_awaited()
@@ -129,16 +129,16 @@ class TestHead(unittest.TestCase):
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(sessions(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             sessions(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -175,7 +175,7 @@ class TestReadOutput(unittest.TestCase):
         self.assertEqual(request.targets[0].session_id, "abc")
         self.assertEqual(request.targets[0].max_lines, 100)
         # Verify the envelope that came out.
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertIn("outputs", parsed["data"])
@@ -226,7 +226,7 @@ class TestReadOutput(unittest.TestCase):
         self.assertEqual(len(request.targets), 2)
         self.assertEqual(request.targets[0].agent, "alice")
         self.assertEqual(request.targets[1].agent, "bob")
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
 
     def test_read_no_targets_falls_through_to_active_session(self):
@@ -247,7 +247,7 @@ class TestReadOutput(unittest.TestCase):
         # to the active session per its docstring.
         request = call_args.args[0]
         self.assertEqual(list(request.targets), [])
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
 
 
@@ -284,7 +284,7 @@ class TestWriteOutput(unittest.TestCase):
         self.assertEqual(request.messages[0].content, "echo hello")
         self.assertEqual(request.messages[0].targets[0].session_id, "abc")
         # Verify the envelope.
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
         self.assertTrue(parsed["ok"])
@@ -345,7 +345,7 @@ class TestWriteOutput(unittest.TestCase):
         self.assertEqual(request.messages[0].content, "echo a")
         self.assertEqual(request.messages[0].targets[0].agent, "alice")
         self.assertEqual(request.messages[1].content, "echo b")
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(parsed["ok"])
 
     def test_write_missing_content_and_targets_returns_err(self):
@@ -357,7 +357,7 @@ class TestWriteOutput(unittest.TestCase):
                 target="output",
                 # no content, no messages
             )
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertFalse(parsed["ok"])
 
     def test_write_content_without_target_returns_err(self):
@@ -370,16 +370,16 @@ class TestWriteOutput(unittest.TestCase):
                 content="echo hi",
                 # no session_id/agent/name/team
             )
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertFalse(parsed["ok"])
         self.assertIn("requires", parsed["error"]["message"].lower())
 
 
 class TestPostWithUnsupportedDefiner(unittest.TestCase):
     def test_post_invoke_not_yet_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             sessions(ctx=_make_ctx(), op="POST", definer="INVOKE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         # Dispatcher converts NotImplementedError into a generic err envelope.
         self.assertIn("not implemented", parsed["error"]["message"].lower())
@@ -387,9 +387,9 @@ class TestPostWithUnsupportedDefiner(unittest.TestCase):
     def test_post_send_without_target_not_yet_implemented(self):
         # SEND without target='output' is reserved for future sub-resources
         # (e.g. POST+SEND on cascade). Should be NotImplemented for now.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             sessions(ctx=_make_ctx(), op="POST", definer="SEND")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
@@ -398,7 +398,7 @@ class TestOptionsAdvertisesOutputAndSend(unittest.TestCase):
     def test_options_lists_send_definer(self):
         async def go():
             return await sessions(ctx=_make_ctx(), op="OPTIONS")
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("SEND", post["definers"])
         # GET method should advertise the new params.
@@ -425,7 +425,7 @@ class TestSendKeys(unittest.TestCase):
                 )
 
         result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "SEND")
         self.assertTrue(parsed["ok"])
@@ -450,22 +450,22 @@ class TestSendKeys(unittest.TestCase):
                     session_id="sid",
                 )
 
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertTrue(parsed["ok"])
         mock_session.send_special_key.assert_awaited_once_with("enter")
 
     def test_send_keys_both_control_and_key_rejected(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(), op="send", target="keys",
             control_char="C", key="enter", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("either", parsed["error"]["message"].lower())
 
     def test_send_keys_missing_both_rejected(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(), op="send", target="keys", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("requires", parsed["error"]["message"].lower())
 
@@ -481,7 +481,7 @@ class TestSendKeys(unittest.TestCase):
                     session_id="nonexistent",
                 )
 
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertFalse(parsed["ok"])
         self.assertIn("no matching session", parsed["error"]["message"].lower())
 
@@ -497,27 +497,27 @@ class TestPatchDefinerValidation(unittest.TestCase):
     def test_patch_append_on_roles_rejected(self):
         # APPEND is tags-only; roles should reject it rather than silently
         # execute as MODIFY.
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=MagicMock()),
             op="append", target="roles", session_id="sid", role="builder",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("APPEND", parsed["error"]["message"])
 
     def test_patch_append_on_locks_rejected(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="append", target="locks",
             session_id="sid", agent="alice", action="lock",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("APPEND", parsed["error"]["message"])
 
     def test_patch_append_on_session_rejected(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(),
             op="append", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("APPEND", parsed["error"]["message"])
 
@@ -525,10 +525,10 @@ class TestPatchDefinerValidation(unittest.TestCase):
         # Sanity: APPEND *is* valid on tags.
         lock_manager = MagicMock()
         lock_manager.set_tags.return_value = ["x"]
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="append", target="tags", session_id="sid", tags=["x"],
-        )))
+        ))
         self.assertTrue(parsed["ok"])
 
 
@@ -536,10 +536,10 @@ class TestPatchTags(unittest.TestCase):
     def test_patch_tags_replaces(self):
         lock_manager = MagicMock()
         lock_manager.set_tags.return_value = ["x", "y"]
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="update", target="tags", session_id="sid", tags=["x", "y"],
-        )))
+        ))
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
         self.assertTrue(parsed["ok"])
@@ -548,26 +548,26 @@ class TestPatchTags(unittest.TestCase):
     def test_patch_tags_append(self):
         lock_manager = MagicMock()
         lock_manager.set_tags.return_value = ["a", "b", "x"]
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="append", target="tags", session_id="sid", tags=["x"],
-        )))
+        ))
         self.assertEqual(parsed["definer"], "APPEND")
         self.assertTrue(parsed["ok"])
         lock_manager.set_tags.assert_called_once_with("sid", ["x"], append=True)
 
     def test_patch_tags_missing_session_id(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="update", target="tags", tags=["x"],
-        )))
+        ))
         self.assertFalse(parsed["ok"])
 
     def test_patch_tags_missing_tags(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="update", target="tags", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("tags", parsed["error"]["message"].lower())
 
@@ -576,10 +576,10 @@ class TestPatchActive(unittest.TestCase):
     def test_focus_session(self):
         terminal = MagicMock()
         terminal.focus_session = AsyncMock()
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(terminal=terminal),
             op="update", target="active", session_id="sid", focus=True,
-        )))
+        ))
         self.assertEqual(parsed["method"], "PATCH")
         self.assertTrue(parsed["ok"])
         terminal.focus_session.assert_awaited_once_with("sid")
@@ -587,10 +587,10 @@ class TestPatchActive(unittest.TestCase):
     def test_focus_without_flag_not_yet_implemented(self):
         # Only focus=true is supported in 4d. Plain PATCH on active session
         # without focus=true should surface NotImplemented.
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(),
             op="update", target="active", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
@@ -599,10 +599,10 @@ class TestPatchRoles(unittest.TestCase):
     def test_assign_role(self):
         from core.models import SessionRole
         role_manager = MagicMock()
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=role_manager),
             op="assign", target="roles", session_id="sid", role="builder",
-        )))
+        ))
         self.assertEqual(parsed["method"], "PATCH")
         self.assertTrue(parsed["ok"])
         # Role string coerced to the SessionRole enum before calling the manager.
@@ -611,18 +611,18 @@ class TestPatchRoles(unittest.TestCase):
         )
 
     def test_assign_role_missing_role(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=MagicMock()),
             op="assign", target="roles", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("role", parsed["error"]["message"].lower())
 
     def test_assign_role_unknown_value(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=MagicMock()),
             op="assign", target="roles", session_id="sid", role="nonsense",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
 
 
@@ -630,10 +630,10 @@ class TestDeleteRole(unittest.TestCase):
     def test_delete_role(self):
         role_manager = MagicMock()
         role_manager.remove_role.return_value = True
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=role_manager),
             op="delete", target="roles", session_id="sid",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["removed"])
@@ -645,10 +645,10 @@ class TestPatchLocks(unittest.TestCase):
     def test_lock_session(self):
         lock_manager = MagicMock()
         lock_manager.lock_session.return_value = (True, "agent1")
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="update", target="locks", session_id="sid", agent="agent1", action="lock",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["acquired"])
         self.assertEqual(parsed["data"]["owner"], "agent1")
@@ -657,36 +657,36 @@ class TestPatchLocks(unittest.TestCase):
         # When `action` is omitted, it defaults to "lock".
         lock_manager = MagicMock()
         lock_manager.lock_session.return_value = (True, "agent1")
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="update", target="locks", session_id="sid", agent="agent1",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         lock_manager.lock_session.assert_called_once_with("sid", "agent1")
 
     def test_request_access(self):
         lock_manager = MagicMock()
         lock_manager.check_permission.return_value = (True, "agent1")
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="update", target="locks", session_id="sid", agent="agent1", action="request_access",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["allowed"])
 
     def test_patch_locks_missing_agent(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="update", target="locks", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent", parsed["error"]["message"].lower())
 
     def test_patch_locks_bad_action(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="update", target="locks", session_id="sid", agent="a", action="bogus",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("unknown action", parsed["error"]["message"].lower())
 
@@ -695,26 +695,26 @@ class TestDeleteLock(unittest.TestCase):
     def test_unlock(self):
         lock_manager = MagicMock()
         lock_manager.unlock_session.return_value = True
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=lock_manager),
             op="unlock", target="locks", session_id="sid", agent="agent1",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["unlocked"])
 
     def test_delete_locks_missing_agent(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(lock_manager=MagicMock()),
             op="delete", target="locks", session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent", parsed["error"]["message"].lower())
 
 
 class TestOptionsAdvertisesPatchAndDelete(unittest.TestCase):
     def test_options_lists_patch_definers_and_delete(self):
-        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS"))
         methods = parsed["data"]["methods"]
         self.assertIn("PATCH", methods)
         self.assertIn("MODIFY", methods["PATCH"]["definers"])
@@ -753,7 +753,7 @@ class TestGetStatus(unittest.TestCase):
                     op="GET", target="status", session_id="sid",
                 )
 
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         # data is a list of status dicts.
@@ -764,9 +764,9 @@ class TestGetStatus(unittest.TestCase):
         self.assertFalse(status["is_monitoring"])
 
     def test_get_status_no_target_info(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             sessions(ctx=_make_ctx(), op="GET", target="status")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("requires", parsed["error"]["message"].lower())
 
@@ -779,7 +779,7 @@ class TestGetStatus(unittest.TestCase):
                     op="GET", target="status", session_id="missing",
                 )
 
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertFalse(parsed["ok"])
         self.assertIn("no matching session", parsed["error"]["message"].lower())
 
@@ -805,7 +805,7 @@ class TestStartMonitoring(unittest.TestCase):
 
         count, call_args, result = asyncio.run(go())
         self.assertEqual(count, 1)
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
         self.assertTrue(parsed["ok"])
@@ -815,10 +815,10 @@ class TestStartMonitoring(unittest.TestCase):
         self.assertIs(call_args.args[0], session)
 
     def test_start_monitoring_no_target_info(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(event_bus=MagicMock()),
             op="start", target="monitoring",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("requires", parsed["error"]["message"].lower())
 
@@ -831,7 +831,7 @@ class TestStartMonitoring(unittest.TestCase):
                     op="start", target="monitoring", session_id="missing",
                 )
 
-        parsed = json.loads(asyncio.run(go()))
+        parsed = asyncio.run(go())
         self.assertFalse(parsed["ok"])
         self.assertIn("no matching session", parsed["error"]["message"].lower())
 
@@ -856,16 +856,16 @@ class TestStopMonitoring(unittest.TestCase):
 
         count, result = asyncio.run(go())
         self.assertEqual(count, 1)
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["monitoring"][0]["stopped"])
 
     def test_stop_monitoring_no_target_info(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(),
             op="stop", target="monitoring",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("requires", parsed["error"]["message"].lower())
 
@@ -897,7 +897,7 @@ class TestCreateSplit(unittest.TestCase):
                 return mock_split.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -908,10 +908,10 @@ class TestCreateSplit(unittest.TestCase):
         self.assertEqual(split_request.direction, "below")
 
     def test_create_split_missing_session_id(self):
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(role_manager=MagicMock()),
             op="POST", definer="CREATE", target="splits", direction="below",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("session_id", parsed["error"]["message"].lower())
 
@@ -952,7 +952,7 @@ class TestPatchAppearance(unittest.TestCase):
 
         count, call_args, result = asyncio.run(go())
         self.assertEqual(count, 1)
-        parsed = json.loads(result)
+        parsed = result
         self.assertEqual(parsed["method"], "PATCH")
         self.assertEqual(parsed["definer"], "MODIFY")
         self.assertTrue(parsed["ok"])
@@ -996,11 +996,11 @@ class TestPatchAppearance(unittest.TestCase):
     def test_patch_appearance_no_fields_returns_err(self):
         # Plain PATCH with no target and no modifications should still fail
         # with the Task 4d "not implemented" error so we don't no-op silently.
-        parsed = json.loads(asyncio.run(sessions(
+        parsed = asyncio.run(sessions(
             ctx=_make_ctx(),
             op="PATCH", definer="MODIFY",
             session_id="sid",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
 
 
@@ -1039,7 +1039,7 @@ class TestCreateSessionsDefaults(unittest.TestCase):
                 return mock_exec.call_args, result
 
         call_args, result = asyncio.run(go())
-        parsed = json.loads(result)
+        parsed = result
         self.assertTrue(
             parsed["ok"],
             f"Expected ok envelope, got error: {parsed.get('error')!r}",
@@ -1051,7 +1051,7 @@ class TestCreateSessionsDefaults(unittest.TestCase):
 
     def test_options_schema_advertises_from_end(self):
         """OPTIONS GET advertises from_end? for output reads (fb #3)."""
-        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS"))
         get_params = parsed["data"]["methods"]["GET"]["params"]
         from_end_entries = [p for p in get_params if p.startswith("from_end")]
         self.assertEqual(
@@ -1063,7 +1063,7 @@ class TestCreateSessionsDefaults(unittest.TestCase):
 
     def test_options_schema_marks_layout_optional(self):
         """OPTIONS must reflect that layout is optional, with its default value."""
-        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS"))
         create_params = parsed["data"]["methods"]["POST"]["definers"]["CREATE"]["params"]
         layout_entries = [p for p in create_params if p.startswith("layout")]
         self.assertEqual(len(layout_entries), 1, f"expected one layout entry, got {layout_entries}")
@@ -1098,7 +1098,7 @@ class TestCreateSessionsDefaults(unittest.TestCase):
 
 class TestOptionsAdvertises4e(unittest.TestCase):
     def test_options_lists_new_targets_and_verbs(self):
-        parsed = json.loads(asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(sessions(ctx=_make_ctx(), op="OPTIONS"))
         methods = parsed["data"]["methods"]
         # POST should advertise TRIGGER.
         self.assertIn("TRIGGER", methods["POST"]["definers"])

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -54,7 +54,7 @@ def _fake_hook_result(
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(teams(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(teams(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "teams")
@@ -65,19 +65,19 @@ class TestOptions(unittest.TestCase):
         self.assertIn("agents", parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(teams(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(teams(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("CREATE", post["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(teams(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(teams(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(teams(ctx=_make_ctx(), op="frobnicate")))
+        parsed = asyncio.run(teams(ctx=_make_ctx(), op="frobnicate"))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
@@ -85,9 +85,9 @@ class TestUnknownOp(unittest.TestCase):
 class TestWrongDefiner(unittest.TestCase):
     def test_post_replace_rejected(self):
         # REPLACE is in the PUT family, not POST.
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             teams(ctx=_make_ctx(), op="POST", definer="REPLACE")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 
@@ -116,13 +116,13 @@ class TestList(unittest.TestCase):
         # No profile → skip profile fields.
         profile_manager.get_team_profile.return_value = None
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
             ),
             op="list",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 2)
@@ -149,13 +149,13 @@ class TestList(unittest.TestCase):
         profile_manager = MagicMock()
         profile_manager.get_team_profile.return_value = fake_profile
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
             ),
             op="GET",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         team = parsed["data"]["teams"][0]
         self.assertEqual(team["profile_guid"], "guid-1")
@@ -164,10 +164,10 @@ class TestList(unittest.TestCase):
     def test_list_empty(self):
         registry = MagicMock()
         registry.list_teams.return_value = []
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="list",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["count"], 0)
         self.assertEqual(parsed["data"]["teams"], [])
@@ -180,10 +180,10 @@ class TestHead(unittest.TestCase):
         # HEAD envelope still gets ok=true and a compact summary.
         registry = MagicMock()
         registry.list_teams.return_value = []
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -221,7 +221,7 @@ class TestCreateTeam(unittest.TestCase):
     def test_create_team_via_friendly_verb(self):
         registry, profile_manager, service_hook_manager = self._setup_ctx()
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
@@ -230,7 +230,7 @@ class TestCreateTeam(unittest.TestCase):
             op="create",
             team_name="infra",
             description="Infrastructure team",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -252,7 +252,7 @@ class TestCreateTeam(unittest.TestCase):
 
     def test_create_team_via_post_plus_definer(self):
         registry, profile_manager, service_hook_manager = self._setup_ctx()
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
@@ -261,21 +261,21 @@ class TestCreateTeam(unittest.TestCase):
             op="POST",
             definer="CREATE",
             team_name="infra",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "CREATE")
 
     def test_create_team_missing_name_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="create",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_create_team_with_parent_and_repo_path(self):
         registry, profile_manager, service_hook_manager = self._setup_ctx()
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
@@ -285,7 +285,7 @@ class TestCreateTeam(unittest.TestCase):
             team_name="infra",
             parent_team="engineering",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         registry.create_team.assert_called_once_with(
             name="infra",
@@ -308,7 +308,7 @@ class TestCreateTeam(unittest.TestCase):
             )
         )
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
@@ -316,7 +316,7 @@ class TestCreateTeam(unittest.TestCase):
             ),
             op="create",
             team_name="infra",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Required service failed", parsed["error"]["message"])
         # Must NOT have created the team or profile when hook blocks.
@@ -351,7 +351,7 @@ class TestCreateTeam(unittest.TestCase):
             )
         )
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
@@ -360,7 +360,7 @@ class TestCreateTeam(unittest.TestCase):
             op="create",
             team_name="infra",
             repo_path="/repo",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         sp = parsed["data"]["service_prompt"]
         self.assertEqual(sp["message"], "Start postgres?")
@@ -378,11 +378,11 @@ class TestAssignAgent(unittest.TestCase):
         registry = MagicMock()
         registry.assign_to_team.return_value = True
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="POST", definer="CREATE", target="agents",
             team_name="infra", agent_name="alice",
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "CREATE")
         self.assertTrue(parsed["ok"])
@@ -395,27 +395,27 @@ class TestAssignAgent(unittest.TestCase):
         registry = MagicMock()
         registry.assign_to_team.return_value = False
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="create", target="agents",
             team_name="infra", agent_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent not found", parsed["error"]["message"].lower())
 
     def test_assign_agent_missing_team_name_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="create", target="agents", agent_name="alice",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_assign_agent_missing_agent_name_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="create", target="agents", team_name="infra",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"].lower())
 
@@ -432,14 +432,14 @@ class TestRemoveTeam(unittest.TestCase):
         profile_manager = MagicMock()
         profile_manager.remove_team_profile.return_value = True
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
             ),
             op="delete",
             team_name="infra",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["team_name"], "infra")
@@ -454,14 +454,14 @@ class TestRemoveTeam(unittest.TestCase):
         profile_manager = MagicMock()
         profile_manager.remove_team_profile.return_value = False
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(
                 agent_registry=registry,
                 profile_manager=profile_manager,
             ),
             op="DELETE",
             team_name="infra",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertFalse(parsed["data"]["profile_removed"])
         profile_manager.save_profiles.assert_not_called()
@@ -470,19 +470,19 @@ class TestRemoveTeam(unittest.TestCase):
         registry = MagicMock()
         registry.remove_team.return_value = False
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="delete",
             team_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("missing", parsed["error"]["message"])
 
     def test_remove_team_missing_name_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="delete",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("team_name", parsed["error"]["message"].lower())
 
@@ -497,11 +497,11 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
         registry = MagicMock()
         registry.remove_from_team.return_value = True
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="delete", target="agents",
             team_name="infra", agent_name="alice",
-        )))
+        ))
         self.assertEqual(parsed["method"], "DELETE")
         self.assertTrue(parsed["ok"])
         self.assertTrue(parsed["data"]["removed"])
@@ -513,27 +513,27 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
         registry = MagicMock()
         registry.remove_from_team.return_value = False
 
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(agent_registry=registry),
             op="delete", target="agents",
             team_name="infra", agent_name="missing",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not found", parsed["error"]["message"].lower())
 
     def test_remove_agent_missing_team_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="DELETE", target="agents", agent_name="alice",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("team_name", parsed["error"]["message"].lower())
 
     def test_remove_agent_missing_agent_returns_err(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="DELETE", target="agents", team_name="infra",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("agent_name", parsed["error"]["message"].lower())
 
@@ -545,17 +545,17 @@ class TestRemoveAgentFromTeam(unittest.TestCase):
 
 class TestUnsupportedCombinations(unittest.TestCase):
     def test_post_send_not_implemented(self):
-        parsed = json.loads(asyncio.run(
+        parsed = asyncio.run(
             teams(ctx=_make_ctx(), op="POST", definer="SEND")
-        ))
+        )
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 
     def test_delete_unknown_target_not_implemented(self):
-        parsed = json.loads(asyncio.run(teams(
+        parsed = asyncio.run(teams(
             ctx=_make_ctx(),
             op="DELETE", target="bogus",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not", parsed["error"]["message"].lower())
 

--- a/tests/test_workflows_dispatch.py
+++ b/tests/test_workflows_dispatch.py
@@ -98,7 +98,7 @@ def _make_event_result(
 
 class TestOptions(unittest.TestCase):
     def test_options_returns_schema(self):
-        parsed = json.loads(asyncio.run(workflows(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(workflows(ctx=_make_ctx(), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["collection"], "workflows")
@@ -115,7 +115,7 @@ class TestOptions(unittest.TestCase):
         self.assertIn("history", parsed["data"]["sub_resources"])
 
     def test_options_lists_post_definers(self):
-        parsed = json.loads(asyncio.run(workflows(ctx=_make_ctx(), op="OPTIONS")))
+        parsed = asyncio.run(workflows(ctx=_make_ctx(), op="OPTIONS"))
         post = parsed["data"]["methods"]["POST"]
         self.assertIn("TRIGGER", post["definers"])
         # CREATE / SEND / INVOKE shouldn't be advertised — workflows only
@@ -125,7 +125,7 @@ class TestOptions(unittest.TestCase):
         self.assertNotIn("INVOKE", post["definers"])
 
     def test_schema_verb_works(self):
-        parsed = json.loads(asyncio.run(workflows(ctx=_make_ctx(), op="schema")))
+        parsed = asyncio.run(workflows(ctx=_make_ctx(), op="schema"))
         self.assertEqual(parsed["method"], "OPTIONS")
         self.assertTrue(parsed["ok"])
 
@@ -161,10 +161,10 @@ class TestListEvents(unittest.TestCase):
         fm = MagicMock()
         fm.list_flows.return_value = ["MyFlow"]
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb, flow_manager=fm),
             op="list",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 2)
@@ -180,10 +180,10 @@ class TestListEvents(unittest.TestCase):
         self.assertEqual(parsed["data"]["flows_registered"], ["MyFlow"])
 
     def test_list_events_empty(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="list",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 0)
         self.assertEqual(parsed["data"]["events"], [])
@@ -200,10 +200,10 @@ class TestListEvents(unittest.TestCase):
             "is_start_event": True,
         })
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="GET", target="events",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 1)
         self.assertEqual(parsed["data"]["events"][0]["event_name"], "evt_x")
@@ -221,7 +221,7 @@ class TestListEvents(unittest.TestCase):
         eb._registry = registry
         ctx.request_context.lifespan_context = {"event_bus": eb, "logger": MagicMock()}
 
-        parsed = json.loads(asyncio.run(workflows(ctx=ctx, op="list")))
+        parsed = asyncio.run(workflows(ctx=ctx, op="list"))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["flows_registered"], [])
 
@@ -251,10 +251,10 @@ class TestHistory(unittest.TestCase):
             ),
         ])
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="GET", target="history",
-        )))
+        ))
         self.assertEqual(parsed["method"], "GET")
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 2)
@@ -281,11 +281,11 @@ class TestHistory(unittest.TestCase):
             ),
         ])
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="GET", target="history",
             event_name="specific_evt",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["data"]["total_count"], 1)
         self.assertEqual(parsed["data"]["entries"][0]["event_name"], "specific_evt")
@@ -297,11 +297,11 @@ class TestHistory(unittest.TestCase):
         eb = MagicMock()
         eb.get_history = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="GET", target="history",
             success_only=True, limit=50,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         _, kwargs = eb.get_history.call_args
         self.assertTrue(kwargs["success_only"])
@@ -311,11 +311,11 @@ class TestHistory(unittest.TestCase):
         eb = MagicMock()
         eb.get_history = AsyncMock(return_value=[])
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="GET", target="history",
             limit=5000,
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         _, kwargs = eb.get_history.call_args
         self.assertEqual(kwargs["limit"], 1000)
@@ -331,12 +331,12 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="trigger",
             event_name="my_event",
             payload={"key": "value"},
-        )))
+        ))
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
         self.assertTrue(parsed["ok"])
@@ -363,13 +363,13 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=result)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="trigger",
             event_name="immediate_evt",
             immediate=True,
             priority="high",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "TRIGGER")
         data = parsed["data"]
@@ -385,11 +385,11 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="POST", definer="TRIGGER",
             event_name="my_event",
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["definer"], "TRIGGER")
         self.assertTrue(parsed["data"]["queued"])
@@ -398,21 +398,21 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="start",
             event_name="my_event",
-        )))
+        ))
         # 'start' is a TRIGGER-family verb in VERB_ATLAS.
         self.assertTrue(parsed["ok"])
         self.assertEqual(parsed["method"], "POST")
         self.assertEqual(parsed["definer"], "TRIGGER")
 
     def test_trigger_missing_event_name_returns_err(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="trigger",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("event_name", parsed["error"]["message"].lower())
 
@@ -420,13 +420,13 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=None)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="trigger",
             event_name="my_event",
             source="my_flow",
             metadata={"trace_id": "abc123"},
-        )))
+        ))
         self.assertTrue(parsed["ok"])
         _, kwargs = eb.trigger.call_args
         self.assertEqual(kwargs["source"], "my_flow")
@@ -443,12 +443,12 @@ class TestTrigger(unittest.TestCase):
         eb = MagicMock()
         eb.trigger = AsyncMock(return_value=result)
 
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(event_bus=eb),
             op="trigger",
             event_name="bad_evt",
             immediate=True,
-        )))
+        ))
         # Envelope is ok=true (handler completed); the payload reports
         # success=false with the error message.
         self.assertTrue(parsed["ok"])
@@ -464,10 +464,10 @@ class TestTrigger(unittest.TestCase):
 
 class TestHead(unittest.TestCase):
     def test_head_returns_compact_envelope(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="HEAD",
-        )))
+        ))
         self.assertEqual(parsed["method"], "HEAD")
         self.assertTrue(parsed["ok"])
 
@@ -479,53 +479,53 @@ class TestHead(unittest.TestCase):
 
 class TestUnknownOp(unittest.TestCase):
     def test_bad_verb_returns_err_envelope(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="frobnicate",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("Unknown op", parsed["error"]["message"])
 
 
 class TestUnsupportedDefiners(unittest.TestCase):
     def test_post_create_not_implemented(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="POST", definer="CREATE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_post_send_not_implemented(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="POST", definer="SEND",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_patch_not_implemented(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="PATCH", definer="MODIFY",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_delete_not_implemented(self):
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="DELETE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not implemented", parsed["error"]["message"].lower())
 
     def test_wrong_family_definer_rejected(self):
         # REPLACE belongs to PUT, not POST.
-        parsed = json.loads(asyncio.run(workflows(
+        parsed = asyncio.run(workflows(
             ctx=_make_ctx(),
             op="POST", definer="REPLACE",
-        )))
+        ))
         self.assertFalse(parsed["ok"])
         self.assertIn("not in POST family", parsed["error"]["message"])
 


### PR DESCRIPTION
Resolves item **#13** of feedback fb-20260424-157473f7 (the final big-three).

## Before

```
mcp.callTool(\"sessions\", {op: \"OPTIONS\"})
→ {result: \"{\\\"method\\\": \\\"OPTIONS\\\", \\\"ok\\\": true, ...}\"}
```

The `result` wrapper plus stringified inner JSON forced every client to do `JSON.parse(response.result)`. Feedback called this out as one of the top-3 fixes that would meaningfully smooth the first-hour MCP experience.

## After

```
mcp.callTool(\"sessions\", {op: \"OPTIONS\"})
→ {method: \"OPTIONS\", ok: true, data: {...}}
```

Native JSON shape, surfaced as `structuredContent`. Half the parsing.

## Why FastMCP gave us `{result: <stringified>}`

`mcp/server/fastmcp/utilities/func_metadata.py:_convert_to_content`:

```python
if not isinstance(result, str):
    result = pydantic_core.to_json(result, fallback=str, indent=2).decode()
return [TextContent(type=\"text\", text=result)]
```

When tool functions are typed `-> str` (we returned a JSON-stringified envelope), FastMCP wraps the string as a TextContent block. Clients surface that as `{result: <text>}`.

For structured output FastMCP looks at the return-type annotation:

- `dict[str, Any]` → uses `RootModel` (special-cased at line 362-367 of `func_metadata.py`); `wrap_output=False`.
- `list[T]`, `tuple`, `Union[...]`, primitives → wraps in a synthetic model with a `result` field; `wrap_output=True`.

So `dict[str, Any]` is the magic annotation that gives us the unwrapped shape.

## What changed

- **`iterm_mcpy/responses.py`** — `ok_envelope` and `err_envelope` now return `dict[str, Any]` (drop `json.dumps`, drop the `json` import).
- **15 tool entry signatures** — `sessions`, `agents`, `teams`, `managers`, `feedback`, `memory`, `services`, `roles`, `workflows`, `messages`, `orchestrate`, `delegate`, `wait_for`, `subscribe`, `telemetry` — all switched from `-> str` to `-> dict[str, Any]`.
- **`iterm_mcpy/dispatcher.py::MethodDispatcher.dispatch`** — same change.
- Two tool modules (`wait_for.py`, `telemetry.py`) needed an explicit `from typing import Any`.

## Tests

- **Mass-unwrap of 389 `json.loads(...)` wrappers** across 15 test files (`tests/test_action_tools.py`, `tests/test_agents.py`, `tests/test_dispatcher.py`, `tests/test_envelope.py`, `tests/test_errors.py`, `tests/test_feedback_dispatch.py`, `tests/test_managers.py`, `tests/test_memory_dispatch.py`, `tests/test_responses.py`, `tests/test_roles_dispatch.py`, `tests/test_services_dispatch.py`, `tests/test_sessions.py`, `tests/test_teams.py`, `tests/test_wait_for_agent.py`, `tests/test_workflows_dispatch.py`). The inner expression is now the dict directly.
- **3 `json.loads` calls restored** around legitimate `ok_json(...)` / `model_dump_json(...)` fixtures (those still return strings by design — they're Pydantic serializer helpers, not envelopes).

```
$ python -m unittest [18 tests/* modules]
Ran 461 tests in 1.610s
OK
```

End-to-end smoke check confirmed: `await sessions(op='OPTIONS')` returns a native dict, not a JSON string.

## This finishes the four-PR feedback stack

- ✅ #117 — layout default
- ✅ #118 + #120 — session name preservation
- ✅ #119 — output tail default
- ✅ #121 — structured `{code, message, hint}` errors
- 🔵 **#122 (this) — native dict envelope**

🤖 Generated with [Claude Code](https://claude.com/claude-code)