### PR TITLE
feat: open new iTerm2 windows in the background by default

### DIFF
--- a/core/terminal.py
+++ b/core/terminal.py
@@ -185,12 +185,24 @@ class ItermTerminal:
         # Return the matching ItermSession wrapper
         return self.sessions.get(iterm_session.session_id)
 
-    async def create_window(self, profile: Optional[str] = None) -> ItermSession:
+    async def create_window(
+        self,
+        profile: Optional[str] = None,
+        foreground: bool = False,
+    ) -> ItermSession:
         """Create a new iTerm2 window.
+
+        By default the new window opens in the background: focus is
+        restored to whichever window was frontmost before the call. Pass
+        ``foreground=True`` to preserve the old behaviour where the new
+        window becomes the active window within iTerm2.
 
         Args:
             profile: Optional profile name to use. If None, uses the "MCP Agent"
                      profile if it exists, otherwise the default profile.
+            foreground: If True, the new window becomes the active window (old
+                        default behaviour). If False (default), focus is restored
+                        to the previously-active window after creation.
 
         Returns:
             The session for the new window
@@ -198,10 +210,16 @@ class ItermTerminal:
         if not self.app:
             raise RuntimeError("Terminal not initialized")
 
+        # Capture the currently-active window so we can restore focus afterward
+        # when opening in the background.  May be None if no window is open.
+        previous_window = self.app.current_terminal_window if not foreground else None
+
         # Use MCP Agent profile by default if available
         profile_to_use = profile or "MCP Agent"
 
-        # Create a new window with the specified profile
+        # Create a new window with the specified profile.
+        # async_create always makes the new window the key/front window within
+        # iTerm2; the restore call below counteracts that for background opens.
         try:
             window = await iterm2.Window.async_create(
                 connection=self.connection,
@@ -210,6 +228,26 @@ class ItermTerminal:
         except Exception:
             # Fall back to default profile if the specified profile doesn't exist
             window = await iterm2.Window.async_create(connection=self.connection)
+
+        # Restore focus to the previously-active window when opening in the
+        # background.  We skip restoration if:
+        #   • foreground=True  (caller wants the new window to be front)
+        #   • previous_window is None  (no window was open before)
+        #   • previous_window is the same object as the new window (shouldn't
+        #     happen in practice but guards against a no-op activate storm)
+        if (
+            not foreground
+            and previous_window is not None
+            and previous_window is not window
+        ):
+            try:
+                await previous_window.async_activate()
+            except Exception as exc:  # noqa: BLE001
+                # A focus-restore failure must never break window creation.
+                import logging as _logging
+                _logging.getLogger(__name__).warning(
+                    "Background window: failed to restore focus to previous window: %s", exc
+                )
         
         # Get the first session from the window
         tabs = window.tabs
@@ -247,16 +285,23 @@ class ItermTerminal:
     
     async def create_tab(self, window_id: Optional[str] = None) -> ItermSession:
         """Create a new tab in the specified window or current window.
-        
+
+        NOTE: The new tab becomes the active tab within its window after
+        creation. The background-window capture/restore pattern (added to
+        create_window) has not been applied here — tab focus changes are
+        within the same window and are less disruptive. A future extension
+        could add a ``foreground: bool = True`` parameter mirroring the one
+        in create_window.
+
         Args:
             window_id: Optional ID of the window to create the tab in
-            
+
         Returns:
             The session for the new tab
         """
         if not self.app:
             raise RuntimeError("Terminal not initialized")
-            
+
         # Get the window to create the tab in
         window = None
         if window_id:
@@ -314,6 +359,13 @@ class ItermTerminal:
         profile: Optional[str] = None
     ) -> ItermSession:
         """Create a new split pane from an existing session.
+
+        NOTE: The new pane becomes the active pane within its window after
+        creation. The background-window capture/restore pattern (added to
+        create_window) has not been applied here — pane focus changes are
+        within the same window and are less disruptive. A future extension
+        could add a ``foreground: bool = True`` parameter mirroring the one
+        in create_window.
 
         Args:
             session_id: The ID of the session to split

