### PR TITLE
test(orchestrate): regression for fb-20260410-7196da03 lifespan-manager threading

### DIFF
--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -228,14 +228,21 @@ class TestOrchestrateV2(unittest.TestCase):
         bound. Lock in the contract: ``tag_lock_manager`` and
         ``notification_manager`` from the lifespan must be threaded into
         ``execute_write_request`` for every command in the playbook.
+
+        We exercise a multi-command playbook and capture the kwargs of
+        each ``execute_write_request`` call separately so a regression
+        that only threads the managers on the first iteration (or only
+        on the last) would still fail.
         """
         from core.models import WriteToSessionsResponse
 
-        captured = {}
+        calls: list[dict] = []
 
         async def fake_write(req, term, reg, log, lock_manager=None, notification_manager=None):
-            captured["lock_manager"] = lock_manager
-            captured["notification_manager"] = notification_manager
+            calls.append({
+                "lock_manager": lock_manager,
+                "notification_manager": notification_manager,
+            })
             return WriteToSessionsResponse(
                 results=[], sent_count=1, skipped_count=0, error_count=0,
             )
@@ -249,6 +256,14 @@ class TestOrchestrateV2(unittest.TestCase):
             notification_manager=sentinel_notify,
         )
 
+        def _cmd(name: str) -> dict:
+            return {
+                "name": name,
+                "messages": [
+                    {"content": f"echo {name}", "targets": [{"agent": "alice"}]},
+                ],
+            }
+
         with patch(
             "iterm_mcpy.tools.orchestrate.execute_write_request",
             side_effect=fake_write,
@@ -256,23 +271,19 @@ class TestOrchestrateV2(unittest.TestCase):
             parsed = asyncio.run(orchestrate(
                 ctx=ctx,
                 op="POST", definer="INVOKE",
-                playbook={
-                    "commands": [
-                        {
-                            "name": "step1",
-                            "messages": [
-                                {
-                                    "content": "echo hi",
-                                    "targets": [{"agent": "alice"}],
-                                },
-                            ],
-                        },
-                    ],
-                },
+                playbook={"commands": [_cmd("step1"), _cmd("step2")]},
             ))
         self.assertTrue(parsed["ok"])
-        self.assertIs(captured["lock_manager"], sentinel_lock)
-        self.assertIs(captured["notification_manager"], sentinel_notify)
+        self.assertEqual(len(calls), 2)
+        for i, call in enumerate(calls):
+            self.assertIs(
+                call["lock_manager"], sentinel_lock,
+                f"command #{i} did not receive lifespan tag_lock_manager",
+            )
+            self.assertIs(
+                call["notification_manager"], sentinel_notify,
+                f"command #{i} did not receive lifespan notification_manager",
+            )
 
 
 # ========================================================================= #

--- a/tests/test_action_tools.py
+++ b/tests/test_action_tools.py
@@ -220,6 +220,60 @@ class TestOrchestrateV2(unittest.TestCase):
         self.assertFalse(parsed["ok"])
         self.assertIn("playbook", parsed["error"]["message"].lower())
 
+    def test_lifespan_managers_threaded_into_write(self):
+        """Regression for fb-20260410-7196da03 / PR #113.
+
+        ``orchestrate`` originally raised ``NameError: name 'lock_manager'
+        is not defined`` because it forwarded a variable that was never
+        bound. Lock in the contract: ``tag_lock_manager`` and
+        ``notification_manager`` from the lifespan must be threaded into
+        ``execute_write_request`` for every command in the playbook.
+        """
+        from core.models import WriteToSessionsResponse
+
+        captured = {}
+
+        async def fake_write(req, term, reg, log, lock_manager=None, notification_manager=None):
+            captured["lock_manager"] = lock_manager
+            captured["notification_manager"] = notification_manager
+            return WriteToSessionsResponse(
+                results=[], sent_count=1, skipped_count=0, error_count=0,
+            )
+
+        sentinel_lock = MagicMock(name="tag_lock_manager")
+        sentinel_notify = MagicMock(name="notification_manager")
+        ctx = _make_ctx(
+            layout_manager=MagicMock(),
+            profile_manager=MagicMock(),
+            tag_lock_manager=sentinel_lock,
+            notification_manager=sentinel_notify,
+        )
+
+        with patch(
+            "iterm_mcpy.tools.orchestrate.execute_write_request",
+            side_effect=fake_write,
+        ):
+            parsed = asyncio.run(orchestrate(
+                ctx=ctx,
+                op="POST", definer="INVOKE",
+                playbook={
+                    "commands": [
+                        {
+                            "name": "step1",
+                            "messages": [
+                                {
+                                    "content": "echo hi",
+                                    "targets": [{"agent": "alice"}],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ))
+        self.assertTrue(parsed["ok"])
+        self.assertIs(captured["lock_manager"], sentinel_lock)
+        self.assertIs(captured["notification_manager"], sentinel_notify)
+
 
 # ========================================================================= #
 # delegate — POST+INVOKE (target=task|plan)                              #


### PR DESCRIPTION
## Summary
- Adds an explicit regression test (`TestOrchestrateV2::test_lifespan_managers_threaded_into_write`) that asserts `tag_lock_manager` and `notification_manager` from the MCP lifespan are threaded into `execute_write_request` for every command in a playbook.
- Closes the coverage gap for [fb-20260410-7196da03](#) / PR #113. The original bug was a `NameError: name 'lock_manager' is not defined` — fixed long ago, but no test pinned the contract that the sentinels actually reach `execute_write_request`. A silent regression (dropped lookup line, wrong lifespan key, default of `None`) would not have been caught by the existing happy-path tests because they don't inspect the kwargs the helper is invoked with.

## Test plan
- [x] `python -m unittest tests.test_action_tools.TestOrchestrateV2 -v` — 7/7 pass (including the new test and the upstream-added `test_options_returns_playbook_schema`).
- [x] `python -m unittest tests.test_action_tools` — 45/45 pass.
- [x] Compatible with the post-#122 native-dict envelope and post-#121 structured `{code, message, hint}` error shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)