### PR TITLE
chore: simplify cumulative feedback-stack changes

### DIFF
--- a/core/layouts.py
+++ b/core/layouts.py
@@ -125,32 +125,16 @@ class LayoutManager:
             A dictionary mapping pane names to session IDs
         """
         pane_names = self._normalize_pane_names(pane_names, pane_hierarchy, 2)
-        
-        print(f"Creating horizontal split with panes: {pane_names}")
-        
-        # Create a new window for the first pane
+
         left_session = await self.terminal.create_window()
         await left_session.set_name(pane_names[0])
-        print(f"Created left pane with name '{pane_names[0]}', actual name: '{left_session.name}'")
-        
-        # Create a split pane for the second pane
+
         right_session = await self.terminal.create_split_pane(
             left_session.id,
             vertical=True,
             name=pane_names[1]
         )
-        
-        print(f"Created right pane with name '{pane_names[1]}', actual name: '{right_session.name}'")
-        
-        # Force update both session names again
-        await left_session.set_name(pane_names[0])
-        await right_session.set_name(pane_names[1])
-        
-        print(f"After rename - Left pane: '{left_session.name}', Right pane: '{right_session.name}'")
-        
-        # Add a delay to allow the name to be set
-        await asyncio.sleep(1)
-        
+
         return {
             pane_names[0]: left_session.id,
             pane_names[1]: right_session.id

--- a/core/session.py
+++ b/core/session.py
@@ -23,6 +23,10 @@ _logger = logging.getLogger("iterm-mcp-session")
 # Cache time-to-live for CWD in seconds
 CWD_CACHE_TTL_SECONDS = 30
 
+# Settings for the set_name retry loop (see ItermSession.set_name).
+_SET_NAME_MAX_ATTEMPTS = 3
+_SET_NAME_RETRY_DELAY = 0.2
+
 
 @dataclass
 class ExpectResult:
@@ -373,48 +377,39 @@ class ItermSession:
         """
         self.logger = logger
     
-    async def set_name(self, name: str, max_attempts: int = 3, retry_delay: float = 0.2) -> None:
+    async def set_name(self, name: str) -> None:
         """Set the name of the session, retrying until iTerm2 agrees.
 
-        iterm2's `async_set_name` propagates asynchronously inside iTerm; on
-        a freshly-created session the first call can land before iTerm has
-        finished applying the profile default, and the rename gets clobbered.
-        We therefore set, sleep briefly, then re-read `session.name` to confirm.
-        See feedback fb-20260424-157473f7 item #2 for the user-visible bug
-        ("session created with name='x' came back named ' '").
-
-        Args:
-            name: The new name for the session.
-            max_attempts: How many times to call `async_set_name` before
-                giving up. Best-effort; we do not raise on final failure.
-            retry_delay: Seconds to wait between attempts.
+        iterm2's ``async_set_name`` propagates asynchronously inside iTerm;
+        on a freshly-created session the first call can land before iTerm
+        has finished applying the profile default, and the rename gets
+        clobbered. We call, check, then sleep+retry only if needed —
+        first-create sessions where the rename takes effect immediately
+        skip the sleep entirely. See fb-20260424-157473f7 item #2.
         """
         self._name = name
 
-        # Fast path: iTerm already agrees, no need to call set_name at all.
+        # Fast path: iTerm already agrees, nothing to send.
         if self.session.name == name:
             if self.logger:
                 self.logger.log_session_renamed(name)
             return
 
-        for attempt in range(max_attempts):
+        for attempt in range(_SET_NAME_MAX_ATTEMPTS):
             await self.session.async_set_name(name)
-            # Always sleep and verify after every attempt, including the last.
-            # This ensures iTerm has had a chance to propagate the rename before
-            # we evaluate whether it succeeded (fixes false "did not apply"
-            # warnings caused by reading session.name before iTerm async-applies
-            # the final attempt).
-            await asyncio.sleep(retry_delay)
+            if self.session.name == name:
+                break
+            # Last attempt: give iTerm one more settle window before giving up.
+            await asyncio.sleep(_SET_NAME_RETRY_DELAY)
             if self.session.name == name:
                 break
 
         if self.session.name != name:
-            # Best-effort warning via stdlib logging; ItermSessionLogger does not
-            # expose log_app_event (that method is on ItermLogManager), so we use
-            # the module-level stdlib logger to ensure the warning is always
-            # emitted regardless of which logger object is attached to the session.
+            # Best-effort warning via stdlib logging; ItermSessionLogger does
+            # not expose log_app_event (that method lives on ItermLogManager).
             _logger.warning(
-                "iterm2 did not apply name %r after %d attempt(s)", name, max_attempts
+                "iterm2 did not apply name %r after %d attempt(s)",
+                name, _SET_NAME_MAX_ATTEMPTS,
             )
 
         if self.logger:

--- a/iterm_mcpy/errors.py
+++ b/iterm_mcpy/errors.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
+from pydantic import ValidationError
+
 
 class ErrorCode(str, Enum):
     """Stable error codes returned in the `{code, message, hint?}` envelope."""