--- a/docs/superpowers/plans/2026-06-13-background-window-default.md
+++ b/docs/superpowers/plans/2026-06-13-background-window-default.md
@@ -1,0 +1,86 @@
+# Background-Window-Default for iTerm2 Window Creation
+
+**Date:** 2026-06-13
+**Feature:** Make new iTerm2 windows open in the background by default (no focus steal)
+
+---
+
+## Confirmed iTerm2 API Facts
+
+- `iterm2.Window.async_create(connection, profile=None, command=None, profile_customizations=None)` — has NO background/activation parameter.
+- `Window.async_activate()` — "Gives the window keyboard focus and orders it to the front." This is what raises a window within iTerm.
+- `App.async_activate(raise_all_windows=True, ignoring_other_apps=False)` — foregrounds the whole iTerm2 app. There is NO `async_deactivate`.
+- `app.current_terminal_window` — the currently-front iTerm2 terminal window (may be None). Used in `core/terminal.py` around line 168.
+- `async_create` always makes the newly created window the key/front window WITHIN iTerm2. This internal promotion is what we are suppressing via capture-and-restore.
+
+---
+
+## Mechanism: Capture-and-Restore in `create_window`
+
+**File:** `core/terminal.py`, function `create_window` (≈ lines 188–246)
+
+### Change Summary
+
+1. Add parameter `foreground: bool = False` — default False means background (new default behavior).
+2. BEFORE creating the window: capture `previous_window = self.app.current_terminal_window` (may be None).
+3. Create the window as before (`iterm2.Window.async_create(...)` with same profile/fallback logic).
+4. AFTER creating:
+   - If `foreground` is False AND `previous_window` is not None AND it is a different object than the new window: call `await previous_window.async_activate()` to restore focus.
+   - Wrap the restore call in `try/except Exception` — a focus-restore failure MUST NOT break window creation. Log at WARNING level and continue.
+5. If `foreground` is True: skip the restore entirely (leave new window in front — matches old behavior).
+6. NEVER call `app.async_activate()`.
+7. All other logic (session wrapper, logging, registry) is unchanged.
+
+### Why This Works
+
+`async_create` makes the new window front within iTerm2. By immediately calling `previous_window.async_activate()` afterward, we hand focus back to the window that was front before. From the user's perspective the new window appears but does not steal focus. This does NOT prevent the iTerm2 app itself from potentially coming to the foreground at the OS level if another app was frontmost — that behavior depends on how iTerm2 handles window creation internally and cannot be controlled without a private API.
+
+---
+
+## Scope: Tabs and Splits
+
+### Decision: Leave tabs/splits unchanged with a NOTE comment
+
+`create_tab` and `create_split_pane` also move focus within a window (the new tab or pane becomes active). Applying the same capture/restore pattern to them is feasible, but:
+
+- The user's explicit ask is about WINDOWS.
+- Tab/split focus changes are within the same window — less disruptive than a new window popping to the front.
+- Adding the pattern to all three methods at once increases the scope and risk surface for a single PR.
+
+**What was done:** Added a `# NOTE:` comment in both `create_tab` and `create_split_pane` explaining that they still steal tab/pane focus within their window, and that the capture/restore pattern could be applied as a future extension (with the same `foreground` flag).
+
+---
+
+## Backward Compatibility
+
+All callers that want the old behavior (new window comes to front) should pass `foreground=True`. The default is now `False` (background). Existing callers that do not pass the parameter will silently get the new background behavior.
+
+This is intentional: the whole point of this change is to make background the default.
+
+---
+
+## LIVE VERIFICATION NEEDED
+
+The following must be confirmed with a live iTerm2 session. No automated test can substitute for these checks:
+
+1. **New window stays behind** — With iTerm2 in the foreground and another app (e.g., Terminal.app or a browser) NOT in focus, call `create_window()` (without `foreground=True`). Confirm the new iTerm2 window opens but the PREVIOUSLY FOCUSED iTerm2 window regains focus within iTerm2 (i.e., the new window does not become the key window).
+
+2. **No disruptive flicker** — Observe whether the new window briefly appears in front before the restore call fires. A short flicker may be unavoidable due to the async round-trip. If this is unacceptable, the only alternative is a private API or a different approach (e.g., AppleScript `ignoring application responses`).
+
+3. **iTerm2 does not foreground over other apps** — If the user is working in a different app (e.g., a browser) when `create_window()` is called, confirm that iTerm2 does NOT jump to the foreground. This is the most important scenario. If iTerm2's `async_create` inherently activates the app at the OS level, `previous_window.async_activate()` alone cannot prevent it — only `app.async_activate()` on the OTHER app could help, which is not available. This would be a KNOWN LIMITATION to document.
+
+4. **`foreground=True` works** — Call `create_window(foreground=True)` and confirm the new window becomes the frontmost window in iTerm2 (old behavior preserved).
+
+5. **`previous_window=None` edge case** — Close all iTerm2 windows, then call `create_window()`. Confirm no exception is raised (no previous window to restore to).
+
+6. **Focus-restore failure is silent** — Manually test a scenario where the previous window is closed between capture and restore (hard to test, but the try/except should cover it). Check that the log shows a WARNING and no exception propagates.
+
+---
+
+## Implementation Plan
+
+1. [x] Write plan doc (`docs/superpowers/plans/2026-06-13-background-window-default.md`) — DONE (this file)
+2. [x] Write failing tests (`tests/test_background_window.py`) covering 4 assertions
+3. [x] Implement `create_window` change in `core/terminal.py`
+4. [x] Run `python -m unittest tests.test_background_window -v` (all pass)
+5. [x] Run `python scripts/test_baseline.py --timeout 60` (no regression)

