### PR TITLE
feat: toggleable always-multiple-choice coercion (stacked on #130)

### DIFF
--- a/docs/examples/hooks-settings.json
+++ b/docs/examples/hooks-settings.json
@@ -1,6 +1,18 @@
 {
-  "_comment": "Example Claude Code hooks configuration for ControIDE Phase-0 driver. Copy the relevant hooks into your project's .claude/settings.json. The Stop hook blocks with a 600s timeout so the human has time to decide; the PreToolUse hook uses 60s. Both fall back safely if the dashboard is not running.",
+  "_comment": "Example Claude Code hooks configuration for ControIDE Phase-0 driver + MC coercion. Copy the relevant hooks into your project's .claude/settings.json. The Stop hook blocks with a 600s timeout so the human has time to decide; the PreToolUse hook uses 60s. UserPromptSubmit is fast (flag-file check only, no HTTP). All hooks fall back safely if the dashboard is not running or the flag is absent.",
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/userpromptsubmit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/docs/superpowers/plans/2026-06-13-mc-coercion.md
+++ b/docs/superpowers/plans/2026-06-13-mc-coercion.md
@@ -1,0 +1,182 @@
+# Always-Multiple-Choice (MC) Coercion — Design Doc
+
+**Date:** 2026-06-13
+**Branch:** `feat/mc-coercion` (stacked on ControIDE driver branch, PR #130)
+**Status:** Implementation plan → active
+
+---
+
+## Problem
+
+Claude Code responses often present a wall of prose. When the human-in-the-loop
+driver is running, we want every assistant turn to end with a structured
+multiple-choice list so the dashboard can offer quick-select tiles and so
+operators can see exactly what Claude thinks the options are.
+
+---
+
+## Design: Three Layers
+
+### Layer 1 — Toggle flag file
+
+```
+~/.iterm-mcp/multiple-choice.on
+```
+
+- **Present** → MC coercion ON.
+- **Absent** → OFF; all hooks behave exactly as #130.
+- No daemon restart needed; hooks re-stat the file each invocation.
+- Toggle script: `hooks/mc_toggle.sh on|off|status`.
+- Optional future: `/api/mc-toggle` endpoint on `core/dashboard.py` so the
+  browser tile can flip it live. (Seam left in code with a TODO comment.)
+
+### Layer 2 — UserPromptSubmit hook (soft injection)
+
+When the flag is ON, every user message receives `additionalContext` instructing
+Claude to end its next response with a numbered multiple-choice list.
+
+**Output shape (ON):**
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "<MC_INSTRUCTION>"
+  }
+}
+```
+
+**Output shape (OFF):**
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit"
+  }
+}
+```
+
+This hook also **resets** the per-session reprompt counter (see Layer 3) because
+a new user turn begins; whatever Claude did last turn is irrelevant.
+
+### Layer 3 — Stop hook reprompt-once enforcement
+
+When the flag is ON:
+
+1. Inspect the just-finished assistant turn via `_read_last_assistant_text`.
+2. If the text does **not** match `OPTION_PATTERN` AND the per-session reprompt
+   counter is `0`:
+   - Return `{"decision": "block", "reason": "<reprompt instruction>"}`.
+   - Increment counter to `1`.
+3. If options **are** present, **or** counter is already `1`:
+   - Fall through to the existing #130 stop behavior (present turn-end options
+     to the dashboard).
+   - **Phase-2 seam (TODO):** When counter is 1 and options still missing,
+     synthesize a choices list from the transcript before posting to the
+     dashboard, rather than showing raw prose.
+
+When the flag is OFF, the stop hook behaves exactly as in #130.
+
+---
+
+## Format Spec — `OPTION_PATTERN`
+
+Accepted formats (any of):
+
+```
+1) Title: description text
+1. Title: description text
+(1) Title: description text
+```
+
+Regex (shared between injection instruction and detector):
+
+```python
+OPTION_PATTERN = re.compile(r'^\s*(?:\d+[.)]\s+|\(\d+\)\s+)\S', re.MULTILINE)
+```
+
+At least **one** matching line anywhere in the assistant response passes detection.
+
+### Injection instruction (injected into `additionalContext`)
+
+```
+Please end your response with a numbered list of 3–5 suggested next steps,
+formatted as:
+
+  1) Option title: brief description
+  2) Option title: brief description
+  ...
+
+Use exactly this format so the driver dashboard can display quick-select tiles.
+```
+
+The detector's regex matches this format so a complying Claude always passes.
+
+---
+
+## Loop-Guard State Machine
+
+State is stored per-session in:
+
+```
+~/.iterm-mcp/mc_reprompt/<session_id>
+```
+
+Content: a single integer (`0` or `1`).
+
+| Event | Action |
+|---|---|
+| UserPromptSubmit | Write `0` to state file (reset for new turn) |
+| Stop hook, flag ON, options missing, count=0 | Block; write `1` |
+| Stop hook, flag ON, options missing, count=1 | Fall through (Phase-2 seam) |
+| Stop hook, flag ON, options present | Fall through |
+| Stop hook, flag OFF | Skip all MC logic |
+
+Missing or corrupt state files are treated as `0`.
+
+State dir is configurable via `MC_STATE_DIR` env var (for tests).
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `hooks/driver_hook.py` | Extended with `userpromptsubmit` mode + stop-hook MC layer |
+| `hooks/userpromptsubmit.sh` | Thin wrapper: `exec python driver_hook.py userpromptsubmit` |
+| `hooks/mc_toggle.sh` | `on\|off\|status` toggle for `~/.iterm-mcp/multiple-choice.on` |
+| `docs/examples/hooks-settings.json` | Updated with `UserPromptSubmit` hook entry |
+| `tests/test_mc_coercion.py` | Unittest coverage for all three layers |
+| `docs/superpowers/plans/2026-06-13-mc-coercion.md` | This document |
+
+---
+
+## Phase-2 Synthesize-Fallback Seam
+
+Location: `hooks/driver_hook.py` → `run_stop_hook()`, guarded by:
+
+```python
+# TODO Phase-2: synthesize options from transcript when Claude didn't comply
+# after reprompt. Replace `prompt` below with AI-generated choices list.
+```
+
+The Phase-2 synthesizer would call a local LLM (or the same Claude session via
+`-p` flag) to extract 3–5 choices from the assistant text before posting to the
+dashboard, so operators get sensible tiles even when Claude ignores the format.
+
+---
+
+## Toggle — Browser Seam
+
+`core/dashboard.py` has a commented-out route `# TODO: /api/mc-toggle` between
+the `/api/answer` and `/api/db/*` routes. Implementing it is low-effort (touch
+or rm the flag file) but deferred to keep this PR focused on the hook layer.
+
+---
+
+## OFF-path guarantee
+
+Every new code path in `driver_hook.py` is gated by `_mc_flag_on()` which is a
+single `Path.exists()` call. When the flag file is absent, no new code runs:
+
+- `run_userpromptsubmit_hook` emits the minimal no-op JSON immediately.
+- `run_stop_hook` proceeds to the existing #130 code path without reading the
+  transcript for MC purposes or touching state files.

