### PR TITLE
feat: addressed durable inter-agent message bus (Phase 1)

### DIFF
--- a/core/bus.py
+++ b/core/bus.py
@@ -1,0 +1,558 @@
+"""Shared, addressed, durable message bus for the iTerm MCP daemon.
+
+Phase 1 of the agent comms tightening plan (2026-06-12).  Provides:
+
+- **Addressed delivery** to ``agent:<name>``, ``team:<name>``, ``broadcast``,
+  or any arbitrary recipient string.
+- **Durable inbox** backed by SQLite — messages survive daemon restarts until
+  they are explicitly acknowledged.
+- **Long-poll receive** that blocks (async, non-blocking to the event loop)
+  until a message arrives or a timeout elapses.
+- **Ack / cursor advancement** so readers have a stable, per-recipient read
+  offset.
+
+This bus is a *complement* to the existing ``core/messaging.py``
+``MessageRouter`` (which handles in-process typed handler dispatch).  The bus
+is what MCP tool callers interact with for durable, cross-agent delivery.
+
+Future phases (not built here):
+  - Phase 2: route ``messages`` tool through the bus; daemon delivery worker.
+  - Phase 3: external ingress/egress bridge (Claude Code Channels adapter).
+  - Phase 4: replace long-poll with SSE/WebSocket push.
+
+The ``sender`` / ``recipient`` address scheme uses ``agent:<name>``,
+``team:<name>``, ``broadcast``, and is extensible to ``external:<session_id>``
+without schema changes.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("iterm-mcp-bus")
+
+
+# ---------------------------------------------------------------------------
+# Envelope
+# ---------------------------------------------------------------------------
+
+
+class BusEnvelope(BaseModel):
+    """Structured message envelope carried by the bus.
+
+    The bus writes ``created_at`` and ``rowid`` on enqueue; callers should
+    not set them directly.
+
+    Attributes:
+        message_id: UUID4 string, unique per message.
+        sender: Originator address, e.g. ``agent:builder`` or ``system``.
+        recipient: Canonical recipient after fan-out, e.g. ``agent:alice``.
+        kind: Semantic category — ``instruction``, ``notification``,
+            ``event``, ``reply``, or any caller-defined string.
+        body: The message payload.  Must be JSON-serializable.
+        correlation_id: Optional ID tying a reply back to a request.
+        created_at: UTC timestamp set by the bus on enqueue.
+        ttl_seconds: Seconds before the message expires.  ``None`` = never.
+        attempts: Delivery attempt counter (incremented by future push paths).
+        rowid: SQLite rowid assigned on insert (used as the durable cursor).
+    """
+
+    message_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    sender: str
+    recipient: str
+    kind: str = "instruction"
+    body: Any = None
+    correlation_id: Optional[str] = None
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    ttl_seconds: Optional[int] = None
+    attempts: int = 0
+    rowid: Optional[int] = None  # set after INSERT
+
+
+# ---------------------------------------------------------------------------
+# AgentMessageBus
+# ---------------------------------------------------------------------------
+
+
+class AgentMessageBus:
+    """Process-global, durable agent message bus backed by SQLite.
+
+    One instance lives in ``AppContext.message_bus``; all daemon clients share
+    it.  The SQLite database is opened once and kept open for the daemon's
+    lifetime.
+
+    Args:
+        db_path: Path to the SQLite database file.  Defaults to the
+            ``ITERM_MCP_BUS_DB_PATH`` env var, or
+            ``~/.iterm-mcp/bus.db``.
+    """
+
+    def __init__(self, db_path: Optional[str] = None):
+        if db_path is None:
+            db_path = os.environ.get(
+                "ITERM_MCP_BUS_DB_PATH",
+                os.path.expanduser("~/.iterm-mcp/bus.db"),
+            )
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn: sqlite3.Connection = sqlite3.connect(
+            str(self.db_path), check_same_thread=False
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._lock = asyncio.Lock()
+
+        # Per-recipient asyncio.Event used for long-poll wakeup.
+        # Event key is the exact recipient string stored in the DB.
+        self._wakeup_events: Dict[str, asyncio.Event] = {}
+        # A single "broadcast" event wakes all "broadcast" recipients.
+        self._broadcast_event: asyncio.Event = asyncio.Event()
+
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        """Initialize the SQLite schema (idempotent)."""
+        c = self._conn
+        c.executescript("""
+            PRAGMA journal_mode=WAL;
+
+            CREATE TABLE IF NOT EXISTS bus_messages (
+                rowid       INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id  TEXT NOT NULL,
+                recipient   TEXT NOT NULL,
+                sender      TEXT NOT NULL,
+                kind        TEXT NOT NULL,
+                body        TEXT NOT NULL,
+                correlation_id TEXT,
+                created_at  TEXT NOT NULL,
+                ttl_seconds INTEGER,
+                attempts    INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_bus_recipient
+                ON bus_messages(recipient, rowid);
+
+            CREATE TABLE IF NOT EXISTS bus_cursors (
+                recipient   TEXT PRIMARY KEY,
+                acked_rowid INTEGER NOT NULL DEFAULT 0,
+                updated_at  TEXT NOT NULL
+            );
+        """)
+        c.commit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _wakeup_event_for(self, recipient: str) -> asyncio.Event:
+        """Get or create a wakeup event for a recipient."""
+        if recipient not in self._wakeup_events:
+            self._wakeup_events[recipient] = asyncio.Event()
+        return self._wakeup_events[recipient]
+
+    def _notify_recipient(self, recipient: str) -> None:
+        """Set the wakeup event for a recipient so long-poll unblocks."""
+        if recipient in self._wakeup_events:
+            self._wakeup_events[recipient].set()
+        if recipient == "broadcast":
+            self._broadcast_event.set()
+
+    def _resolve_fan_out_recipients(
+        self,
+        recipient: str,
+        agent_registry=None,
+    ) -> List[str]:
+        """Expand ``team:`` and ``broadcast`` addresses into individual inboxes.
+
+        Args:
+            recipient: Raw recipient address from the caller.
+            agent_registry: Optional ``AgentRegistry`` instance for lookups.
+
+        Returns:
+            List of canonical recipient strings to write inbox rows for.
+        """
+        if recipient.startswith("agent:"):
+            return [recipient]
+
+        if recipient == "broadcast":
+            if agent_registry is None:
+                return ["broadcast"]
+            agents = agent_registry.list_agents()
+            if not agents:
+                return ["broadcast"]
+            # Fan out to each registered agent AND keep a "broadcast" row for
+            # consumers that subscribe without a specific name.
+            return [f"agent:{a.name}" for a in agents] + ["broadcast"]
+
+        if recipient.startswith("team:"):
+            team_name = recipient[len("team:"):]
+            if agent_registry is None:
+                # Can't resolve; fall back to the team address itself so
+                # callers polling "team:<name>" can still receive.
+                return [recipient]
+            members = agent_registry.list_agents(team=team_name)
+            if not members:
+                return [recipient]
+            return [f"agent:{a.name}" for a in members]
+
+        # Arbitrary address (e.g. "system", "external:...")
+        return [recipient]
+
+    def _insert_envelope(
+        self,
+        envelope: BusEnvelope,
+    ) -> int:
+        """Write one envelope row to the DB. Returns the assigned rowid."""
+        body_json = json.dumps(
+            envelope.body, default=str
+        ) if not isinstance(envelope.body, str) else envelope.body
+        cursor = self._conn.execute(
+            """
+            INSERT INTO bus_messages
+                (message_id, recipient, sender, kind, body,
+                 correlation_id, created_at, ttl_seconds, attempts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                envelope.message_id,
+                envelope.recipient,
+                envelope.sender,
+                envelope.kind,
+                body_json,
+                envelope.correlation_id,
+                envelope.created_at.isoformat(),
+                envelope.ttl_seconds,
+                envelope.attempts,
+            ),
+        )
+        self._conn.commit()
+        return cursor.lastrowid
+
+    def _get_cursor(self, recipient: str) -> int:
+        """Return the current acked_rowid for a recipient (0 if never acked)."""
+        row = self._conn.execute(
+            "SELECT acked_rowid FROM bus_cursors WHERE recipient = ?",
+            (recipient,),
+        ).fetchone()
+        return row["acked_rowid"] if row else 0
+
+    def _set_cursor(self, recipient: str, acked_rowid: int) -> None:
+        """Upsert the durable cursor for a recipient."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO bus_cursors (recipient, acked_rowid, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(recipient) DO UPDATE
+                SET acked_rowid = excluded.acked_rowid,
+                    updated_at  = excluded.updated_at
+            """,
+            (recipient, acked_rowid, now),
+        )
+        self._conn.commit()
+
+    def _query_messages(
+        self,
+        recipient: str,
+        since_rowid: int,
+        kinds: Optional[List[str]],
+        limit: int,
+        now_iso: str,
+    ) -> List[sqlite3.Row]:
+        """Fetch unread, non-expired messages for a recipient."""
+        params: List[Any] = [recipient, since_rowid]
+
+        kind_clause = ""
+        if kinds:
+            placeholders = ",".join("?" * len(kinds))
+            kind_clause = f"AND kind IN ({placeholders})"
+            params.extend(kinds)
+
+        # TTL filter: include rows where ttl_seconds IS NULL, or where the
+        # message is not yet expired.  Expiry = created_at + ttl_seconds.
+        # We compute expiry in Python-free SQL using datetime arithmetic:
+        # datetime(created_at, '+N seconds') > datetime('now').
+        params.append(now_iso)
+
+        rows = self._conn.execute(
+            f"""
+            SELECT rowid, message_id, recipient, sender, kind, body,
+                   correlation_id, created_at, ttl_seconds, attempts
+            FROM bus_messages
+            WHERE recipient = ?
+              AND rowid > ?
+              {kind_clause}
+              AND (
+                  ttl_seconds IS NULL
+                  OR datetime(created_at, '+' || ttl_seconds || ' seconds') > ?
+              )
+            ORDER BY rowid ASC
+            LIMIT ?
+            """,
+            params + [limit],
+        ).fetchall()
+        return rows
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row) -> dict:
+        """Convert a DB row to a plain dict (BusEnvelope-compatible)."""
+        try:
+            body = json.loads(row["body"])
+        except (json.JSONDecodeError, TypeError):
+            body = row["body"]
+        return {
+            "rowid": row["rowid"],
+            "message_id": row["message_id"],
+            "recipient": row["recipient"],
+            "sender": row["sender"],
+            "kind": row["kind"],
+            "body": body,
+            "correlation_id": row["correlation_id"],
+            "created_at": row["created_at"],
+            "ttl_seconds": row["ttl_seconds"],
+            "attempts": row["attempts"],
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        sender: str,
+        recipient: str,
+        kind: str = "instruction",
+        body: Any = None,
+        correlation_id: Optional[str] = None,
+        ttl_seconds: Optional[int] = None,
+        agent_registry=None,
+    ) -> Dict[str, Any]:
+        """Enqueue a message to one or more inboxes.
+
+        Fan-out:
+          - ``agent:<name>`` → one inbox row.
+          - ``team:<name>`` → one row per team member.
+          - ``broadcast`` → one row per registered agent + a ``broadcast`` row.
+          - Any other string → one row for that literal recipient.
+
+        Args:
+            sender: Originator address (``agent:<name>`` or arbitrary).
+            recipient: Destination address.
+            kind: Semantic category (``instruction``, ``notification``, etc.).
+            body: JSON-serializable payload.
+            correlation_id: Optional request-correlation token.
+            ttl_seconds: Expiry in seconds.  ``None`` = never expires.
+            agent_registry: Optional ``AgentRegistry`` for fan-out resolution.
+
+        Returns:
+            ``{message_id, accepted_recipients: [...]}``.
+        """
+        message_id = str(uuid.uuid4())
+        created_at = datetime.now(timezone.utc)
+
+        recipients = self._resolve_fan_out_recipients(recipient, agent_registry)
+        accepted: List[str] = []
+
+        async with self._lock:
+            for r in recipients:
+                env = BusEnvelope(
+                    message_id=message_id,
+                    sender=sender,
+                    recipient=r,
+                    kind=kind,
+                    body=body,
+                    correlation_id=correlation_id,
+                    created_at=created_at,
+                    ttl_seconds=ttl_seconds,
+                )
+                try:
+                    self._insert_envelope(env)
+                    accepted.append(r)
+                    logger.debug(
+                        "bus.send: %s → %s kind=%s mid=%s",
+                        sender, r, kind, message_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "bus.send: failed to insert envelope for %s", r
+                    )
+
+        # Notify outside the lock to avoid holding it during event dispatch.
+        for r in accepted:
+            self._notify_recipient(r)
+
+        return {"message_id": message_id, "accepted_recipients": accepted}
+
+    async def receive(
+        self,
+        recipient: str,
+        wait_up_to: int = 0,
+        since_cursor: Optional[int] = None,
+        kinds: Optional[List[str]] = None,
+        limit: int = 50,
+    ) -> Dict[str, Any]:
+        """Return pending messages for a recipient, optionally long-polling.
+
+        Reads messages with ``rowid > cursor`` (durable cursor if
+        ``since_cursor`` is ``None``).  Does NOT advance the cursor
+        automatically — call :meth:`ack` to commit a read position.
+
+        Args:
+            recipient: The inbox to read, e.g. ``agent:alice``.
+            wait_up_to: Seconds to block waiting for a message.  0 = drain
+                and return immediately even if the inbox is empty.
+            since_cursor: Override the durable cursor; ``None`` uses the last
+                acked rowid from the DB.
+            kinds: Optional whitelist of ``kind`` values to return.
+            limit: Maximum messages per call (default 50).
+
+        Returns:
+            ``{messages: [...], next_cursor: int, has_more: bool}``
+            where ``next_cursor`` is the highest rowid returned (or the
+            current cursor if no messages were returned).
+        """
+        deadline = wait_up_to  # seconds remaining
+
+        async with self._lock:
+            start_cursor = (
+                since_cursor
+                if since_cursor is not None
+                else self._get_cursor(recipient)
+            )
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        async def _drain() -> List[sqlite3.Row]:
+            async with self._lock:
+                return self._query_messages(
+                    recipient, start_cursor, kinds, limit + 1, now_iso
+                )
+
+        rows = await _drain()
+
+        if not rows and deadline > 0:
+            # Long-poll: wait for a wakeup event or timeout.
+            event = self._wakeup_event_for(recipient)
+            try:
+                await asyncio.wait_for(event.wait(), timeout=deadline)
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                event.clear()
+            rows = await _drain()
+
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+
+        messages = [self._row_to_dict(r) for r in rows]
+        next_cursor = rows[-1]["rowid"] if rows else start_cursor
+
+        return {
+            "messages": messages,
+            "next_cursor": next_cursor,
+            "has_more": has_more,
+        }
+
+    async def ack(
+        self,
+        recipient: str,
+        up_to_cursor: int,
+    ) -> Dict[str, Any]:
+        """Advance the durable read cursor.
+
+        Only moves the cursor forward — passing a cursor lower than the
+        current position is a no-op (idempotent).
+
+        Args:
+            recipient: The inbox owner.
+            up_to_cursor: Rowid to acknowledge through (inclusive).
+
+        Returns:
+            ``{acked_through: int}``.
+        """
+        async with self._lock:
+            current = self._get_cursor(recipient)
+            new_cursor = max(current, up_to_cursor)
+            self._set_cursor(recipient, new_cursor)
+        return {"acked_through": new_cursor}
+
+    async def peek(
+        self,
+        recipient: str,
+        limit: int = 5,
+    ) -> Dict[str, Any]:
+        """Non-blocking drain.  Alias for ``receive(wait_up_to=0, limit=limit)``."""
+        return await self.receive(recipient, wait_up_to=0, limit=limit)
+
+    async def list_inboxes(self) -> List[Dict[str, Any]]:
+        """Return inbox depths and oldest unacked message age per recipient.
+
+        Returns:
+            List of ``{recipient, depth, oldest_unacked_age_seconds}``.
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+        async with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT
+                    m.recipient,
+                    COUNT(*) AS depth,
+                    MIN(m.rowid) AS oldest_rowid,
+                    MIN(m.created_at) AS oldest_created_at,
+                    COALESCE(c.acked_rowid, 0) AS acked_rowid
+                FROM bus_messages m
+                LEFT JOIN bus_cursors c ON c.recipient = m.recipient
+                WHERE m.rowid > COALESCE(c.acked_rowid, 0)
+                  AND (
+                      m.ttl_seconds IS NULL
+                      OR datetime(m.created_at,
+                             '+' || m.ttl_seconds || ' seconds') > ?
+                  )
+                GROUP BY m.recipient
+                ORDER BY m.recipient
+                """,
+                (now_iso,),
+            ).fetchall()
+
+        result = []
+        for row in rows:
+            age_seconds: Optional[float] = None
+            if row["oldest_created_at"]:
+                try:
+                    ts = datetime.fromisoformat(row["oldest_created_at"])
+                    age_seconds = (
+                        datetime.now(timezone.utc) - ts
+                    ).total_seconds()
+                except ValueError:
+                    pass
+            result.append({
+                "recipient": row["recipient"],
+                "depth": row["depth"],
+                "oldest_unacked_age_seconds": age_seconds,
+                "acked_rowid": row["acked_rowid"],
+            })
+        return result
+
+    def close(self) -> None:
+        """Close the SQLite connection.
+
+        Called by ``shutdown_app_context()`` at process exit.
+        """
+        try:
+            self._conn.close()
+        except Exception:
+            logger.exception("bus.close: error closing connection")

