### PR TITLE
chore: gitignore .claude-runner.sh and .claude-prompt.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,10 @@ ipython_config.py
 .claude/*
 !.claude/commands/
 
+# Claude background-runner scratch artifacts (per-worktree, never committed)
+.claude-runner.sh
+.claude-prompt.txt
+
 # Local development
 Untitled*.ipynb
 **.worktrees/


### PR DESCRIPTION
## Summary
- Adds `.claude-runner.sh` and `.claude-prompt.txt` to `.gitignore`. These are per-worktree scratch files written by the background-runner harness; they show up as untracked entries (or unstaged deletions of orphaned tracked copies in stale issue-NN branches) in `git status` across most long-lived worktrees.
- Pure noise reduction. No tracked files affected.

## Test plan
- [x] Confirmed neither file is currently tracked on `main` (`git ls-files | grep claude-...` returns nothing).
- [x] After applying, `git status` no longer surfaces these paths in any new worktree where the runner has dropped them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)