--- a/docs/superpowers/plans/2026-06-13-mc-coercion.md
+++ b/docs/superpowers/plans/2026-06-13-mc-coercion.md
@@ -27,8 +27,9 @@ operators can see exactly what Claude thinks the options are.
 - **Absent** → OFF; all hooks behave exactly as #130.
 - No daemon restart needed; hooks re-stat the file each invocation.
 - Toggle script: `hooks/mc_toggle.sh on|off|status`.
-- Optional future: `/api/mc-toggle` endpoint on `core/dashboard.py` so the
-  browser tile can flip it live. (Seam left in code with a TODO comment.)
+- Optional future: a future `POST /api/mc-toggle` route could be added near
+  `/api/answer` to let the browser driver flip the flag.  `core/dashboard.py`
+  is not modified by this PR — adding the route is a separate concern.
 
 ### Layer 2 — UserPromptSubmit hook (soft injection)
 
@@ -166,9 +167,10 @@ dashboard, so operators get sensible tiles even when Claude ignores the format.
 
 ## Toggle — Browser Seam
 
-`core/dashboard.py` has a commented-out route `# TODO: /api/mc-toggle` between
-the `/api/answer` and `/api/db/*` routes. Implementing it is low-effort (touch
-or rm the flag file) but deferred to keep this PR focused on the hook layer.
+A future `POST /api/mc-toggle` route could be added near `/api/answer` to let
+the browser driver flip the flag (touch or rm the flag file) without a shell
+invocation.  `core/dashboard.py` is not modified by this PR — the route is
+deferred to keep this PR focused on the hook layer.
 
 ---
 

