### PR TITLE
feat: accept str namespace + embed Playbook schema in orchestrate OPTIONS

### DIFF
--- a/iterm_mcpy/tools/memory.py
+++ b/iterm_mcpy/tools/memory.py
@@ -23,11 +23,49 @@ enforce safe-character conventions on namespace parts and keys before
 hitting the memory store.
 """
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import Context
 
 from iterm_mcpy.dispatcher import MethodDispatcher
+from iterm_mcpy.errors import ErrorCode, ToolError
+
+
+# Namespace strings can use either "/" or "." as a separator, or both.
+_NAMESPACE_SPLIT = re.compile(r"[./]")
+
+
+def _coerce_namespace(value: Union[str, List[str], None]) -> Optional[List[str]]:
+    """Accept str | list | None and return a list of segments, or None.
+
+    Strings get split on `/` or `.` so callers can write
+    ``"project/agent"`` or ``"project.agent"`` instead of
+    ``["project", "agent"]``. Empty strings raise; downstream
+    ``_validate_namespace`` rejects bad characters per segment.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        if not value:
+            raise ToolError(
+                ErrorCode.INVALID_PARAM,
+                "namespace string cannot be empty",
+                hint="pass a non-empty string like 'project/agent' or a list ['project','agent']",
+            )
+        # Split on `/` or `.` in any order; keep all non-empty segments.
+        parts = [p for p in _NAMESPACE_SPLIT.split(value) if p]
+        if not parts:
+            raise ToolError(
+                ErrorCode.INVALID_PARAM,
+                f"namespace string {value!r} contained only separators",
+            )
+        return parts
+    raise ToolError(
+        ErrorCode.INVALID_PARAM,
+        f"namespace must be a list or string, got {type(value).__name__}",
+    )
 
 
 # Pattern for safe namespace and key characters.