--- a/tests/test_background_window.py
+++ b/tests/test_background_window.py
@@ -1,0 +1,161 @@
+"""Tests for background-window-default feature in ItermTerminal.create_window.
+
+Verifies the capture-and-restore mechanism that makes new windows open
+in the background (without stealing focus) by default.
+
+No live iTerm2 connection is required — all iTerm2 objects are mocked.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_terminal():
+    """Build a minimally-mocked ItermTerminal suitable for create_window tests.
+
+    Returns:
+        A MagicMock that impersonates ItermTerminal with a populated ``app``
+        and the real ``create_window`` method bound to it.
+    """
+    # Import here so the module-level patch on iterm2 is in effect.
+    from core.terminal import ItermTerminal
+
+    # Lightweight stand-in for iterm2.Connection — never actually called.
+    fake_connection = MagicMock()
+
+    terminal = ItermTerminal(connection=fake_connection, enable_logging=False)
+    return terminal
+
+
+def _make_app(previous_window=None, new_window=None):
+    """Build a mock iterm2 app.
+
+    Args:
+        previous_window: The mock window that was current before creation.
+        new_window: The mock window that async_create will produce.
+
+    Returns:
+        A MagicMock whose current_terminal_window is previous_window.
+    """
+    app = MagicMock()
+    app.current_terminal_window = previous_window
+    app.async_activate = AsyncMock()
+    return app
+
+
+def _make_window(session_id="sess-1"):
+    """Build a mock iterm2.Window returned by async_create.
+
+    Args:
+        session_id: The ID string the inner mock session will report.
+
+    Returns:
+        A MagicMock that looks enough like an iterm2.Window to satisfy
+        create_window's post-creation logic.
+    """
+    mock_session = MagicMock()
+    mock_session.session_id = session_id
+
+    mock_tab = MagicMock()
+    mock_tab.sessions = [mock_session]
+
+    window = MagicMock()
+    window.tabs = [mock_tab]
+    window.window_id = "win-1"
+    window.async_activate = AsyncMock()
+    return window
+
+
+# ---------------------------------------------------------------------------
+# Patch iterm2.Window.async_create at the location the SUT imports it.
+# ItermTerminal uses `import iterm2` at the top of core/terminal.py, so we
+# patch `iterm2.Window.async_create` directly.
+# ---------------------------------------------------------------------------
+
+class TestCreateWindowBackground(unittest.IsolatedAsyncioTestCase):
+    """Default (foreground=False): new window opens in the background."""
+
+    async def test_previous_window_activate_called_on_background_create(self):
+        """After create_window(), the previous window's async_activate is awaited."""
+        terminal = _make_terminal()
+
+        previous_window = MagicMock()
+        previous_window.async_activate = AsyncMock()
+        previous_window.window_id = "win-prev"
+
+        new_window = _make_window()
+        new_window.window_id = "win-new"  # different from previous
+
+        terminal.app = _make_app(previous_window=previous_window)
+
+        with patch("iterm2.Window.async_create", new=AsyncMock(return_value=new_window)):
+            session = await terminal.create_window()
+
+        # Focus was restored to the previous window.
+        previous_window.async_activate.assert_awaited_once()
+        # The new window's activate was NOT called (no explicit promotion).
+        new_window.async_activate.assert_not_awaited()
+        # App-level activate was never called.
+        terminal.app.async_activate.assert_not_awaited()
+        # A session was still returned.
+        self.assertIsNotNone(session)
+
+    async def test_foreground_true_skips_restore(self):
+        """With foreground=True the previous window's async_activate is NOT called."""
+        terminal = _make_terminal()
+
+        previous_window = MagicMock()
+        previous_window.async_activate = AsyncMock()
+        previous_window.window_id = "win-prev"
+
+        new_window = _make_window()
+        new_window.window_id = "win-new"
+
+        terminal.app = _make_app(previous_window=previous_window)
+
+        with patch("iterm2.Window.async_create", new=AsyncMock(return_value=new_window)):
+            session = await terminal.create_window(foreground=True)
+
+        previous_window.async_activate.assert_not_awaited()
+        self.assertIsNotNone(session)
+
+    async def test_no_previous_window_no_crash(self):
+        """When no window was open before creation, no restore is attempted."""
+        terminal = _make_terminal()
+
+        new_window = _make_window()
+        terminal.app = _make_app(previous_window=None)
+
+        with patch("iterm2.Window.async_create", new=AsyncMock(return_value=new_window)):
+            session = await terminal.create_window()
+
+        # No crash; a session is returned.
+        self.assertIsNotNone(session)
+        # App-level activate was never called.
+        terminal.app.async_activate.assert_not_awaited()
+
+    async def test_restore_exception_does_not_propagate(self):
+        """If the previous window's async_activate raises, create_window still succeeds."""
+        terminal = _make_terminal()
+
+        previous_window = MagicMock()
+        previous_window.window_id = "win-prev"
+        previous_window.async_activate = AsyncMock(side_effect=RuntimeError("window gone"))
+
+        new_window = _make_window()
+        new_window.window_id = "win-new"
+
+        terminal.app = _make_app(previous_window=previous_window)
+
+        with patch("iterm2.Window.async_create", new=AsyncMock(return_value=new_window)):
+            # Must NOT raise even though async_activate raises.
+            session = await terminal.create_window()
+
+        # activate was attempted (and raised internally, but swallowed).
+        previous_window.async_activate.assert_awaited_once()
+        # A valid session is still returned.
+        self.assertIsNotNone(session)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Open new iTerm2 windows in the **background by default** so an opened window doesn't get promoted to the front of the stack / steal focus.