--- a/hooks/driver_hook.py
+++ b/hooks/driver_hook.py
@@ -63,8 +63,11 @@ PRETOOLUSE_OPTIONS = [
 #   1) Title: description
 #   1. Title: description
 #   (1) Title: description
+#   **1)** Title: description    (bolded marker)
+#   **1. Title: desc**           (whole line bolded)
+#   - 1) Title: description      (leading bullet)
 # At least one such line anywhere in the assistant turn passes detection.
-OPTION_PATTERN = re.compile(r'^\s*(?:\d+[.)]\s+|\(\d+\)\s+)\S', re.MULTILINE)
+OPTION_PATTERN = re.compile(r'^\s*(?:[-*]\s+)?\*{0,2}(?:\d+[.)]|\(\d+\))\*{0,2}\s+\S', re.MULTILINE)
 
 # The instruction injected into every UserPromptSubmit when MC coercion is ON.
 # Written to agree exactly with OPTION_PATTERN so a complying Claude passes.
@@ -118,6 +121,10 @@ def _mc_state_dir() -> Path:
     The directory can be overridden via the MC_STATE_DIR environment variable
     so tests can use a temp directory without touching ~/.iterm-mcp.
 
+    Also opportunistically prunes counter files whose mtime is older than
+    7 days.  The prune is cheap (one stat per file) and fully exception-safe:
+    any failure is silently ignored so a broken prune never crashes the hook.
+
     Returns:
         Path to the state directory (created if absent).
     """
@@ -127,6 +134,21 @@ def _mc_state_dir() -> Path:
     else:
         d = Path.home() / ".iterm-mcp" / "mc_reprompt"
     d.mkdir(parents=True, exist_ok=True)
+
+    # Opportunistic prune: remove counter files older than 7 days.
+    import time as _time
+    cutoff = _time.time() - (7 * 24 * 3600)
+    try:
+        for f in d.iterdir():
+            if f.is_file():
+                try:
+                    if f.stat().st_mtime < cutoff:
+                        f.unlink(missing_ok=True)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
     return d
 
 
@@ -273,16 +295,20 @@ def build_userpromptsubmit_decision(mc_on: bool) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _read_last_assistant_text(transcript_path: str, max_chars: int = 500) -> str:
+def _read_last_assistant_text(transcript_path: str, max_chars: int | None = 500) -> str:
     """Read the last assistant message text from a Claude Code JSONL transcript.
 
     Args:
         transcript_path: Absolute path to the JSONL transcript file.
-        max_chars: Maximum characters to return from the message.
+        max_chars: Maximum characters to return from the message, or None
+            for no truncation (full text).  Defaults to 500 for the #130
+            dashboard preview; pass None at the MC detection call site so
+            options at the end of long responses are not missed.
 
     Returns:
-        First max_chars characters of the last assistant message, or an
-        empty string if the file cannot be read or has no assistant messages.
+        Up to max_chars characters of the last assistant message (or the
+        full text when max_chars is None), or an empty string if the file
+        cannot be read or has no assistant messages.
     """
     try:
         lines = Path(transcript_path).read_text(encoding="utf-8").splitlines()
@@ -311,7 +337,7 @@ def _read_last_assistant_text(transcript_path: str, max_chars: int = 500) -> str
                     parts.append(block.get("text", ""))
             last_text = " ".join(parts)
 
-    return last_text[:max_chars]
+    return last_text if max_chars is None else last_text[:max_chars]
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +420,9 @@ def run_stop_hook(stdin_data: dict) -> None:
         transcript_path = stdin_data.get("transcript_path", "")
         session_id = stdin_data.get("session_id", "")
 
-        last_text = _read_last_assistant_text(transcript_path) if transcript_path else ""
+        # Use max_chars=None to scan the FULL assistant text — options may
+        # appear well past char 500 in long responses.
+        last_text = _read_last_assistant_text(transcript_path, max_chars=None) if transcript_path else ""
         reprompt_count = _read_reprompt_count(session_id)
 
         if not _response_has_options(last_text) and reprompt_count < 1:

--- a/hooks/driver_hook.py
+++ b/hooks/driver_hook.py
@@ -2,24 +2,38 @@
 """
 ControIDE Phase-0 driver hook helper.
 
-Called by stop.sh and pretooluse.sh. Reads Claude Code hook JSON from stdin,
-POSTs a question to the dashboard server, blocks until answered, then emits
-the structured hook-decision JSON to stdout.
+Called by stop.sh, pretooluse.sh, and userpromptsubmit.sh. Reads Claude Code
+hook JSON from stdin, dispatches to the appropriate handler, and emits
+structured hook-decision JSON to stdout.
 
 Usage:
-    driver_hook.py stop        # Stop hook
-    driver_hook.py pretooluse  # PreToolUse hook
+    driver_hook.py stop              # Stop hook
+    driver_hook.py pretooluse        # PreToolUse hook
+    driver_hook.py userpromptsubmit  # UserPromptSubmit hook
+
+Multiple-choice (MC) coercion:
+    When the flag file ~/.iterm-mcp/multiple-choice.on exists, the
+    UserPromptSubmit hook injects an instruction asking Claude to end its
+    response with a numbered multiple-choice list. The Stop hook checks whether
+    the assistant turn contains options in that format; if not (and this is the
+    first Stop for the current user turn), it blocks with a reprompt once.
+    Toggle the feature with hooks/mc_toggle.sh on|off|status.
+
+    State-dir override: set env MC_STATE_DIR to a directory path (used by tests
+    so they don't touch ~/.iterm-mcp).
 
 Error handling:
     If the dashboard is not running or /api/ask times out, the hook falls
     back to a safe default and does NOT crash Claude Code:
     - Stop hook fallback: emit {} (let Claude stop naturally)
     - PreToolUse hook fallback: emit allow (permissive default)
+    - UserPromptSubmit fallback: emit minimal no-op JSON
     Errors are logged to stderr so they appear in Claude Code's hook logs.
 """
 
 import json
 import os
+import re
 import sys
 import urllib.request
 import urllib.error
@@ -40,6 +54,135 @@ PRETOOLUSE_OPTIONS = [
     {"id": "deny",  "label": "Deny",       "text": "deny"},
     {"id": "ask",   "label": "Ask (edit)", "text": "ask"},
 ]
+
+# ---------------------------------------------------------------------------
+# Multiple-choice coercion constants
+# ---------------------------------------------------------------------------
+
+# Regex that matches a numbered option line in any of the accepted formats:
+#   1) Title: description
+#   1. Title: description
+#   (1) Title: description
+# At least one such line anywhere in the assistant turn passes detection.
+OPTION_PATTERN = re.compile(r'^\s*(?:\d+[.)]\s+|\(\d+\)\s+)\S', re.MULTILINE)
+
+# The instruction injected into every UserPromptSubmit when MC coercion is ON.
+# Written to agree exactly with OPTION_PATTERN so a complying Claude passes.
+MC_INSTRUCTION = (
+    "Please end your response with a numbered list of 3-5 suggested next "
+    "steps or options, formatted exactly as:\n\n"
+    "  1) Option title: brief description\n"
+    "  2) Option title: brief description\n"
+    "  ...\n\n"
+    "Use this exact format (number, closing parenthesis, space, title, colon, "
+    "space, description) so the driver dashboard can display quick-select tiles."
+)
+
+# Reprompt reason injected into the Stop block decision when options are missing.
+MC_REPROMPT_REASON = (
+    "Your response is missing the required numbered options list. "
+    "Please restate your answer and end with 3-5 numbered options in this format:\n"
+    "  1) Option title: brief description\n"
+    "  2) Option title: brief description\n"
+    "  ...\n"
+    "This allows the driver dashboard to display quick-select tiles."
+)
+
+
+# ---------------------------------------------------------------------------
+# MC flag + state helpers (pure functions, importable for testing)
+# ---------------------------------------------------------------------------
+
+
+def _mc_flag_path() -> Path:
+    """Return the path of the MC coercion toggle flag file.
+
+    Returns:
+        Path to ~/.iterm-mcp/multiple-choice.on
+    """
+    return Path.home() / ".iterm-mcp" / "multiple-choice.on"
+
+
+def _mc_flag_on() -> bool:
+    """Return True when the MC coercion toggle flag file exists.
+
+    Returns:
+        True if the flag file is present, False otherwise.
+    """
+    return _mc_flag_path().exists()
+
+
+def _mc_state_dir() -> Path:
+    """Return the directory used for per-session reprompt counters.
+
+    The directory can be overridden via the MC_STATE_DIR environment variable
+    so tests can use a temp directory without touching ~/.iterm-mcp.
+
+    Returns:
+        Path to the state directory (created if absent).
+    """
+    override = os.environ.get("MC_STATE_DIR")
+    if override:
+        d = Path(override)
+    else:
+        d = Path.home() / ".iterm-mcp" / "mc_reprompt"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _session_state_path(session_id: str) -> Path:
+    """Return the reprompt-counter file path for a session.
+
+    Args:
+        session_id: The Claude Code session identifier string.
+
+    Returns:
+        Path to the counter file under the state directory.
+    """
+    # Sanitize: keep only alnum, dash, underscore to avoid path traversal.
+    safe = re.sub(r'[^a-zA-Z0-9_\-]', '_', session_id) if session_id else "default"
+    return _mc_state_dir() / safe
+
+
+def _read_reprompt_count(session_id: str) -> int:
+    """Read the reprompt counter for a session.
+
+    Args:
+        session_id: The Claude Code session identifier string.
+
+    Returns:
+        The counter value (0 if absent or corrupt).
+    """
+    p = _session_state_path(session_id)
+    try:
+        return int(p.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def _write_reprompt_count(session_id: str, count: int) -> None:
+    """Write the reprompt counter for a session.
+
+    Args:
+        session_id: The Claude Code session identifier string.
+        count: The integer value to persist.
+    """
+    p = _session_state_path(session_id)
+    p.write_text(str(count), encoding="utf-8")
+
+
+def _response_has_options(text: str) -> bool:
+    """Return True when text contains at least one numbered option line.
+
+    Uses OPTION_PATTERN so the detector agrees exactly with MC_INSTRUCTION.
+
+    Args:
+        text: The assistant turn text to inspect.
+
+    Returns:
+        True if a numbered option line is found, False otherwise.
+    """
+    return bool(OPTION_PATTERN.search(text))
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +241,29 @@ def build_pretooluse_decision(answer: dict) -> dict:
             "hookEventName": "PreToolUse",
             "permissionDecision": decision,
             "permissionDecisionReason": decision,
+        }
+    }
+
+
+def build_userpromptsubmit_decision(mc_on: bool) -> dict:
+    """Shape a UserPromptSubmit hook JSON output.
+
+    Args:
+        mc_on: Whether MC coercion is currently enabled.
+
+    Returns:
+        hookSpecificOutput envelope, with additionalContext when mc_on is True.
+    """
+    if mc_on:
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": MC_INSTRUCTION,
+            }
+        }
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
         }
     }
 
@@ -185,12 +351,66 @@ def _post_ask(payload: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def run_userpromptsubmit_hook(stdin_data: dict) -> None:
+    """Execute the UserPromptSubmit hook logic.
+
+    When MC coercion is ON: resets the per-session reprompt counter (new user
+    turn) and emits additionalContext instructing Claude to end its response
+    with a numbered multiple-choice list.
+
+    When MC coercion is OFF: emits the minimal no-op JSON immediately.
+
+    Args:
+        stdin_data: Parsed JSON from Claude Code's UserPromptSubmit hook stdin.
+    """
+    mc_on = _mc_flag_on()
+
+    if mc_on:
+        # Reset per-session reprompt counter — new user turn begins.
+        session_id = stdin_data.get("session_id", "")
+        _write_reprompt_count(session_id, 0)
+
+    decision = build_userpromptsubmit_decision(mc_on)
+    print(json.dumps(decision))
+
+
 def run_stop_hook(stdin_data: dict) -> None:
     """Execute the Stop hook logic.
+
+    When MC coercion is ON:
+        1. Reads the last assistant turn from the transcript.
+        2. If options are missing AND reprompt count < 1: blocks with a
+           reprompt instruction and increments the counter.
+        3. Otherwise: falls through to the existing #130 dashboard behavior.
+           (Phase-2 seam: when count==1 and options still missing, a future
+           synthesizer would generate options here before posting to dashboard.)
+
+    When MC coercion is OFF: proceeds directly to the #130 dashboard behavior.
 
     Args:
         stdin_data: Parsed JSON from Claude Code's Stop hook stdin.
     """
+    if _mc_flag_on():
+        transcript_path = stdin_data.get("transcript_path", "")
+        session_id = stdin_data.get("session_id", "")
+
+        last_text = _read_last_assistant_text(transcript_path) if transcript_path else ""
+        reprompt_count = _read_reprompt_count(session_id)
+
+        if not _response_has_options(last_text) and reprompt_count < 1:
+            # Block once and ask Claude to redo with numbered options.
+            _write_reprompt_count(session_id, 1)
+            print(json.dumps({"decision": "block", "reason": MC_REPROMPT_REASON}))
+            return
+
+        # Options present, or we already reprompted once — fall through.
+        # TODO Phase-2: when reprompt_count == 1 and options still missing,
+        # synthesize a choices list from `last_text` here (e.g. call a local
+        # LLM or regex-extract bullet points) and inject it into `prompt`
+        # before posting to the dashboard, so operators get sensible tiles
+        # even when Claude ignores the format after being asked once.
+
+    # --- Existing #130 stop behavior (unchanged) ---
     transcript_path = stdin_data.get("transcript_path", "")
     prompt = _read_last_assistant_text(transcript_path) if transcript_path else ""
     if not prompt:
@@ -251,8 +471,9 @@ def main() -> None:
     Reads hook type from argv[1], parses stdin JSON, dispatches to the
     appropriate run_*_hook function.
     """
-    if len(sys.argv) < 2 or sys.argv[1] not in ("stop", "pretooluse"):
-        print("Usage: driver_hook.py stop | pretooluse", file=sys.stderr)
+    valid_modes = ("stop", "pretooluse", "userpromptsubmit")
+    if len(sys.argv) < 2 or sys.argv[1] not in valid_modes:
+        print(f"Usage: driver_hook.py {'|'.join(valid_modes)}", file=sys.stderr)
         sys.exit(1)
 
     hook_type = sys.argv[1]
@@ -266,8 +487,10 @@ def main() -> None:
 
     if hook_type == "stop":
         run_stop_hook(stdin_data)
-    else:
+    elif hook_type == "pretooluse":
         run_pretooluse_hook(stdin_data)
+    else:
+        run_userpromptsubmit_hook(stdin_data)
 
 
 if __name__ == "__main__":

--- a/hooks/mc_toggle.sh
+++ b/hooks/mc_toggle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ControIDE MC coercion toggle helper.
+#
+# Usage:
+#   mc_toggle.sh on      — enable always-multiple-choice coercion
+#   mc_toggle.sh off     — disable always-multiple-choice coercion
+#   mc_toggle.sh status  — print current state (on/off) and flag path
+#
+# The toggle works by touching / removing the flag file:
+#   ~/.iterm-mcp/multiple-choice.on
+#
+# No daemon restart is needed; hook scripts re-check the file each invocation.
+#
+# Browser seam: the dashboard could expose POST /api/mc-toggle that calls
+# this script (or directly touches/removes the flag file). See the TODO
+# comment in core/dashboard.py near the /api/answer route.
+
+set -euo pipefail
+
+FLAG_FILE="${HOME}/.iterm-mcp/multiple-choice.on"
+FLAG_DIR="$(dirname "${FLAG_FILE}")"
+
+cmd="${1:-}"
+
+case "${cmd}" in
+  on)
+    mkdir -p "${FLAG_DIR}"
+    touch "${FLAG_FILE}"
+    echo "MC coercion ON  (${FLAG_FILE})"
+    ;;
+  off)
+    rm -f "${FLAG_FILE}"
+    echo "MC coercion OFF (${FLAG_FILE} removed)"
+    ;;
+  status)
+    if [ -f "${FLAG_FILE}" ]; then
+      echo "MC coercion: ON  (${FLAG_FILE})"
+    else
+      echo "MC coercion: OFF (${FLAG_FILE} absent)"
+    fi
+    ;;
+  *)
+    echo "Usage: mc_toggle.sh on | off | status" >&2
+    exit 1
+    ;;
+esac