--- a/core/bus.py
+++ b/core/bus.py
@@ -285,7 +285,11 @@ class AgentMessageBus:
         # TTL filter: include rows where ttl_seconds IS NULL, or where the
         # message is not yet expired.  Expiry = created_at + ttl_seconds.
         # We compute expiry in Python-free SQL using datetime arithmetic:
-        # datetime(created_at, '+N seconds') > datetime('now').
+        # datetime(created_at, '+N seconds') > datetime(?).
+        # Both sides must be wrapped in datetime() so SQLite compares
+        # normalised "YYYY-MM-DD HH:MM:SS" strings rather than doing a raw
+        # lexical compare against the ISO-8601 string (which may include a
+        # timezone offset that confuses ordering).
         params.append(now_iso)
 
         rows = self._conn.execute(
@@ -298,7 +302,7 @@ class AgentMessageBus:
               {kind_clause}
               AND (
                   ttl_seconds IS NULL
-                  OR datetime(created_at, '+' || ttl_seconds || ' seconds') > ?
+                  OR datetime(created_at, '+' || ttl_seconds || ' seconds') > datetime(?)
               )
             ORDER BY rowid ASC
             LIMIT ?
@@ -483,6 +487,13 @@ class AgentMessageBus:
 
         Returns:
             ``{acked_through: int}``.
+
+        Note — Phase 1 unbounded growth:
+            Acknowledged and TTL-expired rows are **never deleted** from
+            ``bus_messages`` in Phase 1.  The table will grow indefinitely
+            under heavy traffic.  A future ``purge(before_rowid)`` /
+            TTL-sweep utility should be added (Phase 2) to reclaim space
+            and keep query performance stable.
         """
         async with self._lock:
             current = self._get_cursor(recipient)
@@ -520,7 +531,7 @@ class AgentMessageBus:
                   AND (
                       m.ttl_seconds IS NULL
                       OR datetime(m.created_at,
-                             '+' || m.ttl_seconds || ' seconds') > ?
+                             '+' || m.ttl_seconds || ' seconds') > datetime(?)
                   )
                 GROUP BY m.recipient
                 ORDER BY m.recipient

--- a/docs/superpowers/plans/2026-06-12-agent-bus-phase1.md
+++ b/docs/superpowers/plans/2026-06-12-agent-bus-phase1.md
@@ -1,0 +1,244 @@
+# Agent Message Bus — Phase 1 Implementation Plan
+
+**Date:** 2026-06-12
+**Status:** Implementation
+**Branch:** agent-af5ac01d7f0af1ffc (worktree from main)
+
+---
+
+## Overview
+
+Build a shared, addressed, durable, push/long-poll message bus that lives in
+the singleton daemon's process-global state. Phase 1 builds only the internal
+bus; external ingress/egress (Channels bridge) is deferred to Phase 3.
+
+The existing `core/messaging.py` `MessageRouter` handles typed
+request/response routing between Python objects. The new `AgentMessageBus`
+is a different, complementary primitive: it provides **addressed durable
+delivery to named recipients** (agent:, team:, broadcast), **long-poll
+receive**, and **ack/cursor advancement**. It does not replace
+`MessageRouter`; both coexist. The bus is what tool-layer consumers (MCP
+tool callers) interact with; `MessageRouter` remains a module-internal
+handler-dispatch mechanism.
+
+---
+
+## 1. Envelope Shape
+
+```python
+class BusEnvelope(BaseModel):
+    message_id: str          # UUID4
+    sender: str              # "agent:builder" | "system" | arbitrary
+    recipient: str           # "agent:<name>" | "team:<name>" | "broadcast"
+    kind: str                # "instruction" | "notification" | "event" | "reply" | str
+    body: Any                # str or JSON-serializable dict
+    correlation_id: Optional[str]   # ties replies to a request
+    created_at: datetime     # UTC, set by bus on enqueue
+    ttl_seconds: Optional[int]      # expiry; None = never expire
+    # delivery tracking (set by bus, not caller)
+    attempts: int = 0
+```
+
+Stored as JSON in SQLite `bus_messages` table. `body` is JSON-encoded text.
+
+---
+
+## 2. SQLite Schema
+
+Database: `~/.iterm-mcp/bus.db` (env override: `ITERM_MCP_BUS_DB_PATH`)
+
+```sql
+-- Inbox: one row per (recipient, message). recipient is the canonical
+-- addressee after fan-out (broadcast → one row per registered agent).
+CREATE TABLE IF NOT EXISTS bus_messages (
+    rowid       INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id  TEXT NOT NULL,
+    recipient   TEXT NOT NULL,        -- "agent:<name>" | "broadcast"
+    sender      TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    body        TEXT NOT NULL,        -- JSON
+    correlation_id TEXT,
+    created_at  TEXT NOT NULL,        -- ISO8601 UTC
+    ttl_seconds INTEGER,
+    attempts    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_bus_recipient
+    ON bus_messages(recipient, rowid);
+
+-- Durable read cursors: last acked rowid per recipient.
+CREATE TABLE IF NOT EXISTS bus_cursors (
+    recipient   TEXT PRIMARY KEY,
+    acked_rowid INTEGER NOT NULL DEFAULT 0,
+    updated_at  TEXT NOT NULL
+);
+```
+
+Cursor semantics: `acked_rowid` is the highest rowid the recipient has
+acknowledged. `receive` returns `WHERE rowid > acked_rowid` for the
+recipient, ordered by `rowid ASC`.
+
+---
+
+## 3. Bus Class API  (`core/bus.py`)
+
+```python
+class AgentMessageBus:
+    def __init__(self, db_path: Optional[str] = None): ...
+
+    # ---- write path ----
+    async def send(
+        self,
+        sender: str,
+        recipient: str,           # "agent:<name>" | "team:<name>" | "broadcast"
+        kind: str,
+        body: Any,
+        correlation_id: Optional[str] = None,
+        ttl_seconds: Optional[int] = None,
+        agent_registry=None,      # needed to fan out team: / broadcast
+    ) -> dict:
+        """Enqueue envelope(s). Returns {message_id, accepted_recipients: [...]}."""
+
+    # ---- read path ----
+    async def receive(
+        self,
+        recipient: str,           # "agent:<name>"
+        wait_up_to: int = 0,      # seconds; 0 = non-blocking drain
+        since_cursor: Optional[int] = None,  # rowid; None = use durable cursor
+        kinds: Optional[list[str]] = None,
+        limit: int = 50,
+    ) -> dict:
+        """Return {messages: [...BusEnvelope dicts], next_cursor: int, has_more: bool}.
+        Long-polls (asyncio.Event) if wait_up_to > 0 and inbox is empty.
+        Does NOT advance the durable cursor automatically."""
+
+    # ---- ack ----
+    async def ack(
+        self,
+        recipient: str,
+        up_to_cursor: int,        # rowid to ack through (inclusive)
+    ) -> dict:
+        """Advance the durable cursor. Returns {acked_through: int}."""
+
+    # ---- introspection ----
+    async def list_inboxes(self) -> list[dict]:
+        """Inbox depths + oldest unacked age per recipient."""
+
+    async def peek(
+        self,
+        recipient: str,
+        limit: int = 5,
+    ) -> dict:
+        """Non-blocking drain (same as receive(wait_up_to=0))."""
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+```
+
+### Fan-out rules
+- `agent:<name>` → one row for that agent.
+- `team:<name>` → one row per registered member of the team.
+- `broadcast` → one row per registered agent in the registry, plus one
+  `recipient="broadcast"` row for consumers with no specific name.
+  If `agent_registry` is None, only the `broadcast` row is written.
+
+### Long-poll implementation
+Each recipient gets one `asyncio.Event` in `_wakeup_events: dict[str, asyncio.Event]`.
+`send()` sets the event for each recipient it writes to (and for "broadcast").
+`receive()` waits on the event with `asyncio.wait_for(event.wait(), timeout)`.
+On wake, it clears the event before querying (race-safe: at worst, it re-polls
+once more and finds nothing, then waits again).
+
+---
+
+## 4. Tool Module: `iterm_mcpy/tools/bus.py`
+
+Action tool (not a collection dispatcher). Ops:
+
+| op                      | method+definer   | description |
+|-------------------------|------------------|-------------|
+| `"POST"` / `"send"`     | POST + SEND      | Enqueue a message |
+| `"GET"` / `"receive"`   | GET              | Long-poll drain inbox |
+| `"POST"` + `"TRIGGER"` / `"ack"` | POST + TRIGGER | Advance cursor |
+| `"GET"` + `target="status"` | GET         | Inbox stats |
+| `"GET"` + `target="peek"`   | GET         | Non-blocking drain |
+| `"OPTIONS"`             | OPTIONS          | Self-describe |
+
+Function signature:
+```python
+async def bus(
+    ctx: Context,
+    op: str = "GET",
+    definer: Optional[str] = None,
+    # send params
+    to: Optional[str] = None,
+    kind: str = "instruction",
+    body: Optional[Any] = None,
+    sender: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    # receive params
+    agent: Optional[str] = None,
+    wait_up_to: int = 0,
+    since_cursor: Optional[int] = None,
+    kinds: Optional[list[str]] = None,
+    limit: int = 50,
+    target: Optional[str] = None,    # "status" | "peek" | "ack"
+    # ack params
+    up_to_cursor: Optional[int] = None,
+) -> dict[str, Any]:
+```
+
+---
+
+## 5. AppContext Wiring
+
+In `iterm_mcpy/app_context.py`:
+1. Add `message_bus: Any = None` field to `AppContext` dataclass.
+2. In `_build_app_context()`: construct `AgentMessageBus()` and assign to `message_bus`.
+3. In `shutdown_app_context()`: call `ctx.message_bus.close()` if set.
+
+---
+
+## 6. NotificationManager Adapter
+
+In `NotificationManager.add()` (after the existing ring-buffer write):
+- If `_message_bus` is set, call `asyncio.create_task(bus.send(..., kind="notification", ...))`.
+- The adapter is wired by `_build_app_context()` after both objects are constructed:
+  `notification_manager._message_bus = message_bus`.
+- This is additive: if `_message_bus` is None, nothing changes.
+- Notifications also continue to be written to the ring buffer.
+
+---
+
+## 7. Test List (`tests/test_bus.py`)
+
+All tests are `unittest.IsolatedAsyncioTestCase`; DB is `":memory:"` or a
+`tempfile.mkstemp()` path that is deleted in `tearDown`.
+
+1. **test_send_to_agent** — send `agent:alice` → one row in inbox.
+2. **test_send_to_team** — fan-out to 2 team members → 2 rows.
+3. **test_broadcast** — fan-out to 3 registered agents → 3 rows.
+4. **test_receive_nonblocking** — drain empty inbox → `{messages: [], next_cursor: 0}`.
+5. **test_receive_returns_messages** — send 3, receive → 3 envelopes in FIFO order.
+6. **test_ack_advances_cursor** — ack through cursor, receive again → empty.
+7. **test_cursor_durability** — reopen DB (new `AgentMessageBus(path)`), receive unacked → still there.
+8. **test_long_poll_wakeup** — `receive(wait_up_to=5)` in task, `send` in another → resolves before timeout.
+9. **test_long_poll_timeout** — `receive(wait_up_to=0.1)` with no producer → returns empty after timeout.
+10. **test_per_recipient_fifo** — send A, B, C to alice, B, C to bob → each gets only their own in order.
+11. **test_kinds_filter** — send "instruction" and "event", receive(kinds=["event"]) → only event.
+12. **test_ttl_expiry** — send with `ttl_seconds=1`, wait 2s, receive → empty (expired rows filtered).
+13. **test_notification_adapter** — `NotificationManager.add_simple(agent="alice")` with bus wired → bus inbox gets a notification envelope.
+14. **test_bus_tool_send_op** — call `bus(op="POST", to="agent:alice", kind="instruction", body="hello")` → ok envelope, message_id in data.
+15. **test_bus_tool_receive_op** — send then `bus(op="GET", agent="alice")` → messages in data.
+16. **test_bus_tool_ack_op** — receive, then `bus(op="POST", definer="TRIGGER", agent="alice", up_to_cursor=N)` → acked_through.
+17. **test_bus_tool_options** — `bus(op="OPTIONS")` → ok envelope with tool schema.
+
+---
+
+## 8. What Is Designed-For-But-Deferred
+
+- **Phase 2 — write/push path:** Route `messages` tool through bus. Daemon delivery worker for keystroke fallback. `agent.idle` events from `wait_for`.
+- **Phase 3 — Claude Code ingress/egress:** Channel-style adapter. External CC session sends/receives via `bus`. The envelope's `sender`/`recipient` address scheme is designed to accommodate an `external:<session_id>` prefix without schema changes.
+- **Phase 4 — SSE/WebSocket push:** Replace long-poll with SSE stream from the daemon. The `asyncio.Event` wakeup mechanism is the same primitive an SSE loop would use; swapping is a transport-only change.
+- **`send_multi` fan-out to in-process handlers:** The existing `MessageRouter` is kept as-is. Future work could make the bus call `router.publish()` for typed handler dispatch when the kind maps to a known topic.

--- a/iterm_mcpy/app_context.py
+++ b/iterm_mcpy/app_context.py
@@ -32,6 +32,7 @@ from core.flows import get_event_bus, get_flow_manager
 from core.manager import ManagerRegistry
 from core.memory import SQLiteMemoryStore
 from core.models import AgentNotification
+from core.bus import AgentMessageBus
 from core.profiles import get_profile_manager
 from core.roles import RoleManager
 from core.service_hooks import get_service_hook_manager
@@ -64,9 +65,18 @@ class NotificationManager:
         self._max_per_agent = max_per_agent
         self._max_total = max_total
         self._lock = asyncio.Lock()
+        # Wired by _build_app_context() after both objects are constructed.
+        # When set, add() also enqueues into the bus (non-destructively).
+        self._message_bus: Optional[Any] = None
 
     async def add(self, notification: AgentNotification) -> None:
-        """Add a notification, maintaining ring buffer limits."""
+        """Add a notification, maintaining ring buffer limits.
+
+        Also enqueues a ``kind="notification"`` envelope onto the message bus
+        if one has been wired via ``_message_bus``.  The bus write is
+        fire-and-forget (scheduled as a background task) so it cannot block
+        the ring-buffer write or raise.
+        """
         async with self._lock:
             self._notifications.append(notification)
             # Trim per-agent ring buffer: drop oldest notifications for this agent
@@ -79,6 +89,29 @@ class NotificationManager:
             # Trim to max total
             if len(self._notifications) > self._max_total:
                 self._notifications = self._notifications[-self._max_total:]
+
+        # Bus adapter — additive, does not alter existing behavior.
+        if self._message_bus is not None:
+            try:
+                body = {
+                    "level": notification.level,
+                    "summary": notification.summary,
+                    "context": notification.context,
+                    "action_hint": notification.action_hint,
+                    "timestamp": notification.timestamp.isoformat(),
+                }
+                asyncio.create_task(
+                    self._message_bus.send(
+                        sender="system",
+                        recipient=f"agent:{notification.agent}",
+                        kind="notification",
+                        body=body,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "NotificationManager: failed to enqueue bus notification"
+                )
 
     async def add_simple(
         self,
@@ -169,6 +202,7 @@ class AppContext:
     flow_manager: Any = None
     role_manager: Any = None
     memory_store: Any = None
+    message_bus: Any = None
     logger: Any = None
     log_dir: Optional[str] = None
 
@@ -308,6 +342,13 @@ async def _build_app_context() -> AppContext:
     memory_store = SQLiteMemoryStore()
     build_logger.info("Memory store initialized (SQLite with FTS5)")
 
+    # Initialize message bus (durable, addressed, long-poll inbox)
+    message_bus = AgentMessageBus()
+    build_logger.info("Message bus initialized (SQLite, durable inbox)")
+
+    # Wire the notification-manager → bus adapter.
+    notification_manager._message_bus = message_bus
+
     return AppContext(
         connection=connection,
         terminal=terminal,
@@ -329,6 +370,7 @@ async def _build_app_context() -> AppContext:
         flow_manager=flow_manager,
         role_manager=role_manager,
         memory_store=memory_store,
+        message_bus=message_bus,
         logger=build_logger,
         log_dir=log_dir,
     )
@@ -361,4 +403,9 @@ async def shutdown_app_context() -> None:
             await ctx.event_bus.stop()
         except Exception:
             logger.exception("Error stopping event bus during shutdown")
+    if ctx.message_bus is not None:
+        try:
+            ctx.message_bus.close()
+        except Exception:
+            logger.exception("Error closing message bus during shutdown")
     shutdown_tracing()

--- a/iterm_mcpy/app_context.py
+++ b/iterm_mcpy/app_context.py
@@ -68,6 +68,9 @@ class NotificationManager:
         # Wired by _build_app_context() after both objects are constructed.
         # When set, add() also enqueues into the bus (non-destructively).
         self._message_bus: Optional[Any] = None
+        # Retained set of in-flight bus tasks.  Holds a strong reference so
+        # the garbage collector cannot cancel tasks before they complete.
+        self._bus_tasks: set = set()
 
     async def add(self, notification: AgentNotification) -> None:
         """Add a notification, maintaining ring buffer limits.
@@ -93,25 +96,49 @@ class NotificationManager:
         # Bus adapter — additive, does not alter existing behavior.
         if self._message_bus is not None:
             try:
-                body = {
-                    "level": notification.level,
-                    "summary": notification.summary,
-                    "context": notification.context,
-                    "action_hint": notification.action_hint,
-                    "timestamp": notification.timestamp.isoformat(),
-                }
-                asyncio.create_task(
-                    self._message_bus.send(
-                        sender="system",
-                        recipient=f"agent:{notification.agent}",
-                        kind="notification",
-                        body=body,
+                # Only schedule when an event loop is already running.
+                # If there is no running loop (e.g. during tests or sync
+                # startup), skip scheduling entirely — creating a coroutine
+                # object without scheduling it produces a RuntimeWarning and
+                # the coroutine would never execute.
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass  # No running loop — skip the bus write silently.
+            else:
+                try:
+                    body = {
+                        "level": notification.level,
+                        "summary": notification.summary,
+                        "context": notification.context,
+                        "action_hint": notification.action_hint,
+                        "timestamp": notification.timestamp.isoformat(),
+                    }
+                    task = asyncio.create_task(
+                        self._message_bus.send(
+                            sender="system",
+                            recipient=f"agent:{notification.agent}",
+                            kind="notification",
+                            body=body,
+                        )
                     )
-                )
-            except Exception:
-                logger.exception(
-                    "NotificationManager: failed to enqueue bus notification"
-                )
+                    # Retain the task so GC cannot collect it before it runs.
+                    self._bus_tasks.add(task)
+
+                    def _bus_task_done(t: asyncio.Task) -> None:
+                        self._bus_tasks.discard(t)
+                        exc = t.exception() if not t.cancelled() else None
+                        if exc is not None:
+                            logger.warning(
+                                "NotificationManager: bus send task failed: %s",
+                                exc,
+                                exc_info=exc,
+                            )
+
+                    task.add_done_callback(_bus_task_done)
+                except Exception:
+                    logger.exception(
+                        "NotificationManager: failed to enqueue bus notification"
+                    )
 
     async def add_simple(
         self,

--- a/iterm_mcpy/tools/__init__.py
+++ b/iterm_mcpy/tools/__init__.py
@@ -1,18 +1,18 @@
 """iTerm MCP tool modules (SP2 method-semantic surface).
 
 Each module exposes a ``register(mcp)`` function that registers its
-single tool with the FastMCP instance. The 15 tools together cover the
+single tool with the FastMCP instance. The 16 tools together cover the
 full method-semantic API:
 
   Collections (9): sessions, agents, teams, managers, feedback, memory,
                    services, roles, workflows
-  Actions (6):     messages, orchestrate, delegate, wait_for, subscribe,
-                   telemetry
+  Actions (7):     messages, orchestrate, delegate, wait_for, subscribe,
+                   telemetry, bus
 """
 
 
 def register_all(mcp):
-    """Register all 15 SP2 tools with the FastMCP instance.
+    """Register all 16 SP2 tools with the FastMCP instance.
 
     Called from fastmcp_server.py after mcp creation and before run().
     """
@@ -20,12 +20,14 @@ def register_all(mcp):
         sessions, agents, teams, managers,
         feedback, memory, services, roles, workflows,
         messages, orchestrate, delegate, wait_for, subscribe, telemetry,
+        bus,
     )
 
     _MODULES = [
         sessions, agents, teams, managers,
         feedback, memory, services, roles, workflows,
         messages, orchestrate, delegate, wait_for, subscribe, telemetry,
+        bus,
     ]
 
     for mod in _MODULES:

--- a/iterm_mcpy/tools/bus.py
+++ b/iterm_mcpy/tools/bus.py
@@ -153,6 +153,32 @@ async def bus(
         return ok_envelope(method="OPTIONS", data=_OPTIONS_SCHEMA)
 
     # ------------------------------------------------------------------
+    # Local friendly-alias normalisation (bus-specific; does NOT touch the
+    # global VERB_ATLAS).  These are the aliases advertised in _OPTIONS_SCHEMA
+    # that resolve_op does not know about, so we intercept them here before
+    # handing off to the shared resolver.
+    #
+    #   receive / drain  → treat as GET (the receive path)
+    #   ack / acknowledge → treat as POST + definer=TRIGGER (the ack path)
+    #   peek             → treat as GET with target="peek"
+    # ------------------------------------------------------------------
+    _RECEIVE_ALIASES = {"receive", "drain"}
+    _ACK_ALIASES = {"ack", "acknowledge"}
+    _PEEK_ALIASES = {"peek"}
+
+    op_lower = op.lower() if op else "get"
+    if op_lower in _RECEIVE_ALIASES:
+        op = "GET"
+        definer = None
+    elif op_lower in _ACK_ALIASES:
+        op = "POST"
+        definer = "TRIGGER"
+    elif op_lower in _PEEK_ALIASES:
+        op = "GET"
+        definer = None
+        target = "peek"
+
+    # ------------------------------------------------------------------
     # Resolve op.
     # ------------------------------------------------------------------
     try:

--- a/iterm_mcpy/tools/bus.py
+++ b/iterm_mcpy/tools/bus.py
@@ -1,0 +1,313 @@
+"""SP2 `bus` action tool — Phase 1 agent message bus.
+
+Exposes the process-global ``AgentMessageBus`` (``AppContext.message_bus``)
+as a single MCP tool with WebSpec method-semantic ops.
+
+Ops summary:
+
+    bus op="POST"           Send a message to an inbox (POST+SEND).
+        to="agent:builder" | "team:backend" | "broadcast" | arbitrary
+        kind="instruction"  (or "notification", "event", "reply", ...)
+        body=<str|dict>
+        sender?             defaults to "caller"
+        correlation_id?
+        ttl_seconds?
+
+    bus op="GET"            Long-poll receive from an inbox.
+        agent="alice"       (required)
+        wait_up_to?=0       0 = non-blocking drain; max 600 s
+        since_cursor?       override the durable cursor
+        kinds?=[...]        kind filter
+        limit?=50
+
+    bus op="GET" target="status"   Inbox depths + oldest unacked age.
+
+    bus op="GET" target="peek"     Non-blocking 5-item drain.
+        agent="alice"
+
+    bus op="POST" definer="TRIGGER"   Advance the durable read cursor.
+        agent="alice"       (required)
+        up_to_cursor=<int>  rowid to ack through (inclusive)
+
+    bus op="OPTIONS"        Self-describe (consistent with SP2 tools).
+
+Registration: ``register(mcp)`` follows the same pattern as all other tools.
+The tool count moves from 15 → 16.
+"""
+from typing import Any, List, Optional
+
+from mcp.server.fastmcp import Context
+
+from core.definer_verbs import DefinerError, resolve_op
+from iterm_mcpy.errors import ErrorCode, ToolError
+from iterm_mcpy.responses import err_envelope, ok_envelope
+
+
+_OPTIONS_SCHEMA = {
+    "tool": "bus",
+    "kind": "action",
+    "description": (
+        "Shared durable message bus. Send addressed envelopes to "
+        "agent:/team:/broadcast inboxes; receive with long-poll; "
+        "acknowledge to advance a durable cursor."
+    ),
+    "methods": {
+        "POST": {
+            "definer": "SEND",
+            "aliases": ["send", "post", "notify", "dispatch"],
+            "params": {
+                "to": "recipient: agent:<name> | team:<name> | broadcast (required)",
+                "kind?": "envelope kind: instruction|notification|event|reply (default: instruction)",
+                "body?": "message payload (str or JSON-serializable dict)",
+                "sender?": "originator address (default: 'caller')",
+                "correlation_id?": "ties replies to a request",
+                "ttl_seconds?": "expiry; None = never expires",
+            },
+            "returns": "{message_id, accepted_recipients: [...]}",
+        },
+        "GET": {
+            "aliases": ["receive", "get", "list", "read", "drain"],
+            "params": {
+                "agent": "inbox owner — required for receive/peek (omit for status)",
+                "wait_up_to?": "long-poll timeout seconds (0=non-blocking, max 600)",
+                "since_cursor?": "override durable cursor (rowid integer)",
+                "kinds?": "list of kind strings to filter by",
+                "limit?": "max messages to return (default 50)",
+                "target?": "'status' for inbox stats; 'peek' for 5-item drain",
+            },
+            "returns": "{messages: [...], next_cursor: int, has_more: bool}",
+        },
+        "POST_TRIGGER": {
+            "definer": "TRIGGER",
+            "aliases": ["ack", "acknowledge"],
+            "params": {
+                "agent": "inbox owner (required)",
+                "up_to_cursor": "rowid to ack through, inclusive (required)",
+            },
+            "returns": "{acked_through: int}",
+        },
+        "OPTIONS": {"description": "This schema."},
+    },
+    "future_phases": [
+        "Phase 2: route messages tool through bus; daemon delivery worker",
+        "Phase 3: Claude Code Channels ingress/egress bridge (external:<session_id>)",
+        "Phase 4: SSE/WebSocket push transport replacing long-poll",
+    ],
+}
+
+
+async def bus(
+    ctx: Context,
+    op: str = "GET",
+    definer: Optional[str] = None,
+    # --- send params ---
+    to: Optional[str] = None,
+    kind: str = "instruction",
+    body: Optional[Any] = None,
+    sender: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    # --- receive params ---
+    agent: Optional[str] = None,
+    wait_up_to: int = 0,
+    since_cursor: Optional[int] = None,
+    kinds: Optional[List[str]] = None,
+    limit: int = 50,
+    target: Optional[str] = None,
+    # --- ack params ---
+    up_to_cursor: Optional[int] = None,
+) -> dict[str, Any]:
+    """Shared durable message bus for inter-agent communication.
+
+    Send structured envelopes to addressed inboxes (agent:/team:/broadcast),
+    receive with optional long-polling, and acknowledge to advance a durable
+    read cursor that survives daemon restarts.
+
+    See the module docstring for the full op surface and parameter details.
+
+    Args:
+        op: HTTP method or friendly verb (GET, POST, send, receive, ack, …).
+        definer: Explicit definer (SEND, TRIGGER). Usually inferred from ``op``.
+        to: Recipient address for SEND (``agent:<n>``, ``team:<n>``,
+            ``broadcast``, or arbitrary string).
+        kind: Envelope kind (``instruction``, ``notification``, ``event``,
+            ``reply``, or any string).
+        body: Payload — str or JSON-serializable value.
+        sender: Originator label.  Defaults to ``"caller"``.
+        correlation_id: Optional request-correlation token.
+        ttl_seconds: Expiry in seconds.  ``None`` = never expires.
+        agent: Inbox owner for GET / ack operations.
+        wait_up_to: Long-poll timeout in seconds (0 = non-blocking).
+        since_cursor: Override the durable cursor (rowid integer).
+        kinds: List of kind strings to filter received messages by.
+        limit: Maximum messages per receive call (default 50).
+        target: Sub-operation: ``"status"`` for inbox stats, ``"peek"``
+            for a 5-item non-blocking drain.
+        up_to_cursor: Rowid to acknowledge through (inclusive).
+    """
+    # ------------------------------------------------------------------
+    # OPTIONS — always available without AppContext.
+    # ------------------------------------------------------------------
+    op_upper = op.upper() if op else "GET"
+    if op_upper == "OPTIONS":
+        return ok_envelope(method="OPTIONS", data=_OPTIONS_SCHEMA)
+
+    # ------------------------------------------------------------------
+    # Resolve op.
+    # ------------------------------------------------------------------
+    try:
+        resolution = resolve_op(op, definer)
+    except DefinerError as e:
+        return err_envelope(method=op_upper, error=ToolError.from_exception(e))
+
+    method = resolution.method
+    resolved_definer = resolution.definer
+
+    # ------------------------------------------------------------------
+    # Get the bus from AppContext.
+    # ------------------------------------------------------------------
+    try:
+        lifespan = ctx.request_context.lifespan_context
+        message_bus = lifespan.get("message_bus")
+        agent_registry = lifespan.get("agent_registry")
+    except Exception as e:
+        return err_envelope(
+            method=method,
+            definer=resolved_definer,
+            error=ToolError(ErrorCode.INTERNAL, f"Could not access AppContext: {e}"),
+        )
+
+    if message_bus is None:
+        return err_envelope(
+            method=method,
+            definer=resolved_definer,
+            error=ToolError(
+                ErrorCode.INTERNAL,
+                "message_bus not available — daemon may not be initialized",
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Dispatch.
+    # ------------------------------------------------------------------
+    try:
+        # ---- SEND ----
+        # Accept POST+SEND explicitly, or plain POST when `to` is supplied
+        # (the caller clearly intended a send even without the definer).
+        if method == "POST" and (
+            resolved_definer == "SEND"
+            or (resolved_definer == "CREATE" and to is not None)
+        ):
+            if not to:
+                return err_envelope(
+                    method=method, definer=resolved_definer,
+                    error=ToolError(
+                        ErrorCode.MISSING_PARAM,
+                        "'to' is required for send (POST+SEND)",
+                        hint="Pass definer='SEND' or use op='send'",
+                    ),
+                )
+            result = await message_bus.send(
+                sender=sender or "caller",
+                recipient=to,
+                kind=kind,
+                body=body,
+                correlation_id=correlation_id,
+                ttl_seconds=ttl_seconds,
+                agent_registry=agent_registry,
+            )
+            return ok_envelope(method=method, definer="SEND", data=result)
+
+        # ---- ACK ----
+        if method == "POST" and resolved_definer == "TRIGGER":
+            if not agent:
+                return err_envelope(
+                    method=method, definer=resolved_definer,
+                    error=ToolError(ErrorCode.MISSING_PARAM, "'agent' is required for ack"),
+                )
+            if up_to_cursor is None:
+                return err_envelope(
+                    method=method, definer=resolved_definer,
+                    error=ToolError(
+                        ErrorCode.MISSING_PARAM,
+                        "'up_to_cursor' is required for ack",
+                    ),
+                )
+            result = await message_bus.ack(
+                recipient=f"agent:{agent}" if not agent.startswith("agent:") else agent,
+                up_to_cursor=up_to_cursor,
+            )
+            return ok_envelope(method=method, definer=resolved_definer, data=result)
+
+        # ---- GET ----
+        if method == "GET":
+            # status sub-op
+            if target == "status":
+                inboxes = await message_bus.list_inboxes()
+                return ok_envelope(method=method, data={"inboxes": inboxes})
+
+            # peek sub-op
+            if target == "peek":
+                if not agent:
+                    return err_envelope(
+                        method=method,
+                        error=ToolError(
+                            ErrorCode.MISSING_PARAM, "'agent' is required for peek"
+                        ),
+                    )
+                recipient_addr = (
+                    f"agent:{agent}"
+                    if not agent.startswith("agent:")
+                    else agent
+                )
+                result = await message_bus.peek(recipient_addr, limit=5)
+                return ok_envelope(method=method, data=result)
+
+            # receive (default GET)
+            if not agent:
+                return err_envelope(
+                    method=method,
+                    error=ToolError(
+                        ErrorCode.MISSING_PARAM,
+                        "'agent' is required for receive "
+                        "(use target='status' for inbox stats)",
+                    ),
+                )
+            recipient_addr = (
+                f"agent:{agent}"
+                if not agent.startswith("agent:")
+                else agent
+            )
+            clamped_wait = max(0, min(wait_up_to, 600))
+            result = await message_bus.receive(
+                recipient=recipient_addr,
+                wait_up_to=clamped_wait,
+                since_cursor=since_cursor,
+                kinds=kinds,
+                limit=max(1, min(limit, 500)),
+            )
+            return ok_envelope(method=method, data=result)
+
+        # ---- Unsupported method ----
+        return err_envelope(
+            method=method,
+            definer=resolved_definer,
+            error=ToolError(
+                ErrorCode.INVALID_OP,
+                f"bus does not support {method}"
+                + (f"+{resolved_definer}" if resolved_definer else ""),
+                hint="Supported ops: GET (receive/status/peek), POST+SEND, POST+TRIGGER (ack), OPTIONS",
+            ),
+        )
+
+    except Exception as e:
+        return err_envelope(
+            method=method,
+            definer=resolved_definer,
+            error=ToolError.from_exception(e),
+        )
+
+
+def register(mcp) -> None:
+    """Register the bus action tool with the FastMCP instance."""
+    mcp.tool(name="bus")(bus)

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -391,6 +391,36 @@ class TestBusTtlExpiry(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("stale", bodies)
         self.assertIn("fresh", bodies)
 
+    async def test_ttl_positive_not_dropped(self):
+        """Messages with a positive TTL (e.g. 3600 s) must NOT be filtered out."""
+        # Send a message that won't expire for an hour.
+        await self.bus.send(
+            sender="s", recipient="agent:alice",
+            kind="instruction", body="long-lived",
+            ttl_seconds=3600,
+        )
+        # Send a message with no TTL (never expires).
+        await self.bus.send(
+            sender="s", recipient="agent:alice",
+            kind="instruction", body="no-ttl",
+        )
+        result = await self.bus.receive("agent:alice", wait_up_to=0)
+        bodies = [m["body"] for m in result["messages"]]
+        self.assertIn("long-lived", bodies, "positive-TTL message should still be returned")
+        self.assertIn("no-ttl", bodies)
+
+    async def test_ttl_list_inboxes_positive_not_dropped(self):
+        """list_inboxes must also count positive-TTL messages as live."""
+        await self.bus.send(
+            sender="s", recipient="agent:alice",
+            kind="instruction", body="live-msg",
+            ttl_seconds=3600,
+        )
+        inboxes = await self.bus.list_inboxes()
+        by_r = {i["recipient"]: i for i in inboxes}
+        self.assertIn("agent:alice", by_r, "inbox should be visible with positive-TTL msg")
+        self.assertEqual(by_r["agent:alice"]["depth"], 1)
+
 
 class TestBusListInboxes(unittest.IsolatedAsyncioTestCase):
     """list_inboxes returns depth and age info per recipient."""
@@ -745,6 +775,79 @@ class TestBusToolFriendlyVerbAliases(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(self.bus)
         result = await bus_tool(ctx, op="notify", to="agent:alice", body="notif")
         self.assertTrue(result["ok"], result)
+
+    async def test_receive_alias(self):
+        """'receive' must actually receive messages (not error)."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        # Seed a message first.
+        await bus_tool(ctx, op="send", to="agent:alice", body="via-receive-alias")
+
+        result = await bus_tool(ctx, op="receive", agent="alice", wait_up_to=0)
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["method"], "GET")
+        self.assertEqual(len(result["data"]["messages"]), 1)
+        self.assertEqual(result["data"]["messages"][0]["body"], "via-receive-alias")
+
+    async def test_drain_alias(self):
+        """'drain' is equivalent to 'receive' (non-blocking drain)."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        await bus_tool(ctx, op="send", to="agent:alice", body="via-drain-alias")
+
+        result = await bus_tool(ctx, op="drain", agent="alice", wait_up_to=0)
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(len(result["data"]["messages"]), 1)
+
+    async def test_ack_alias(self):
+        """'ack' must actually advance the cursor."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        await bus_tool(ctx, op="send", to="agent:alice", body="m-for-ack-alias")
+
+        recv = await bus_tool(ctx, op="receive", agent="alice", wait_up_to=0)
+        cursor = recv["data"]["next_cursor"]
+
+        ack_result = await bus_tool(
+            ctx, op="ack", agent="alice", up_to_cursor=cursor
+        )
+        self.assertTrue(ack_result["ok"], ack_result)
+        self.assertEqual(ack_result["data"]["acked_through"], cursor)
+
+        # Inbox should now be empty.
+        recv2 = await bus_tool(ctx, op="receive", agent="alice", wait_up_to=0)
+        self.assertEqual(recv2["data"]["messages"], [])
+
+    async def test_acknowledge_alias(self):
+        """'acknowledge' is equivalent to 'ack'."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        await bus_tool(ctx, op="send", to="agent:alice", body="m-for-acknowledge")
+
+        recv = await bus_tool(ctx, op="receive", agent="alice", wait_up_to=0)
+        cursor = recv["data"]["next_cursor"]
+
+        ack_result = await bus_tool(
+            ctx, op="acknowledge", agent="alice", up_to_cursor=cursor
+        )
+        self.assertTrue(ack_result["ok"], ack_result)
+
+    async def test_peek_alias(self):
+        """'peek' must return messages non-blockingly (maps to GET target=peek)."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        for i in range(3):
+            await bus_tool(ctx, op="send", to="agent:alice", body=f"peek-{i}")
+
+        result = await bus_tool(ctx, op="peek", agent="alice")
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["method"], "GET")
+        self.assertEqual(len(result["data"]["messages"]), 3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,0 +1,782 @@
+"""Tests for the AgentMessageBus (core/bus.py).
+
+Covers:
+- Addressing: agent:, team:, broadcast
+- Durable enqueue / receive / ack
+- Per-recipient FIFO ordering
+- Long-poll: returns-on-new-message vs times-out-empty
+- Restart durability: reopen DB and still get unacked messages
+- TTL expiry filtering
+- NotificationManager → bus adapter
+- bus tool ops: send, receive, ack, status, options
+"""
+
+import asyncio
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bus(path: str):
+    """Create an AgentMessageBus pointed at a temp path."""
+    from core.bus import AgentMessageBus
+    return AgentMessageBus(db_path=path)
+
+
+def _make_registry(agents=None, teams=None):
+    """Minimal stub of AgentRegistry for fan-out resolution."""
+    registry = MagicMock()
+    agent_objects = []
+    if agents:
+        for name in agents:
+            a = MagicMock()
+            a.name = name
+            a.teams = teams.get(name, []) if teams else []
+            agent_objects.append(a)
+
+    def list_agents_side_effect(team=None):
+        if team is None:
+            return agent_objects
+        return [a for a in agent_objects if team in a.teams]
+
+    registry.list_agents.side_effect = list_agents_side_effect
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Core Bus Tests
+# ---------------------------------------------------------------------------
+
+class TestBusSendToAgent(unittest.IsolatedAsyncioTestCase):
+    """test_send_to_agent — send agent:alice → one row in inbox."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_send_to_agent(self):
+        result = await self.bus.send(
+            sender="orchestrator",
+            recipient="agent:alice",
+            kind="instruction",
+            body="hello alice",
+        )
+        self.assertEqual(result["accepted_recipients"], ["agent:alice"])
+        self.assertIn("message_id", result)
+
+        recv = await self.bus.receive("agent:alice", wait_up_to=0)
+        self.assertEqual(len(recv["messages"]), 1)
+        self.assertEqual(recv["messages"][0]["body"], "hello alice")
+        self.assertEqual(recv["messages"][0]["sender"], "orchestrator")
+        self.assertEqual(recv["messages"][0]["kind"], "instruction")
+
+
+class TestBusFanOutToTeam(unittest.IsolatedAsyncioTestCase):
+    """test_send_to_team — fan-out to 2 team members."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_send_to_team(self):
+        registry = _make_registry(
+            agents=["alice", "bob"],
+            teams={"alice": ["backend"], "bob": ["backend"]},
+        )
+        result = await self.bus.send(
+            sender="orchestrator",
+            recipient="team:backend",
+            kind="instruction",
+            body="team msg",
+            agent_registry=registry,
+        )
+        self.assertIn("agent:alice", result["accepted_recipients"])
+        self.assertIn("agent:bob", result["accepted_recipients"])
+
+        alice_msgs = await self.bus.receive("agent:alice", wait_up_to=0)
+        bob_msgs = await self.bus.receive("agent:bob", wait_up_to=0)
+        self.assertEqual(len(alice_msgs["messages"]), 1)
+        self.assertEqual(len(bob_msgs["messages"]), 1)
+
+
+class TestBusBroadcast(unittest.IsolatedAsyncioTestCase):
+    """test_broadcast — fan-out to 3 registered agents."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_broadcast(self):
+        registry = _make_registry(agents=["alice", "bob", "carol"])
+        result = await self.bus.send(
+            sender="system",
+            recipient="broadcast",
+            kind="event",
+            body="system event",
+            agent_registry=registry,
+        )
+        # Should have 3 agent rows + 1 broadcast row = 4
+        self.assertEqual(len(result["accepted_recipients"]), 4)
+        self.assertIn("broadcast", result["accepted_recipients"])
+
+        for name in ["alice", "bob", "carol"]:
+            msgs = await self.bus.receive(f"agent:{name}", wait_up_to=0)
+            self.assertEqual(len(msgs["messages"]), 1, f"{name} should have 1 message")
+
+
+class TestBusReceiveNonblocking(unittest.IsolatedAsyncioTestCase):
+    """test_receive_nonblocking — drain empty inbox returns empty list."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_receive_empty(self):
+        result = await self.bus.receive("agent:nobody", wait_up_to=0)
+        self.assertEqual(result["messages"], [])
+        self.assertEqual(result["next_cursor"], 0)
+        self.assertFalse(result["has_more"])
+
+
+class TestBusReceiveReturnsMessages(unittest.IsolatedAsyncioTestCase):
+    """test_receive_returns_messages — send 3, receive → 3 envelopes FIFO."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_receive_three(self):
+        for i in range(3):
+            await self.bus.send(
+                sender="sender", recipient="agent:alice",
+                kind="instruction", body=f"msg{i}",
+            )
+        result = await self.bus.receive("agent:alice", wait_up_to=0)
+        self.assertEqual(len(result["messages"]), 3)
+        bodies = [m["body"] for m in result["messages"]]
+        self.assertEqual(bodies, ["msg0", "msg1", "msg2"])
+
+
+class TestBusAckAdvancesCursor(unittest.IsolatedAsyncioTestCase):
+    """test_ack_advances_cursor — ack through cursor, receive again → empty."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_ack(self):
+        for i in range(3):
+            await self.bus.send(
+                sender="s", recipient="agent:alice",
+                kind="instruction", body=f"m{i}",
+            )
+        recv = await self.bus.receive("agent:alice", wait_up_to=0)
+        self.assertEqual(len(recv["messages"]), 3)
+
+        # Ack all through next_cursor.
+        ack_result = await self.bus.ack("agent:alice", recv["next_cursor"])
+        self.assertEqual(ack_result["acked_through"], recv["next_cursor"])
+
+        # Second receive should see nothing.
+        recv2 = await self.bus.receive("agent:alice", wait_up_to=0)
+        self.assertEqual(recv2["messages"], [])
+
+
+class TestBusCursorDurability(unittest.IsolatedAsyncioTestCase):
+    """test_cursor_durability — reopen DB, unacked messages still there."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+
+    async def asyncTearDown(self):
+        os.unlink(self.db_path)
+
+    async def test_durability(self):
+        # Write messages with bus instance 1.
+        bus1 = _make_bus(self.db_path)
+        for i in range(3):
+            await bus1.send(
+                sender="s", recipient="agent:alice",
+                kind="instruction", body=f"m{i}",
+            )
+        recv = await bus1.receive("agent:alice", wait_up_to=0)
+        # Ack only the first message.
+        first_rowid = recv["messages"][0]["rowid"]
+        await bus1.ack("agent:alice", first_rowid)
+        bus1.close()
+
+        # Reopen with bus instance 2 — should see 2 unacked messages.
+        bus2 = _make_bus(self.db_path)
+        recv2 = await bus2.receive("agent:alice", wait_up_to=0)
+        bus2.close()
+
+        self.assertEqual(len(recv2["messages"]), 2)
+        bodies = [m["body"] for m in recv2["messages"]]
+        self.assertEqual(bodies, ["m1", "m2"])
+
+
+class TestBusLongPollWakeup(unittest.IsolatedAsyncioTestCase):
+    """test_long_poll_wakeup — receive unblocks when message arrives."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_long_poll_wakeup(self):
+        received: list = []
+
+        async def reader():
+            result = await self.bus.receive("agent:alice", wait_up_to=5)
+            received.extend(result["messages"])
+
+        async def writer():
+            await asyncio.sleep(0.05)
+            await self.bus.send(
+                sender="s", recipient="agent:alice",
+                kind="instruction", body="wake up!",
+            )
+
+        start = time.monotonic()
+        await asyncio.gather(reader(), writer())
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["body"], "wake up!")
+        # Should have completed well before the 5s timeout.
+        self.assertLess(elapsed, 2.0)
+
+
+class TestBusLongPollTimeout(unittest.IsolatedAsyncioTestCase):
+    """test_long_poll_timeout — receive returns empty after timeout."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_long_poll_timeout(self):
+        start = time.monotonic()
+        result = await self.bus.receive("agent:alice", wait_up_to=0.1)
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result["messages"], [])
+        # Should have taken roughly 0.1 s but not more than 2 s.
+        self.assertGreaterEqual(elapsed, 0.05)
+        self.assertLess(elapsed, 2.0)
+
+
+class TestBusPerRecipientFifo(unittest.IsolatedAsyncioTestCase):
+    """test_per_recipient_fifo — each recipient gets only their own, in order."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_fifo(self):
+        # Alice gets A, B, C.  Bob gets B, C only.
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="A")
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="B")
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="C")
+        await self.bus.send(sender="s", recipient="agent:bob",   kind="instruction", body="B")
+        await self.bus.send(sender="s", recipient="agent:bob",   kind="instruction", body="C")
+
+        alice = await self.bus.receive("agent:alice", wait_up_to=0)
+        bob   = await self.bus.receive("agent:bob",   wait_up_to=0)
+
+        self.assertEqual([m["body"] for m in alice["messages"]], ["A", "B", "C"])
+        self.assertEqual([m["body"] for m in bob["messages"]],   ["B", "C"])
+
+
+class TestBusKindsFilter(unittest.IsolatedAsyncioTestCase):
+    """test_kinds_filter — receive(kinds=["event"]) returns only events."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_kinds_filter(self):
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="inst")
+        await self.bus.send(sender="s", recipient="agent:alice", kind="event",       body="evt")
+        await self.bus.send(sender="s", recipient="agent:alice", kind="notification", body="notif")
+
+        result = await self.bus.receive("agent:alice", wait_up_to=0, kinds=["event"])
+        self.assertEqual(len(result["messages"]), 1)
+        self.assertEqual(result["messages"][0]["kind"], "event")
+
+
+class TestBusTtlExpiry(unittest.IsolatedAsyncioTestCase):
+    """test_ttl_expiry — expired messages are not returned."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_ttl_expiry(self):
+        # Send a message with ttl_seconds=0 (already expired).
+        await self.bus.send(
+            sender="s", recipient="agent:alice",
+            kind="instruction", body="stale",
+            ttl_seconds=0,
+        )
+        # Send a non-expiring message.
+        await self.bus.send(
+            sender="s", recipient="agent:alice",
+            kind="instruction", body="fresh",
+        )
+        result = await self.bus.receive("agent:alice", wait_up_to=0)
+        bodies = [m["body"] for m in result["messages"]]
+        self.assertNotIn("stale", bodies)
+        self.assertIn("fresh", bodies)
+
+
+class TestBusListInboxes(unittest.IsolatedAsyncioTestCase):
+    """list_inboxes returns depth and age info per recipient."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_list_inboxes(self):
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="x")
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="y")
+        inboxes = await self.bus.list_inboxes()
+        by_recipient = {i["recipient"]: i for i in inboxes}
+        self.assertIn("agent:alice", by_recipient)
+        self.assertEqual(by_recipient["agent:alice"]["depth"], 2)
+
+
+# ---------------------------------------------------------------------------
+# NotificationManager Adapter Test
+# ---------------------------------------------------------------------------
+
+class TestNotificationManagerBusAdapter(unittest.IsolatedAsyncioTestCase):
+    """test_notification_adapter — add_simple with bus wired → bus inbox gets it."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_notification_adapter(self):
+        from iterm_mcpy.app_context import NotificationManager
+
+        nm = NotificationManager()
+        nm._message_bus = self.bus
+
+        await nm.add_simple(
+            agent="alice",
+            level="info",
+            summary="test notification",
+            context="ctx",
+        )
+
+        # Allow the create_task to execute.
+        await asyncio.sleep(0.05)
+
+        result = await self.bus.receive("agent:alice", wait_up_to=0)
+        self.assertEqual(len(result["messages"]), 1)
+        msg = result["messages"][0]
+        self.assertEqual(msg["kind"], "notification")
+        self.assertEqual(msg["sender"], "system")
+        self.assertIn("summary", msg["body"])
+        self.assertEqual(msg["body"]["summary"], "test notification")
+
+    async def test_notification_adapter_not_wired(self):
+        """add_simple without bus wired should not raise."""
+        from iterm_mcpy.app_context import NotificationManager
+
+        nm = NotificationManager()
+        # _message_bus is None by default
+        await nm.add_simple(agent="bob", level="warning", summary="quiet")
+        # Ring buffer still works.
+        notifs = await nm.get(agent="bob")
+        self.assertEqual(len(notifs), 1)
+
+
+# ---------------------------------------------------------------------------
+# Bus Tool Tests (unit tests with a fake ctx)
+# ---------------------------------------------------------------------------
+
+def _make_ctx(bus_instance, registry=None):
+    """Build a minimal fake FastMCP Context for bus tool tests."""
+    lifespan = {"message_bus": bus_instance, "agent_registry": registry}
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = lifespan
+    return ctx
+
+
+class TestBusToolSendOp(unittest.IsolatedAsyncioTestCase):
+    """test_bus_tool_send_op — POST SEND returns ok envelope with message_id."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_send_op(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        # Use op="send" (maps to POST+SEND) or op="POST" definer="SEND".
+        result = await bus_tool(
+            ctx,
+            op="send",
+            to="agent:alice",
+            kind="instruction",
+            body="hello",
+            sender="tester",
+        )
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["method"], "POST")
+        self.assertIn("message_id", result["data"])
+
+    async def test_send_op_explicit_definer(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(
+            ctx,
+            op="POST",
+            definer="SEND",
+            to="agent:alice",
+            kind="instruction",
+            body="hello2",
+        )
+        self.assertTrue(result["ok"], result)
+
+    async def test_send_missing_to(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        # POST+SEND without `to` — should fail.
+        result = await bus_tool(ctx, op="POST", definer="SEND", body="hello")
+        self.assertFalse(result["ok"])
+        self.assertIn("to", result["error"]["message"])
+
+
+class TestBusToolReceiveOp(unittest.IsolatedAsyncioTestCase):
+    """test_bus_tool_receive_op — GET after send returns messages in data."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_receive_op(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        # Send first using op="send" (POST+SEND).
+        await bus_tool(ctx, op="send", to="agent:alice", kind="instruction", body="test msg")
+
+        # Receive via GET.
+        result = await bus_tool(ctx, op="GET", agent="alice", wait_up_to=0)
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["method"], "GET")
+        self.assertEqual(len(result["data"]["messages"]), 1)
+        self.assertEqual(result["data"]["messages"][0]["body"], "test msg")
+
+    async def test_receive_missing_agent(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="GET", wait_up_to=0)
+        self.assertFalse(result["ok"])
+
+
+class TestBusToolAckOp(unittest.IsolatedAsyncioTestCase):
+    """test_bus_tool_ack_op — POST+TRIGGER returns acked_through."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_ack_op(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        await bus_tool(ctx, op="send", to="agent:alice", kind="instruction", body="m")
+
+        # Receive to get cursor.
+        recv = await bus_tool(ctx, op="GET", agent="alice", wait_up_to=0)
+        cursor = recv["data"]["next_cursor"]
+
+        # Ack via tool.
+        ack_result = await bus_tool(
+            ctx,
+            op="POST",
+            definer="TRIGGER",
+            agent="alice",
+            up_to_cursor=cursor,
+        )
+        self.assertTrue(ack_result["ok"], ack_result)
+        self.assertEqual(ack_result["data"]["acked_through"], cursor)
+
+        # Subsequent receive should be empty.
+        recv2 = await bus_tool(ctx, op="GET", agent="alice", wait_up_to=0)
+        self.assertEqual(recv2["data"]["messages"], [])
+
+    async def test_ack_missing_agent(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(
+            ctx, op="POST", definer="TRIGGER", up_to_cursor=5
+        )
+        self.assertFalse(result["ok"])
+
+    async def test_ack_missing_cursor(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(
+            ctx, op="POST", definer="TRIGGER", agent="alice"
+        )
+        self.assertFalse(result["ok"])
+
+
+class TestBusToolStatusOp(unittest.IsolatedAsyncioTestCase):
+    """GET target=status returns inbox depths."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_status_op(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body="x")
+
+        result = await bus_tool(ctx, op="GET", target="status")
+        self.assertTrue(result["ok"], result)
+        self.assertIn("inboxes", result["data"])
+        inboxes = result["data"]["inboxes"]
+        by_r = {i["recipient"]: i for i in inboxes}
+        self.assertIn("agent:alice", by_r)
+
+
+class TestBusToolPeekOp(unittest.IsolatedAsyncioTestCase):
+    """GET target=peek returns up to 5 messages non-blocking."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_peek_op(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        for i in range(3):
+            await self.bus.send(sender="s", recipient="agent:alice", kind="instruction", body=f"m{i}")
+
+        result = await bus_tool(ctx, op="GET", target="peek", agent="alice")
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(len(result["data"]["messages"]), 3)
+
+
+class TestBusToolOptionsOp(unittest.IsolatedAsyncioTestCase):
+    """test_bus_tool_options — OPTIONS returns ok envelope with schema."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_options(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="OPTIONS")
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["method"], "OPTIONS")
+        self.assertIn("methods", result["data"])
+        self.assertIn("future_phases", result["data"])
+
+    async def test_options_without_appcontext(self):
+        """OPTIONS should work even with a broken/missing ctx."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        # Simulate a ctx where lifespan access would fail.
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {}  # message_bus missing
+
+        result = await bus_tool(ctx, op="OPTIONS")
+        self.assertTrue(result["ok"], result)
+
+
+class TestBusToolFriendlyVerbAliases(unittest.IsolatedAsyncioTestCase):
+    """Friendly verb aliases (send, receive, ack) resolve correctly."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.bus = _make_bus(self.db_path)
+
+    async def asyncTearDown(self):
+        self.bus.close()
+        os.unlink(self.db_path)
+
+    async def test_send_alias(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="send", to="agent:alice", body="via alias")
+        self.assertTrue(result["ok"], result)
+
+    async def test_get_alias(self):
+        """'get' and 'read' are GET-family aliases."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="get", agent="alice", wait_up_to=0)
+        self.assertTrue(result["ok"], result)
+
+    async def test_read_alias(self):
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="read", agent="alice", wait_up_to=0)
+        self.assertTrue(result["ok"], result)
+
+    async def test_notify_alias(self):
+        """'notify' maps to POST+SEND."""
+        from iterm_mcpy.tools.bus import bus as bus_tool
+
+        ctx = _make_ctx(self.bus)
+        result = await bus_tool(ctx, op="notify", to="agent:alice", body="notif")
+        self.assertTrue(result["ok"], result)
+
+
+# ---------------------------------------------------------------------------
+# BusEnvelope Model Test
+# ---------------------------------------------------------------------------
+
+class TestBusEnvelopeModel(unittest.TestCase):
+    """BusEnvelope Pydantic model behaves correctly."""
+
+    def test_defaults(self):
+        from core.bus import BusEnvelope
+
+        env = BusEnvelope(sender="s", recipient="agent:a")
+        self.assertEqual(env.kind, "instruction")
+        self.assertEqual(env.attempts, 0)
+        self.assertIsNone(env.rowid)
+        self.assertIsNotNone(env.message_id)
+
+    def test_all_fields(self):
+        from core.bus import BusEnvelope
+
+        env = BusEnvelope(
+            sender="agent:builder",
+            recipient="agent:alice",
+            kind="reply",
+            body={"result": 42},
+            correlation_id="corr-123",
+            ttl_seconds=60,
+        )
+        self.assertEqual(env.correlation_id, "corr-123")
+        self.assertEqual(env.ttl_seconds, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase-1 of a unified inter-agent message bus: an addressed, SQLite-durable, long-poll bus hosted in the singleton daemon's process-global `AppContext`, so all clients share one message spine.

- **`core/bus.py`** — `AgentMessageBus` with `send` / `receive` (long-poll via per-recipient `asyncio.Event`, DB as source of truth) / `ack` (idempotent durable cursor) / `peek` / `list_inboxes`. `BusEnvelope` Pydantic model. Addressing: `agent:<name>`, `team:<name>`, `broadcast`. Durable inbox + cursor tables in `~/.iterm-mcp/bus.db` (reuses the repo's `SQLiteMemoryStore` pattern; survives restart).
- **`iterm_mcpy/tools/bus.py`** — the 16th SP2 tool: `send` / `receive` (GET long-poll) / `ack` / `peek` / `status` / `OPTIONS`, following the existing dispatcher + envelope conventions. Friendly verb aliases (`receive`, `ack`, `peek`, …) resolve to the right method/definer so the self-describing `OPTIONS` schema is honest.
- **AppContext wiring** — `message_bus` field built in `_build_app_context()` and closed in `shutdown_app_context()`.
- **Non-destructive adapter** — `NotificationManager.add()` still does its ring-buffer write unchanged and *also* enqueues into the bus when one is wired (retained, exception-logged fire-and-forget task). Existing notifications/cascade/subscribe behavior is unchanged.

Built as the **shared internal bus** (the foundation both messaging interpretations need); the `agent:`/`team:`/`broadcast` scheme and the long-poll primitive are designed to extend to an external Channels bridge and SSE push in later phases. Design doc: `docs/research-agent-comms` branch.

Review note: the new `core/bus.py` is a fresh durable inbox rather than a retrofit of the in-memory, type-dispatch `core/messaging.py` `MessageRouter` — the two solve different problems and now coexist (documented in the plan doc). A critical TTL-expiry SQL bug found in review (raw-string timestamp compare dropping positive-TTL messages) was fixed and covered.

## Test Plan
- [x] `python -m unittest tests.test_bus` — 40 tests passing (addressing, durable enqueue/receive/ack, cursor advancement, per-recipient FIFO, long-poll wake vs timeout, restart durability, positive-TTL retention, notification adapter, tool verb aliases).
- [x] `python scripts/test_baseline.py --timeout 60` — 37 PASS / 4 pre-existing pytest-style / 7 pre-existing live-iTerm2 over 48 modules; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