@@ -84,7 +122,7 @@ class MemoryDispatcher(MethodDispatcher):
             "params": [
                 "target=None | 'search' | 'keys' | 'namespaces' | 'stats'",
                 # retrieve (target=None + namespace + key):
-                "namespace?=[str]",
+                "namespace?=[str] | str  (accepts dotted 'a.b.c' or slashed 'a/b/c')",
                 "key?",
                 # search (target='search'):
                 "query?",
@@ -415,7 +453,7 @@ async def memory(
     op: str = "GET",
     definer: Optional[str] = None,
     target: Optional[str] = None,
-    namespace: Optional[List[str]] = None,
+    namespace: Optional[Union[str, List[str]]] = None,
     key: Optional[str] = None,
     value: Optional[Any] = None,
     metadata: Optional[Dict[str, Any]] = None,
@@ -472,6 +510,15 @@ async def memory(
         # Explicit target wins over the mapping's implied target.
         if mapped_target is not None and target is None:
             target = mapped_target
+
+    # Accept namespace as a list, dotted string, or slashed string.
+    # Coercion errors surface as a structured envelope rather than a
+    # late ValueError from _validate_namespace.
+    from iterm_mcpy.responses import err_envelope
+    try:
+        namespace = _coerce_namespace(namespace)
+    except ToolError as e:
+        return err_envelope(method=op.upper(), error=e)
 
     raw_params = {
         "target": target,

--- a/iterm_mcpy/tools/orchestrate.py
+++ b/iterm_mcpy/tools/orchestrate.py
@@ -15,6 +15,7 @@ from core.definer_verbs import DefinerError, resolve_op
 from core.models import (
     OrchestrateRequest,
     OrchestrateResponse,
+    Playbook,
     PlaybookCommandResult,
     WriteToSessionsRequest,
 )
@@ -55,6 +56,28 @@ async def orchestrate(
         resolution = resolve_op(op, definer)
     except DefinerError as e:
         return err_envelope(method=op.upper(), error=ToolError.from_exception(e))
+
+    if resolution.method == "OPTIONS":
+        return ok_envelope(
+            method="OPTIONS",
+            data={
+                "tool": "orchestrate",
+                "kind": "action",
+                "method": "POST",
+                "definer": "INVOKE",
+                "aliases": ["invoke", "execute", "run", "orchestrate"],
+                "params": {
+                    "playbook": "Playbook (see playbook_schema below)",
+                },
+                "playbook_schema": Playbook.model_json_schema(),
+                "description": (
+                    "Run a playbook bundling layout + commands + cascade + "
+                    "reads in a single call. The 'playbook_schema' field is "
+                    "the JSON Schema for the Playbook model — feed it into "
+                    "your client to validate playbooks before sending."
+                ),
+            },
+        )
 
     if resolution.method != "POST" or resolution.definer != "INVOKE":
         return err_envelope(

--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -132,6 +132,25 @@ class TestOrchestrateV2(unittest.TestCase):
             profile_manager=MagicMock(),
         )
 
+    def test_options_returns_playbook_schema(self):
+        """fb-20260424-157473f7 #15: OPTIONS embeds the Playbook schema so
+        callers don't need to read the source to know what shape to send."""
+        parsed = asyncio.run(orchestrate(ctx=self._ctx(), op="OPTIONS"))
+        self.assertTrue(parsed["ok"])
+        self.assertEqual(parsed["method"], "OPTIONS")
+        data = parsed["data"]
+        self.assertEqual(data["tool"], "orchestrate")
+        self.assertEqual(data["method"], "POST")
+        self.assertEqual(data["definer"], "INVOKE")
+        # The schema is JSON Schema (Pydantic-emitted).
+        schema = data["playbook_schema"]
+        self.assertIn("properties", schema)
+        # The Playbook model has these top-level fields.
+        self.assertEqual(
+            set(schema["properties"].keys()),
+            {"layout", "commands", "cascade", "reads"},
+        )
+
     def test_happy_path_empty_playbook(self):
         parsed = asyncio.run(orchestrate(
             ctx=self._ctx(),

--- a/tests/test_memory_dispatch.py
+++ b/tests/test_memory_dispatch.py
@@ -711,5 +711,81 @@ class TestLegacyOpInterop(unittest.TestCase):
         self.assertEqual(parsed["method"], "DELETE")
 
 
+class TestNamespaceStringCoercion(unittest.TestCase):
+    """Regression for fb-20260424-157473f7 #5: accept dotted/slashed strings.
+
+    Callers used to be forced to pass `namespace=["a","b","c"]`. They can
+    now pass `"a/b/c"` or `"a.b.c"` and get the same result.
+    """
+
+    def _retrieve_with_namespace(self, namespace_arg):
+        store = MagicMock()
+        store.retrieve = AsyncMock(return_value=None)
+        parsed = asyncio.run(memory(
+            ctx=_make_ctx(memory_store=store),
+            op="retrieve",
+            namespace=namespace_arg,
+            key="k",
+        ))
+        return store.retrieve.call_args, parsed
+
+    def test_slash_separated_string_coerces_to_list(self):
+        call_args, parsed = self._retrieve_with_namespace("proj/agent/scratch")
+        # memory_store.retrieve is called with tuple(namespace).
+        ns_tuple = call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj", "agent", "scratch"))
+
+    def test_dot_separated_string_coerces_to_list(self):
+        call_args, parsed = self._retrieve_with_namespace("proj.agent.scratch")
+        ns_tuple = call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj", "agent", "scratch"))
+
+    def test_single_segment_string_yields_one_element_list(self):
+        call_args, parsed = self._retrieve_with_namespace("proj")
+        ns_tuple = call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj",))
+
+    def test_existing_list_input_still_works(self):
+        call_args, parsed = self._retrieve_with_namespace(["proj", "agent"])
+        ns_tuple = call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj", "agent"))
+
+    def test_mixed_separators_split_on_any(self):
+        # Edge case: caller used a mix. Accept both since we're being lenient.
+        call_args, parsed = self._retrieve_with_namespace("proj/sub.scratch")
+        ns_tuple = call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj", "sub", "scratch"))
+
+    def test_empty_string_is_an_error(self):
+        # Empty string isn't a valid namespace; coerce should not silently
+        # produce an empty list — the dispatcher's `if not namespace` check
+        # would then mistakenly flag missing-param.
+        store = MagicMock()
+        store.retrieve = AsyncMock(return_value=None)
+        parsed = asyncio.run(memory(
+            ctx=_make_ctx(memory_store=store),
+            op="retrieve",
+            namespace="",
+            key="k",
+        ))
+        self.assertFalse(parsed["ok"])
+
+    def test_store_accepts_string_namespace(self):
+        # Coercion must apply on every entry that takes a namespace.
+        store = MagicMock()
+        store.store = AsyncMock(return_value=None)
+        parsed = asyncio.run(memory(
+            ctx=_make_ctx(memory_store=store),
+            op="store",
+            namespace="proj/agent",
+            key="k",
+            value="v",
+        ))
+        self.assertTrue(parsed["ok"])
+        # store.store(namespace_tuple, key, value, metadata=...)
+        ns_tuple = store.store.call_args.args[0]
+        self.assertEqual(ns_tuple, ("proj", "agent"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Paired tiny UX fixes from feedback **fb-20260424-157473f7**.

## #5 — memory namespace as string

Before: `memory(op="GET", namespace=["project", "agent"], key="...")` only.

After: any of these work:
- `namespace=["project", "agent"]` (legacy)
- `namespace="project/agent"`
- `namespace="project.agent"`
- mixed: `namespace="project/sub.scratch"`

Empty strings and separator-only inputs return a structured `INVALID_PARAM` error with a hint instead of silently coercing to `[]`.

`_coerce_namespace(value)` splits on `[./]` at the tool entry, then feeds the resulting list into the existing `_validate_namespace` and downstream handlers — no handler logic changes.

OPTIONS schema for GET now advertises `"namespace?=[str] | str  (accepts dotted 'a.b.c' or slashed 'a/b/c')"`.

## #15 — orchestrate Playbook schema in OPTIONS

Before: callers had to read `core/models.py::Playbook` source to know what shape to send.

After: `orchestrate(op="OPTIONS")` returns:

```json
{
  "method": "OPTIONS",
  "ok": true,
  "data": {
    "tool": "orchestrate",
    "kind": "action",
    "method": "POST",
    "definer": "INVOKE",
    "aliases": ["invoke", "execute", "run", "orchestrate"],
    "params": {"playbook": "Playbook (see playbook_schema below)"},
    "playbook_schema": { /* JSON Schema for Playbook */ },
    "description": "..."
  }
}
```

`playbook_schema` is emitted via `Playbook.model_json_schema()` — fully typed: `layout` (CreateSessionsRequest), `commands` (PlaybookCommand[]), `cascade` (CascadeMessageRequest), `reads` (ReadSessionsRequest). Drop into a JSON-Schema-aware client to validate playbooks before sending.

## Tests

- `tests/test_memory_dispatch.py::TestNamespaceStringCoercion` — 7 cases (/, ., mixed, single-segment, list passthrough, empty error, store path).
- `tests/test_action_tools.py::test_options_returns_playbook_schema` — locks OPTIONS shape and the four top-level Playbook fields.

```
$ python -m unittest tests.test_memory_dispatch tests.test_action_tools tests.test_envelope tests.test_dispatcher tests.test_sessions tests.test_errors
Ran 206 tests in 0.093s
OK
```

## Next up

PR-B (subscribe lifecycle: id-on-create, list, cancel + cross-agent pattern feed via notification queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)