--- a/hooks/mc_toggle.sh
+++ b/hooks/mc_toggle.sh
@@ -11,9 +11,9 @@
 #
 # No daemon restart is needed; hook scripts re-check the file each invocation.
 #
-# Browser seam: the dashboard could expose POST /api/mc-toggle that calls
-# this script (or directly touches/removes the flag file). See the TODO
-# comment in core/dashboard.py near the /api/answer route.
+# Browser seam: a future POST /api/mc-toggle route could be added near
+# /api/answer to let the browser driver flip the flag (touch/rm the file)
+# without a shell invocation.  core/dashboard.py is not modified by this PR.
 
 set -euo pipefail
 

--- a/hooks/userpromptsubmit.sh
+++ b/hooks/userpromptsubmit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# ControIDE MC coercion UserPromptSubmit hook.
+# Invoked by Claude Code on every UserPromptSubmit event; delegates to
+# driver_hook.py. When the MC coercion flag is ON it injects additionalContext
+# instructing Claude to end its response with a numbered multiple-choice list
+# and resets the per-session reprompt counter.
+set -euo pipefail
+exec python "$(dirname "$0")/driver_hook.py" userpromptsubmit

--- a/tests/test_mc_coercion.py
+++ b/tests/test_mc_coercion.py
@@ -614,5 +614,185 @@ class TestStateFileRobustness(McCoercionTestBase):
         self.assertEqual(p.name, "default")
 
 