The iTerm2 Python API has no "background" parameter on `Window.async_create` and no `async_deactivate`, so this uses the documented-primitive **capture-and-restore**: `core/terminal.py:create_window` now takes `foreground: bool = False`; when background it captures `app.current_terminal_window` before creating, then `await previous_window.async_activate()` to hand focus back to the window you were on. `app.async_activate()` is never called. The focus-restore is exception-safe (a failure never breaks window creation). `foreground=True` reproduces the old behavior; all existing no-arg callers silently get the background default.

`create_tab`/`create_split_pane` are left as-is (within-window focus is far less disruptive than a new window popping forward) with NOTE comments marking the same pattern as a future extension.

## Live verification needed
Mocked unit tests prove the focus-restore logic, but OS-level window stacking can't be unit-tested. On a real iTerm2, confirm: (1) a new window opens behind the one you were using; (2) no disruptive flicker; (3) **iTerm2 doesn't jump in front of other apps** when you're in a different app (the highest-risk unknown — `async_create` *might* activate iTerm at the OS level regardless, which `async_activate`-on-the-previous-window can't undo); (4) `foreground=True` still brings the window forward; (5) no window open → no crash.

## Test Plan
- [x] `python -m unittest tests.test_background_window` — 4 tests (background restores previous focus; foreground skips restore; no-previous-window no crash; restore exception swallowed). `app.async_activate` asserted never awaited.
- [x] `python scripts/test_baseline.py --timeout 60` — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
