### PR TITLE
fix: address post-merge review on PRs #124 and #125

### DIFF
--- a/core/flows.py
+++ b/core/flows.py
@@ -205,6 +205,7 @@ class _PatternSubscription:
     target_session_id: Optional[str] = None
     target_agent: Optional[str] = None
     notify_agent: Optional[str] = None
+    notify_level: Optional[str] = None
     created_at: datetime = field(default_factory=datetime.now)
 
 
@@ -569,6 +570,7 @@ class EventBus:
         target_session_id: Optional[str] = None,
         target_agent: Optional[str] = None,
         notify_agent: Optional[str] = None,
+        notify_level: Optional[str] = None,
     ) -> str:
         """Subscribe to terminal output matching a pattern.
 
@@ -620,6 +622,7 @@ class EventBus:
             target_session_id=target_session_id,
             target_agent=target_agent,
             notify_agent=notify_agent,
+            notify_level=notify_level,
         )
         self._logger.info(f"Registered pattern subscription: {pattern} (id={subscription_id})")
         return subscription_id
@@ -642,6 +645,7 @@ class EventBus:
                 "target_session_id": sub.target_session_id,
                 "target_agent": sub.target_agent,
                 "notify_agent": sub.notify_agent,
+                "notify_level": sub.notify_level,
                 "created_at": sub.created_at.isoformat(),
             }
             for sub in self._pattern_subscriptions.values()

--- a/core/models.py
+++ b/core/models.py
@@ -919,6 +919,10 @@ class PatternSubscriptionResponse(BaseModel):
         default=None,
         description="Agent that receives a notification when the pattern matches.",
     )
+    notify_level: Optional[str] = Field(
+        default=None,
+        description="Notification level used when pushing to notify_agent (e.g. 'info', 'warning').",
+    )
 
 
 # ============================================================================

--- a/iterm_mcpy/tools/memory.py
+++ b/iterm_mcpy/tools/memory.py
@@ -29,6 +29,7 @@ from mcp.server.fastmcp import Context
 
 from iterm_mcpy.dispatcher import MethodDispatcher
 from iterm_mcpy.errors import ErrorCode, ToolError
+from iterm_mcpy.responses import err_envelope
 
 
 # Namespace strings can use either "/" or "." as a separator, or both.
@@ -60,6 +61,7 @@ def _coerce_namespace(value: Union[str, List[str], None]) -> Optional[List[str]]
             raise ToolError(
                 ErrorCode.INVALID_PARAM,
                 f"namespace string {value!r} contained only separators",
+                hint="pass a non-empty string like 'project/agent' or a list ['project','agent']",
             )
         return parts
     raise ToolError(
@@ -514,7 +516,6 @@ async def memory(
     # Accept namespace as a list, dotted string, or slashed string.
     # Coercion errors surface as a structured envelope rather than a
     # late ValueError from _validate_namespace.
-    from iterm_mcpy.responses import err_envelope
     try:
         namespace = _coerce_namespace(namespace)
     except ToolError as e:

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -480,6 +480,7 @@ async def _start_monitoring_core(
     event_bus: Optional[EventBus],
     logger,
     *,
+    agent_registry=None,
     enable_event_bus: bool = True,
     settle_delay: float = 2.0,
 ) -> bool:
@@ -495,6 +496,11 @@ async def _start_monitoring_core(
             enable_event_bus is False), monitoring still starts but no
             callback is attached — output is not published to the bus.
         logger: Logger for debug/info/error messages.
+        agent_registry: Optional registry used to resolve session→agent
+            inside the event-bus callback so cross-agent pattern
+            subscriptions (`target_agent`) can fire. When None,
+            `target_agent` filters always reject (caller can still use
+            `target_session_id` for per-session filtering).
         enable_event_bus: Whether to attach a callback that routes output to
             the EventBus (for pattern subscriptions). Default True. Silently
             skipped when event_bus is None.
@@ -510,9 +516,19 @@ async def _start_monitoring_core(
         async def event_bus_callback(output: str) -> None:
             """Route terminal output to EventBus for pattern matching."""
             try:
+                # Resolve session→agent at delivery time so subscriptions
+                # filtered by target_agent can fire. Resolution must be
+                # per-call (not per-session) because agents can detach
+                # and reattach.
+                agent_name = None
+                if agent_registry is not None:
+                    agent = agent_registry.get_agent_by_session(session.id)
+                    if agent is not None:
+                        agent_name = agent.name
                 triggered = await event_bus.process_terminal_output(
                     session_id=session.id,
                     output=output,
+                    agent_name=agent_name,
                 )
                 if triggered:
                     logger.debug(f"Pattern subscriptions triggered: {triggered}")
@@ -1503,6 +1519,7 @@ class SessionsDispatcher(MethodDispatcher):
                 session,
                 event_bus,
                 logger,
+                agent_registry=agent_registry,
                 enable_event_bus=enable_event_bus,
                 # Settle delay mostly matters for the legacy blocking tool;
                 # sessions returns the result structurally so skip the wait.

--- a/iterm_mcpy/tools/subscribe.py
+++ b/iterm_mcpy/tools/subscribe.py
@@ -177,6 +177,8 @@ async def subscribe(
             target_session_id=target_session_id,
             target_agent=target_agent,
             notify_agent=notify_agent,
+            # Only persist notify_level when it actually drives behavior.
+            notify_level=notify_level if notify_agent else None,
         )
         result = PatternSubscriptionResponse(
             subscription_id=sub_id,
@@ -185,6 +187,7 @@ async def subscribe(
             target_session_id=target_session_id,
             target_agent=target_agent,
             notify_agent=notify_agent,
+            notify_level=notify_level if notify_agent else None,
         )
         logger.info(
             "subscribe: pattern=%r event=%r target_session=%r target_agent=%r notify=%r id=%s",

--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -535,6 +535,7 @@ class TestSubscribeV2(unittest.TestCase):
             target_session_id="s-other",
             target_agent="alice",
             notify_agent="watcher",
+            notify_level="warning",
         ))
         self.assertTrue(parsed["ok"])
         # Verify the event_bus call carries all the filter + notify metadata.
@@ -543,9 +544,28 @@ class TestSubscribeV2(unittest.TestCase):
         self.assertEqual(kwargs["target_session_id"], "s-other")
         self.assertEqual(kwargs["target_agent"], "alice")
         self.assertEqual(kwargs["notify_agent"], "watcher")
-        # Response echoes the metadata.
+        # notify_level round-trips when notify_agent is set (review fixup).
+        self.assertEqual(kwargs["notify_level"], "warning")
+        # Response echoes the full metadata.
         self.assertEqual(parsed["data"]["target_agent"], "alice")
         self.assertEqual(parsed["data"]["notify_agent"], "watcher")
+        self.assertEqual(parsed["data"]["notify_level"], "warning")
+
+    def test_notify_level_omitted_when_no_notify_agent(self):
+        """notify_level without notify_agent is meaningless — drop it from
+        persisted state and the response so list output doesn't lie."""
+        event_bus = MagicMock()
+        event_bus.subscribe_to_pattern = AsyncMock(return_value="sub-x")
+        parsed = asyncio.run(subscribe(
+            ctx=_make_ctx(event_bus=event_bus),
+            op="subscribe",
+            pattern="x",
+            notify_level="error",  # no notify_agent
+        ))
+        self.assertTrue(parsed["ok"])
+        kwargs = event_bus.subscribe_to_pattern.await_args.kwargs
+        self.assertIsNone(kwargs["notify_level"])
+        self.assertIsNone(parsed["data"].get("notify_level"))
 
     def test_match_callback_pushes_notification_to_subscribing_agent(self):
         """The on_match closure should add a notification to the subscribing


### PR DESCRIPTION
Two reviewer threads, four fixes.

## Memory tool (PR #124 follow-up — Copilot)

- \`_coerce_namespace\`'s separator-only error now includes a \`hint\`, matching the empty-string branch for consistency.
- \`err_envelope\` import lifted to module scope from inside \`memory()\`, matching every other tool module.

## Subscribe lifecycle (PR #125 follow-up — Codex P1 + Copilot)

### HIGH/P1: target_agent was dead code

The production call site (\`_start_monitoring_core\`'s \`event_bus_callback\` at \`sessions.py:510\`) invoked \`process_terminal_output\` without passing \`agent_name\`. Inside the bus, every subscription with \`target_agent\` set then took the \`agent_name is None\` early-return branch, so cross-agent filtering **never fired**. The whole feature shipped in PR #125 was non-functional in production.

Fix: threaded \`agent_registry\` into \`_start_monitoring_core\` as a kwarg. The callback now does:

\`\`\`python
agent_name = None
if agent_registry is not None:
    agent = agent_registry.get_agent_by_session(session.id)
    if agent is not None:
        agent_name = agent.name
triggered = await event_bus.process_terminal_output(
    session_id=session.id, output=output, agent_name=agent_name,
)
\`\`\`

Resolution is per-call, not per-session, because agents can detach and reattach. \`agent_registry\` is optional (kwarg, defaults to None) so the few legacy callers that don't need cross-agent filtering aren't disturbed.

### notify_level wasn't observable

\`notify_level\` was accepted by the subscribe tool and used at delivery time, but **not** stored on the subscription record nor echoed in the response or list output. Reviewers correctly flagged this as a contract gap — clients couldn't round-trip or audit it.

Fix: added \`notify_level\` to:

- \`_PatternSubscription\` dataclass (\`core/flows.py\`)
- \`EventBus.subscribe_to_pattern(...)\` kwargs
- \`list_pattern_subscriptions()\` output
- \`PatternSubscriptionResponse\` (\`core/models.py\`)

The level only persists when \`notify_agent\` is also set — meaningless without one. \`subscribe.py\` enforces this with \`notify_level if notify_agent else None\` at the persistence + response sites.

## Tests

- Extended \`test_post_passes_cross_agent_filters_to_event_bus\` to assert \`notify_level\` round-trips into both \`event_bus.subscribe_to_pattern\` kwargs and the response data.
- New \`test_notify_level_omitted_when_no_notify_agent\` — guards the "drop level when no agent" rule so list output doesn't lie.

\`\`\`
$ python -m unittest tests.test_action_tools.TestSubscribeV2 tests.test_memory_dispatch.TestNamespaceStringCoercion tests.test_envelope tests.test_dispatcher tests.test_sessions tests.test_errors
Ran 137 tests in 0.032s
OK
\`\`\`

Replies posted on the original review comment threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)