+# ---------------------------------------------------------------------------
+# 9. Fix 1 — full-text option detection (long responses)
+# ---------------------------------------------------------------------------
+
+
+class TestFullTextDetection(McCoercionTestBase):
+    """Fix 1: options at the END of a long response must be detected.
+
+    The bug: _read_last_assistant_text(transcript, max_chars=500) was called
+    at the MC detection site, so options after the first 500 chars were
+    invisible and the hook would spuriously block on every long compliant turn.
+    Fix: call _read_last_assistant_text with max_chars=None at the detection
+    site so the full text is scanned.
+    """
+
+    SESSION = "fulltext-session"
+
+    def test_long_compliant_response_not_blocked(self) -> None:
+        """Stop does NOT block when options appear after the first 500 chars.
+
+        The assistant text is >500 chars of prose followed by a numbered list
+        at the end. With the bug (max_chars=500) the options are invisible and
+        the hook blocks; with the fix (max_chars=None) they are found and the
+        hook falls through.
+        """
+        self.enable_mc()
+
+        # Build a response whose options start well past char 500.
+        preamble = "A" * 600  # 600 chars of prose — options will start at char 600+
+        options_block = "\n1) Refactor: clean up the module\n2) Deploy: push to prod\n3) Wait: gather more info"
+        long_text = preamble + options_block
+
+        transcript = self._make_transcript(long_text)
+
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        # MC layer should NOT block — options are present (past char 500).
+        # _post_ask raises → fallback {} returned when not blocked.
+        reason = result.get("reason", "")
+        self.assertNotEqual(
+            result.get("decision"), "block",
+            msg="Stop should NOT block: options are present past char 500 — "
+                "full-text scan required. reason=%r" % reason,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. Fix 2 — hardened OPTION_PATTERN for bolded/bulleted output
+# ---------------------------------------------------------------------------
+
+
+class TestHardenedOptionPattern(McCoercionTestBase):
+    """Fix 2: OPTION_PATTERN must accept bolded/bulleted formats Claude emits.
+
+    New accepted forms:
+        **1)** Title       — bolded marker only
+        **1. Title: y**    — whole line bolded
+        - 1) Title         — leading bullet before number
+
+    Still rejected:
+        - Option A          — bullet with no number
+        1)                  — bare marker, nothing after
+        There are 3) reasons — mid-sentence number
+        plain prose
+    """
+
+    # ---- Positive (must match) ------------------------------------------------
+
+    def test_bolded_marker_paren_matches(self) -> None:
+        """'**1)** Title' is detected as an option."""
+        text = "Here is my response.\n**1)** Refactor: clean the code\n**2)** Deploy: push it"
+        self.assertTrue(
+            self.hook._response_has_options(text),
+            "**1)** format should match",
+        )
+
+    def test_bolded_whole_line_dot_matches(self) -> None:
+        """'**1. Title: desc**' (whole line bolded) is detected."""
+        text = "Let me suggest:\n**1. Refactor: clean it up**\n**2. Deploy: push now**"
+        self.assertTrue(
+            self.hook._response_has_options(text),
+            "**1. Title: desc** format should match",
+        )
+
+    def test_bullet_then_number_matches(self) -> None:
+        """'- 1) Title' (leading bullet before number) is detected."""
+        text = "Options:\n- 1) Alpha: first choice\n- 2) Beta: second choice"
+        self.assertTrue(
+            self.hook._response_has_options(text),
+            "- 1) format should match",
+        )
+
+    def test_star_bullet_then_number_matches(self) -> None:
+        """'* 1) Title' (asterisk bullet before number) is detected."""
+        text = "Options:\n* 1) Alpha: first\n* 2) Beta: second"
+        self.assertTrue(
+            self.hook._response_has_options(text),
+            "* 1) format should match",
+        )
+
+    # ---- Negative (must NOT match) -------------------------------------------
+
+    def test_bullet_no_number_no_match(self) -> None:
+        """'- Option A' (bullet without number) does not match."""
+        text = "- Option A: something\n- Option B: something else"
+        self.assertFalse(
+            self.hook._response_has_options(text),
+            "plain bullet without number should not match",
+        )
+
+    def test_bare_marker_nothing_after_no_match(self) -> None:
+        """'1) ' with nothing after (trailing space only) does not match."""
+        text = "1) "
+        self.assertFalse(
+            self.hook._response_has_options(text),
+            "bare marker with no following content should not match",
+        )
+
+    def test_mid_sentence_number_no_match(self) -> None:
+        """A number mid-sentence ('There are 3) reasons') does not match."""
+        text = "There are 3) reasons why this is good."
+        self.assertFalse(
+            self.hook._response_has_options(text),
+            "mid-sentence number should not match",
+        )
+
+    def test_plain_prose_no_match(self) -> None:
+        """Plain prose without any numbered marker does not match."""
+        text = "I recommend doing X because of Y. You should also consider Z."
+        self.assertFalse(
+            self.hook._response_has_options(text),
+            "plain prose should not match",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 11. Fix 3 — opportunistic prune of stale session counter files
+# ---------------------------------------------------------------------------
+
+
+import time  # noqa: E402  (import inside module is fine for tests)
+
+
+class TestStaleCounterPrune(McCoercionTestBase):
+    """Fix 3: counter files older than 7 days are pruned when the state dir
+    is accessed.  Fresh files are kept; the prune never raises."""
+
+    def test_old_counter_pruned_new_counter_kept(self) -> None:
+        """File >7 days old is deleted; file created just now is kept."""
+        # Create an "old" counter file and back-date its mtime by 8 days.
+        old_file = self.state_dir / "old-session"
+        old_file.write_text("1", encoding="utf-8")
+        eight_days_ago = time.time() - (8 * 24 * 3600)
+        os.utime(str(old_file), (eight_days_ago, eight_days_ago))
+
+        # Create a fresh counter file (mtime = now).
+        fresh_file = self.state_dir / "fresh-session"
+        fresh_file.write_text("0", encoding="utf-8")
+
+        # Trigger the prune by calling _mc_state_dir() (the access point
+        # that the hook calls every time it reads/writes state).
+        self.hook._mc_state_dir()
+
+        self.assertFalse(old_file.exists(), "8-day-old counter file should be pruned")
+        self.assertTrue(fresh_file.exists(), "fresh counter file should be kept")
+
+    def test_prune_does_not_raise_on_permission_error(self) -> None:
+        """A prune failure (e.g. permission error) must never crash the hook."""
+        # We simulate a prune that fails by patching os.remove/Path.unlink.
+        # The hook must not raise.
+        with patch("os.unlink", side_effect=OSError("permission denied")):
+            try:
+                self.hook._mc_state_dir()
+            except Exception as exc:  # pragma: no cover
+                self.fail(f"_mc_state_dir raised unexpectedly: {exc}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_mc_coercion.py
+++ b/tests/test_mc_coercion.py
@@ -1,0 +1,618 @@
+"""
+Tests for the always-multiple-choice (MC) coercion layer.
+
+Coverage:
+- OPTION_PATTERN detector: positive and negative cases including all accepted
+  formats (1), 1., (1)) and clear non-matching text.
+- MC flag helpers (_mc_flag_on): ON when flag file present, OFF when absent.
+- build_userpromptsubmit_decision: correct JSON shape for ON and OFF.
+- Per-session reprompt state machine:
+    UserPromptSubmit resets counter → first Stop blocks when options missing →
+    second Stop passes (falls through to dashboard); Stop does NOT block when
+    options are present; OFF flag → never blocks.
+- run_userpromptsubmit_hook: emits correct JSON, resets counter when ON.
+- run_stop_hook MC layer: blocks once, falls through on second call, falls
+  through when options present, no-op when flag OFF.
+
+All tests use a temp directory for the MC state dir (MC_STATE_DIR env var) and
+a temp flag file so they never touch ~/.iterm-mcp. No live iTerm2 / Claude
+Code required; _post_ask is monkey-patched to avoid real HTTP.
+
+Run with:
+    python -m unittest tests.test_mc_coercion -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure the project root is on sys.path.
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers for loading driver_hook with an isolated temp environment
+# ---------------------------------------------------------------------------
+
+
+def _load_driver_hook():
+    """Import driver_hook.py as a fresh module (not cached).
+
+    Returns:
+        The driver_hook module object.
+    """
+    hooks_dir = PROJECT_ROOT / "hooks"
+    spec = importlib.util.spec_from_file_location(
+        "driver_hook", hooks_dir / "driver_hook.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class McCoercionTestBase(unittest.TestCase):
+    """Base class that sets up a temp directory for flag + state files.
+
+    Each test gets:
+        self.tmp_dir     — Path to a temporary directory
+        self.flag_file   — Path that acts as the flag file
+        self.state_dir   — Path used as MC_STATE_DIR
+        self.hook        — Fresh driver_hook module with env patched
+    """
+
+    def setUp(self) -> None:
+        self._tmpdir_ctx = tempfile.TemporaryDirectory()
+        tmp = Path(self._tmpdir_ctx.name)
+        self.tmp_dir = tmp
+        self.flag_file = tmp / "multiple-choice.on"
+        self.state_dir = tmp / "mc_reprompt"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        # Patch env so driver_hook uses our temp state dir.
+        self._env_patcher = patch.dict(
+            os.environ, {"MC_STATE_DIR": str(self.state_dir)}
+        )
+        self._env_patcher.start()
+
+        # Load a fresh module instance so env patches are picked up.
+        self.hook = _load_driver_hook()
+
+        # Patch _mc_flag_path to return our temp flag path.
+        self._flag_patcher = patch.object(
+            self.hook, "_mc_flag_path", return_value=self.flag_file
+        )
+        self._flag_patcher.start()
+
+    def tearDown(self) -> None:
+        self._flag_patcher.stop()
+        self._env_patcher.stop()
+        self._tmpdir_ctx.cleanup()
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    def enable_mc(self) -> None:
+        """Touch the flag file to turn MC coercion ON."""
+        self.flag_file.touch()
+
+    def disable_mc(self) -> None:
+        """Remove the flag file to turn MC coercion OFF."""
+        self.flag_file.unlink(missing_ok=True)
+
+    def reprompt_count(self, session_id: str) -> int:
+        """Read the reprompt counter for a session from the temp state dir."""
+        return self.hook._read_reprompt_count(session_id)
+
+    def _capture_stop(self, stdin_data: dict) -> dict:
+        """Run run_stop_hook with stdin_data and capture its stdout JSON.
+
+        _post_ask is patched to always raise so the hook never blocks on HTTP.
+        We only care about the MC-layer block decisions (which print before
+        calling _post_ask) and the fallback path (when _post_ask raises).
+
+        Returns:
+            Parsed JSON dict emitted to stdout.
+        """
+        with patch.object(self.hook, "_post_ask", side_effect=RuntimeError("no dashboard")):
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+                self.hook.run_stop_hook(stdin_data)
+                return json.loads(mock_out.getvalue().strip())
+
+    def _capture_userpromptsubmit(self, stdin_data: dict) -> dict:
+        """Run run_userpromptsubmit_hook and capture its stdout JSON.
+
+        Returns:
+            Parsed JSON dict emitted to stdout.
+        """
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+            self.hook.run_userpromptsubmit_hook(stdin_data)
+            return json.loads(mock_out.getvalue().strip())
+
+    def _make_transcript(self, assistant_text: str) -> Path:
+        """Write a minimal JSONL transcript with one assistant message.
+
+        Args:
+            assistant_text: The text content for the assistant turn.
+
+        Returns:
+            Path to the temp transcript file.
+        """
+        entry = {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": assistant_text}]
+            },
+        }
+        p = self.tmp_dir / "transcript.jsonl"
+        p.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+        return p
+
+
+# ---------------------------------------------------------------------------
+# 1. OPTION_PATTERN detector tests
+# ---------------------------------------------------------------------------
+
+
+class TestOptionPatternDetector(McCoercionTestBase):
+    """Tests for _response_has_options and OPTION_PATTERN."""
+
+    def test_format_1paren_matches(self) -> None:
+        """'1) Title: desc' format is detected."""
+        text = "Here is my response.\n1) Do the thing: because reasons\n2) Skip it: not needed"
+        self.assertTrue(self.hook._response_has_options(text))
+
+    def test_format_1dot_matches(self) -> None:
+        """'1. Title: desc' format is detected."""
+        text = "Answer:\n1. Option one: first choice\n2. Option two: second choice"
+        self.assertTrue(self.hook._response_has_options(text))
+
+    def test_format_paren1_matches(self) -> None:
+        """'(1) Title: desc' format is detected."""
+        text = "Options:\n(1) Alpha: the first\n(2) Beta: the second"
+        self.assertTrue(self.hook._response_has_options(text))
+
+    def test_single_option_line_sufficient(self) -> None:
+        """A single numbered option line is enough to pass."""
+        text = "Long prose.\n1) Only one: just one option"
+        self.assertTrue(self.hook._response_has_options(text))
+
+    def test_indented_option_matches(self) -> None:
+        """Leading whitespace before the number is accepted."""
+        text = "  1) Indented option: fine"
+        self.assertTrue(self.hook._response_has_options(text))
+
+    def test_plain_prose_no_match(self) -> None:
+        """Plain prose without numbered options does not match."""
+        text = "I recommend doing X because of Y. You should also consider Z."
+        self.assertFalse(self.hook._response_has_options(text))
+
+    def test_numbered_list_without_content_no_match(self) -> None:
+        """A bare number with close paren but no following content does not match."""
+        # '1) ' with nothing after — regex requires \S after the space
+        text = "1) "
+        self.assertFalse(self.hook._response_has_options(text))
+
+    def test_markdown_bold_no_match(self) -> None:
+        """Markdown bullets without numbers do not match."""
+        text = "- Option A: something\n- Option B: something else"
+        self.assertFalse(self.hook._response_has_options(text))
+
+    def test_number_in_middle_of_prose_no_match(self) -> None:
+        """A number mid-sentence does not trigger the detector."""
+        text = "There are 3) reasons why this is good."
+        # '3) ' followed by non-space — but it's not at line start / after indent
+        # Our pattern uses re.MULTILINE so '^' matches line start.
+        # '3) reasons' mid-sentence → does NOT start after optional whitespace
+        # Actually 'There are 3)' — the 3 is not at the start of the line.
+        self.assertFalse(self.hook._response_has_options(text))
+
+    def test_empty_string_no_match(self) -> None:
+        """Empty text does not match."""
+        self.assertFalse(self.hook._response_has_options(""))
+
+    def test_mc_instruction_itself_matches(self) -> None:
+        """The MC_INSTRUCTION example lines pass the detector."""
+        # The instruction tells Claude to use '1) Title: desc' — verify our
+        # own format passes the detector.
+        text = "1) Option title: brief description\n2) Another: second"
+        self.assertTrue(self.hook._response_has_options(text))
+
+
+# ---------------------------------------------------------------------------
+# 2. MC flag helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMcFlagHelpers(McCoercionTestBase):
+    """Tests for _mc_flag_on."""
+
+    def test_flag_on_when_file_present(self) -> None:
+        """_mc_flag_on returns True when the flag file exists."""
+        self.enable_mc()
+        self.assertTrue(self.hook._mc_flag_on())
+
+    def test_flag_off_when_file_absent(self) -> None:
+        """_mc_flag_on returns False when the flag file does not exist."""
+        self.disable_mc()
+        self.assertFalse(self.hook._mc_flag_on())
+
+
+# ---------------------------------------------------------------------------
+# 3. build_userpromptsubmit_decision
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUserPromptSubmitDecision(McCoercionTestBase):
+    """Tests for build_userpromptsubmit_decision."""
+
+    def test_mc_on_includes_additional_context(self) -> None:
+        """When mc_on=True the decision contains additionalContext."""
+        result = self.hook.build_userpromptsubmit_decision(True)
+        inner = result["hookSpecificOutput"]
+        self.assertEqual(inner["hookEventName"], "UserPromptSubmit")
+        self.assertIn("additionalContext", inner)
+        self.assertGreater(len(inner["additionalContext"]), 0)
+
+    def test_mc_off_no_additional_context(self) -> None:
+        """When mc_on=False the decision has no additionalContext."""
+        result = self.hook.build_userpromptsubmit_decision(False)
+        inner = result["hookSpecificOutput"]
+        self.assertEqual(inner["hookEventName"], "UserPromptSubmit")
+        self.assertNotIn("additionalContext", inner)
+
+    def test_additional_context_contains_format_example(self) -> None:
+        """additionalContext includes the option format so Claude knows what to emit."""
+        result = self.hook.build_userpromptsubmit_decision(True)
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        # The context should show '1)' format so Claude produces detectable output.
+        self.assertIn("1)", ctx)
+
+    def test_hook_event_name_always_userpromptsubmit(self) -> None:
+        """hookEventName is always 'UserPromptSubmit'."""
+        for mc_on in (True, False):
+            with self.subTest(mc_on=mc_on):
+                result = self.hook.build_userpromptsubmit_decision(mc_on)
+                self.assertEqual(
+                    result["hookSpecificOutput"]["hookEventName"],
+                    "UserPromptSubmit",
+                )
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-session reprompt state machine
+# ---------------------------------------------------------------------------
+
+
+class TestRepromptStateMachine(McCoercionTestBase):
+    """Tests for the full reprompt-once state machine across UserPromptSubmit
+    and Stop hook invocations."""
+
+    SESSION = "test-session-abc"
+
+    def test_userpromptsubmit_resets_counter_when_mc_on(self) -> None:
+        """UserPromptSubmit resets the reprompt counter to 0 when MC is ON."""
+        self.enable_mc()
+        # Manually set counter to 1 (as if a reprompt already happened).
+        self.hook._write_reprompt_count(self.SESSION, 1)
+        self.assertEqual(self.reprompt_count(self.SESSION), 1)
+
+        self._capture_userpromptsubmit({"session_id": self.SESSION})
+
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+    def test_userpromptsubmit_does_not_touch_counter_when_mc_off(self) -> None:
+        """UserPromptSubmit does NOT write a counter file when MC is OFF."""
+        self.disable_mc()
+        # No counter file should be created.
+        state_file = self.hook._session_state_path(self.SESSION)
+        self.assertFalse(state_file.exists())
+
+        self._capture_userpromptsubmit({"session_id": self.SESSION})
+
+        self.assertFalse(state_file.exists())
+
+    def test_first_stop_blocks_when_options_missing(self) -> None:
+        """First Stop call blocks with a reprompt when options are absent."""
+        self.enable_mc()
+        # Counter starts at 0 (no state file).
+        transcript = self._make_transcript("Here is my plain prose answer with no options.")
+
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("reason", result)
+        self.assertGreater(len(result["reason"]), 0)
+
+    def test_first_stop_increments_counter(self) -> None:
+        """First Stop block increments the reprompt counter to 1."""
+        self.enable_mc()
+        transcript = self._make_transcript("No options here at all.")
+
+        self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        self.assertEqual(self.reprompt_count(self.SESSION), 1)
+
+    def test_second_stop_falls_through_when_options_still_missing(self) -> None:
+        """Second Stop (counter==1) falls through even if options are still absent.
+
+        'Fall through' here means the MC layer does NOT emit a block decision;
+        it falls to the existing #130 dashboard path. Since we mock _post_ask
+        to raise, the fallback {} (empty let-stop) is returned instead of a
+        block decision — the key assertion is that decision != block with the
+        MC reprompt reason.
+        """
+        self.enable_mc()
+        self.hook._write_reprompt_count(self.SESSION, 1)
+        transcript = self._make_transcript("Still no options after reprompt.")
+
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        # Should NOT be the MC reprompt block — it's either {} (dashboard
+        # fallback) or whatever the dashboard returned. The MC reprompt block
+        # carries MC_REPROMPT_REASON in its reason field.
+        reason = result.get("reason", "")
+        self.assertNotIn("numbered", reason.lower(),
+                         msg="Second stop should not re-emit the numbered-options reprompt")
+
+    def test_stop_does_not_block_when_options_present(self) -> None:
+        """Stop falls through (no MC block) when options are already present."""
+        self.enable_mc()
+        transcript = self._make_transcript(
+            "Here is my answer.\n1) Do X: because A\n2) Do Y: because B"
+        )
+
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        # MC layer should not block — falls through to dashboard path.
+        # _post_ask raises → fallback {} returned.
+        reason = result.get("reason", "")
+        self.assertNotIn("numbered", reason.lower(),
+                         msg="Stop should not block when options are present")
+
+    def test_stop_counter_not_incremented_when_options_present(self) -> None:
+        """Counter is not incremented when options are present (no block issued)."""
+        self.enable_mc()
+        transcript = self._make_transcript(
+            "My answer.\n1) Alpha: first\n2) Beta: second"
+        )
+
+        self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        # Counter should remain 0 (fall-through, no block).
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+    def test_stop_mc_off_never_blocks_for_options(self) -> None:
+        """When MC is OFF, Stop never issues an MC reprompt block."""
+        self.disable_mc()
+        transcript = self._make_transcript("Plain prose, no options, MC is off.")
+
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+
+        reason = result.get("reason", "")
+        self.assertNotIn("numbered", reason.lower(),
+                         msg="MC OFF: stop should not issue MC reprompt block")
+
+    def test_full_turn_lifecycle(self) -> None:
+        """UserPromptSubmit reset → first Stop blocks → second Stop falls through."""
+        self.enable_mc()
+
+        # 1. Simulate first user turn start: UPS resets counter.
+        result_ups = self._capture_userpromptsubmit({"session_id": self.SESSION})
+        inner = result_ups["hookSpecificOutput"]
+        self.assertIn("additionalContext", inner)
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+        # 2. Claude responds without options → first Stop blocks.
+        transcript = self._make_transcript("I will do the task. No options.")
+        result1 = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+        self.assertEqual(result1.get("decision"), "block")
+        self.assertEqual(self.reprompt_count(self.SESSION), 1)
+
+        # 3. Claude responds again without options → second Stop falls through.
+        result2 = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+        reason2 = result2.get("reason", "")
+        self.assertNotIn("numbered", reason2.lower())
+
+        # 4. New user turn resets counter back to 0.
+        self._capture_userpromptsubmit({"session_id": self.SESSION})
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+        # 5. With fresh counter, Stop blocks again (new turn, first missing → block).
+        result3 = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+        self.assertEqual(result3.get("decision"), "block")
+
+
+# ---------------------------------------------------------------------------
+# 5. run_userpromptsubmit_hook output shapes
+# ---------------------------------------------------------------------------
+
+
+class TestRunUserPromptSubmitHook(McCoercionTestBase):
+    """Integration-style tests for run_userpromptsubmit_hook output."""
+
+    SESSION = "ups-session-xyz"
+
+    def test_mc_on_emits_additional_context(self) -> None:
+        """When flag ON, hook emits JSON with additionalContext."""
+        self.enable_mc()
+        result = self._capture_userpromptsubmit({"session_id": self.SESSION})
+        self.assertIn("hookSpecificOutput", result)
+        inner = result["hookSpecificOutput"]
+        self.assertEqual(inner["hookEventName"], "UserPromptSubmit")
+        self.assertIn("additionalContext", inner)
+
+    def test_mc_off_emits_minimal_json(self) -> None:
+        """When flag OFF, hook emits JSON without additionalContext."""
+        self.disable_mc()
+        result = self._capture_userpromptsubmit({"session_id": self.SESSION})
+        self.assertIn("hookSpecificOutput", result)
+        inner = result["hookSpecificOutput"]
+        self.assertEqual(inner["hookEventName"], "UserPromptSubmit")
+        self.assertNotIn("additionalContext", inner)
+
+    def test_emitted_json_is_valid(self) -> None:
+        """Hook always emits valid JSON regardless of flag state."""
+        for mc_on in (True, False):
+            with self.subTest(mc_on=mc_on):
+                if mc_on:
+                    self.enable_mc()
+                else:
+                    self.disable_mc()
+                # _capture_userpromptsubmit already does json.loads; if it
+                # doesn't raise, the JSON is valid.
+                self._capture_userpromptsubmit({"session_id": self.SESSION})
+
+
+# ---------------------------------------------------------------------------
+# 6. Reprompt reason content
+# ---------------------------------------------------------------------------
+
+
+class TestRepromptReasonContent(McCoercionTestBase):
+    """Tests that the block reason from Stop instructs Claude to add options."""
+
+    SESSION = "reason-session"
+
+    def test_block_reason_mentions_numbered_format(self) -> None:
+        """The MC reprompt block reason references the numbered format."""
+        self.enable_mc()
+        transcript = self._make_transcript("No options in this response.")
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+        self.assertEqual(result.get("decision"), "block")
+        reason = result.get("reason", "")
+        # Reason should tell Claude about numbered options.
+        self.assertTrue(
+            "numbered" in reason.lower() or "1)" in reason,
+            msg=f"Reprompt reason should mention numbered format, got: {reason!r}",
+        )
+
+    def test_block_reason_shows_option_format_example(self) -> None:
+        """The MC reprompt reason includes '1)' so Claude knows the format."""
+        self.enable_mc()
+        transcript = self._make_transcript("Still no options.")
+        result = self._capture_stop({
+            "session_id": self.SESSION,
+            "transcript_path": str(transcript),
+        })
+        self.assertIn("1)", result.get("reason", ""))
+
+
+# ---------------------------------------------------------------------------
+# 7. Existing #130 stop behavior preserved when MC is OFF
+# ---------------------------------------------------------------------------
+
+
+class TestExistingStopBehaviorPreserved(McCoercionTestBase):
+    """Ensure the #130 stop hook behaviors are intact when MC is OFF.
+
+    We verify that build_stop_decision still works correctly (the function
+    is unchanged), and that run_stop_hook falls through to the dashboard
+    path (or fallback) when MC is OFF.
+    """
+
+    def test_build_stop_decision_continue(self) -> None:
+        """build_stop_decision('continue') still returns block+reason."""
+        result = self.hook.build_stop_decision({"choice_id": "continue", "custom_text": None})
+        self.assertEqual(result["decision"], "block")
+
+    def test_build_stop_decision_stop(self) -> None:
+        """build_stop_decision('stop') still returns empty dict."""
+        result = self.hook.build_stop_decision({"choice_id": "stop", "custom_text": None})
+        self.assertEqual(result, {})
+
+    def test_run_stop_hook_off_no_mc_side_effects(self) -> None:
+        """With MC OFF, no counter file is created by run_stop_hook."""
+        self.disable_mc()
+        session_id = "off-session-test"
+        transcript = self._make_transcript("Plain prose, MC off.")
+        state_file = self.hook._session_state_path(session_id)
+        self.assertFalse(state_file.exists())
+
+        with patch.object(self.hook, "_post_ask", side_effect=RuntimeError("no dashboard")):
+            with patch("sys.stdout", new_callable=io.StringIO):
+                self.hook.run_stop_hook({
+                    "session_id": session_id,
+                    "transcript_path": str(transcript),
+                })
+
+        self.assertFalse(state_file.exists(),
+                         msg="MC OFF: stop hook should not create a counter file")
+
+
+# ---------------------------------------------------------------------------
+# 8. State file robustness
+# ---------------------------------------------------------------------------
+
+
+class TestStateFileRobustness(McCoercionTestBase):
+    """Edge cases for the per-session counter file."""
+
+    SESSION = "robustness-session"
+
+    def test_missing_state_file_treated_as_zero(self) -> None:
+        """_read_reprompt_count returns 0 when no state file exists."""
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+    def test_corrupt_state_file_treated_as_zero(self) -> None:
+        """_read_reprompt_count returns 0 when the state file is corrupt."""
+        p = self.hook._session_state_path(self.SESSION)
+        p.write_text("not-a-number", encoding="utf-8")
+        self.assertEqual(self.reprompt_count(self.SESSION), 0)
+
+    def test_session_id_sanitized_to_safe_filename(self) -> None:
+        """Unusual session IDs (slashes, dots) are sanitized to safe filenames."""
+        weird_id = "abc/def/../../../etc/passwd"
+        p = self.hook._session_state_path(weird_id)
+        # Must stay within the state_dir
+        try:
+            p.relative_to(self.state_dir)
+        except ValueError:
+            self.fail("_session_state_path produced a path outside state_dir")
+
+    def test_empty_session_id_uses_default(self) -> None:
+        """Empty session_id falls back to 'default' filename, not an error."""
+        p = self.hook._session_state_path("")
+        self.assertEqual(p.name, "default")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Toggleable "always-multiple-choice" coercion for Claude Code, built into the #130 driver hook layer. Stacked on `feat/controide-driver-phase0` — **merge #130 first.**

Three layers, all gated on a flag file `~/.iterm-mcp/multiple-choice.on` (live toggle, no restart):
- **`UserPromptSubmit` hook** — when ON, injects `additionalContext` instructing numbered multiple-choice; also resets a per-session reprompt counter (new user turn).
- **`Stop` hook (extends #130's)** — when ON and the finished turn lacks options, returns `{"decision":"block","reason":…}` exactly **once** (per-session counter, loop-guarded), then falls through to #130's dashboard behavior. Phase-2 choice-synthesizer is the documented final fallback.
- **OFF is a strict no-op** vs #130 — no transcript read, no state files.

`hooks/mc_toggle.sh on|off|status` flips the flag; a future `POST /api/mc-toggle` could let the browser driver toggle it.

Review fixes folded in: full-text option detection (was reading the first 500 chars; options land at the end), a hardened regex that accepts Claude's common **bolded**/bulleted markers (`**1)**`, `- 1)`), and a 7-day prune of the per-session counter files (avoids the unbounded-growth leak class).

## Test Plan
- [x] `python -m unittest tests.test_driver tests.test_mc_coercion` — **72 tests** (#130's 23 preserved + 49 here), all green.
- [ ] Manual: wire `UserPromptSubmit`+`Stop` from `docs/examples/hooks-settings.json`, `touch ~/.iterm-mcp/multiple-choice.on`, confirm Claude switches to options mid-session and reverts on `rm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