@@ -83,17 +85,11 @@ class ToolError(Exception):
                 f"Missing required parameter: {key!r}",
             )
 
-        if isinstance(exc, ValueError):
+        if isinstance(exc, ValidationError):
             return ToolError(ErrorCode.INVALID_PARAM, str(exc))
 
-        # Pydantic ValidationError lives in pydantic; import lazily so this
-        # module has no hard pydantic dependency.
-        try:
-            from pydantic import ValidationError
-            if isinstance(exc, ValidationError):
-                return ToolError(ErrorCode.INVALID_PARAM, str(exc))
-        except ImportError:
-            pass
+        if isinstance(exc, ValueError):
+            return ToolError(ErrorCode.INVALID_PARAM, str(exc))
 
         if isinstance(exc, NotImplementedError):
             return ToolError(ErrorCode.NOT_IMPLEMENTED, str(exc) or "Not implemented")

--- a/iterm_mcpy/responses.py
+++ b/iterm_mcpy/responses.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+from iterm_mcpy.errors import ErrorCode, ToolError
+
 
 def ok_json(model: BaseModel) -> str:
     """Serialize a Pydantic model to JSON, excluding None fields.
@@ -81,8 +83,6 @@ def err_envelope(
     Returns:
         Envelope dict (not a JSON string).
     """
-    from iterm_mcpy.errors import ErrorCode, ToolError
-
     if isinstance(error, str):
         error = ToolError(ErrorCode.INTERNAL, error)
 

--- a/iterm_mcpy/tools/workflows.py
+++ b/iterm_mcpy/tools/workflows.py
@@ -17,7 +17,7 @@ legacy per-verb tools; the cutover (rename to ``workflows`` and unregister
 the legacy tools) happens at the end of SP2.
 
 ``list`` uses the public ``EventBus.get_event_info`` introspection API
-(added on PR #114 to remove the previous ``event_bus._registry`` reach-in).
+rather than reaching into the private ``event_bus._registry`` attribute.
 """
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
\`/simplify\` pass over the four-PR feedback stack (#117–#122) found a handful of leftover workarounds, dead code, and unnecessary lazy imports.

## Substantive

- **\`core/layouts.py::_create_horizontal_split_layout\`** — drop the redundant set_name calls, the \`asyncio.sleep(1)\` workaround, and \`print()\` debug statements. The retry+verify loop now lives in \`ItermSession.set_name\` (PR #118 + #120), so the layout-layer workaround is unnecessary. **Saves ~1s of unconditional latency on every horizontal-split create.**
- **\`core/session.py::set_name\`** — restructure the retry loop from \`call → sleep → check\` to \`call → check → sleep+retry-only-on-failure\`. On fresh sessions where iterm2 propagates the rename on the first \`async_set_name\` call (the common case), the function now returns without sleeping. Worst case unchanged (~0.6s for 3 attempts).
  - Test runtime dropped from 1.6s → 1.2s for the targeted suite, mostly from \`tests/test_iterm_session_naming.py\` no longer sleeping on the happy path.

## Cleanup (no behavior change)

- **\`core/session.py\`** — lift magic numbers to module constants \`_SET_NAME_MAX_ATTEMPTS\`/\`_SET_NAME_RETRY_DELAY\`. No call site ever overrode them; the public signature is now plain \`set_name(name)\`.
- **\`iterm_mcpy/errors.py\`** — drop the lazy \`from pydantic import ValidationError\` inside \`from_exception\`. Pydantic is a hard project dependency; the \`try/except ImportError\` branch could never trigger. Top-level import.
- **\`iterm_mcpy/responses.py::err_envelope\`** — drop the lazy \`from iterm_mcpy.errors import ToolError\` inside the function. There is no circular import (\`errors.py\` imports nothing from \`responses.py\`). Top-level import.
- **\`iterm_mcpy/tools/workflows.py\`** — replace the \"added on PR #114\" comment with a substantive WHY (\"rather than reaching into the private \`event_bus._registry\` attribute\"). PR numbers in source rot.

## Tests

\`\`\`
$ python -m unittest [18 tests/* modules]
Ran 461 tests in 1.199s
OK
\`\`\`

## Findings deliberately left alone

The /simplify reviews surfaced a few items that aren't worth changing in this scope:

- **\`agents.py::manage_agent_hooks\`'s \`error=str(e)\`** — that's the legacy Pydantic \`ManageAgentHooksResponse\` shape, not the SP2 method-semantic envelope. Different API surface, deliberate.
- **The 9-file \`params = {k: v for k, v in raw_params.items() if v is not None}\` pattern** — predates these PRs; would touch a lot of files for low value. Defer.
- **The \`from_end=False\` opt-out used only in tests** — public API surface; keeping it for explicit caller intent.
- **Docstring references to \`fb-20260424-157473f7\`** — the ticket ID is informative; if a reader doesn't recognize it, the surrounding text still explains the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)