### PR TITLE
feat: test window hygiene — tagged MCP-TEST profile + selective teardown

### DIFF
--- a/core/test_window_tracker.py
+++ b/core/test_window_tracker.py
@@ -7,21 +7,44 @@ Tag format: ``MCP-TEST·<pid>-<uuid8>``
 
 Usage example::
 
-    from core.test_window_tracker import make_run_tag, mark_session, close_tagged_sessions
+    from core.test_window_tracker import (
+        make_run_tag, mark_session, close_tagged_sessions,
+        ensure_test_profile,
+    )
 
     tag = make_run_tag()
+
+    # Once at test-suite startup — writes the stable MCP-TEST dynamic profile
+    # (idempotent; skipped if the file already exists with the right content):
+    ensure_test_profile()
 
     # After creating a session:
     await mark_session(raw_iterm2_session, tag)
 
     # In teardown:
     closed = await close_tagged_sessions(connection, tag)
+
+Profile strategy
+----------------
+``ensure_test_profile()`` writes a stable ``MCP-TEST`` iTerm2 Dynamic Profile
+to ``~/Library/Application Support/iTerm2/DynamicProfiles/iterm-mcp-test-profile.json``
+exactly once.  The profile has a distinctive orange badge and background tint
+so test windows are immediately eyeball-trackable.
+
+Because iTerm2 may not reload the profile synchronously after the file is
+written, ``create_window(profile="MCP-TEST")`` falls back to the default
+profile if ``MCP-TEST`` is not loaded yet.  That is acceptable — the
+``user.mcp_test_run`` variable set unconditionally after window creation
+remains the functional teardown key, so every test window is closeable even
+if it missed the profile.
 """
 
+import json
 import os
 import re
 import uuid
 import logging
+from pathlib import Path
 from typing import Optional
 
 import iterm2
@@ -31,6 +54,88 @@ log = logging.getLogger("iterm-mcp.test-tracker")
 # Stable prefix that identifies any test-opened session by profile name.
 # Production profiles start with "MCP Agent" or "MCP Team:" — never this prefix.
 TAG_PREFIX = "MCP-TEST·"  # middle-dot U+00B7
+
+# ---------------------------------------------------------------------------
+# Stable visible test profile
+# ---------------------------------------------------------------------------
+
+#: Exact name of the stable iTerm2 Dynamic Profile used for test windows.
+TEST_PROFILE_NAME = "MCP-TEST"
+
+#: Stable GUID for the MCP-TEST dynamic profile.  Never changes so iTerm2
+#: can track it across restarts without creating orphan entries.
+_TEST_PROFILE_GUID = "E7A1C3F0-9B2D-4E8A-B5C6-D1F234567890"
+
+#: Path where the single-file dynamic profile is written.
+_DYNAMIC_PROFILES_DIR = Path.home() / "Library/Application Support/iTerm2/DynamicProfiles"
+_TEST_PROFILE_FILE = _DYNAMIC_PROFILES_DIR / "iterm-mcp-test-profile.json"
+
+#: The canonical profile dict.  Written once and never overwritten if already
+#: present, avoiding per-run churn that would trigger iTerm2 reload races.
+_TEST_PROFILE_DATA: dict = {
+    "Profiles": [
+        {
+            "Name": TEST_PROFILE_NAME,
+            "Guid": _TEST_PROFILE_GUID,
+            "Dynamic Profile Parent Name": "Default",
+            # Vivid amber/orange tab colour — stands out from production sessions.
+            "Custom Tab Color": True,
+            "Tab Color": {
+                "Red Component": 0.85,
+                "Green Component": 0.45,
+                "Blue Component": 0.05,
+                "Color Space": "sRGB",
+            },
+            # Human-readable badge so the window label reads "MCP-TEST" even
+            # when the tab is too narrow to show the profile name.
+            "Badge Text": "MCP-TEST",
+            "Tags": ["mcp", "test"],
+        }
+    ]
+}
+
+
+def ensure_test_profile(
+    profiles_dir: Optional[Path] = None,
+) -> Path:
+    """Write the stable ``MCP-TEST`` iTerm2 Dynamic Profile if not present.
+
+    Idempotent: if the file already exists it is NOT overwritten, so there is
+    no per-run reload race in iTerm2.  Create the DynamicProfiles directory
+    if it does not exist (mirrors what ``ProfileManager`` does).
+
+    Args:
+        profiles_dir: Override the DynamicProfiles directory (used in tests to
+            point at a temp dir instead of the real user library).
+
+    Returns:
+        Path to the profile file (written or pre-existing).
+    """
+    target_dir = profiles_dir or _DYNAMIC_PROFILES_DIR
+    target_file = target_dir / "iterm-mcp-test-profile.json"
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        if target_file.exists():
+            log.debug("ensure_test_profile: profile file already exists at %s", target_file)
+            return target_file
+
+        target_file.write_text(json.dumps(_TEST_PROFILE_DATA, indent=2))
+        log.info(
+            "ensure_test_profile: wrote MCP-TEST dynamic profile to %s "
+            "(iTerm2 will load it shortly; first window may fall back to default profile)",
+            target_file,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "ensure_test_profile: could not write profile file to %s: %s "
+            "(test windows will still open and be tagged for teardown)",
+            target_file,
+            exc,
+        )
+
+    return target_file
 
 
 def make_run_tag() -> str:
@@ -121,10 +226,13 @@ async def close_tagged_sessions(
                     )
 
                 # --- secondary check: profile name prefix (orphan sweep) ---
+                # Match both the stable "MCP-TEST" profile name AND per-run
+                # "MCP-TEST·…" variants.  Production profiles ("MCP Agent",
+                # "MCP Team: …") never start with "MCP-TEST".
                 if not should_close and prefix_sweep:
                     try:
                         prof = await session.async_get_profile()
-                        if prof.name.startswith(TAG_PREFIX):
+                        if prof.name.startswith("MCP-TEST"):
                             should_close = True
                     except Exception as exc:  # noqa: BLE001
                         log.debug(

--- a/core/test_window_tracker.py
+++ b/core/test_window_tracker.py
@@ -51,7 +51,8 @@ import iterm2
 
 log = logging.getLogger("iterm-mcp.test-tracker")
 
-# Stable prefix that identifies any test-opened session by profile name.
+# Stable prefix; orphan sweep matches profile names starting with "MCP-TEST"
+# (covering the stable MCP-TEST profile and any MCP-TEST·<run> variants).
 # Production profiles start with "MCP Agent" or "MCP Team:" — never this prefix.
 TAG_PREFIX = "MCP-TEST·"  # middle-dot U+00B7
 

--- a/core/test_window_tracker.py
+++ b/core/test_window_tracker.py
@@ -1,0 +1,177 @@
+"""Test window tracking and hygiene for iTerm2 integration tests.
+
+Provides per-run tagging and safe teardown logic so that integration tests
+never close windows opened by the user or a concurrent test run.
+
+Tag format: ``MCP-TEST·<pid>-<uuid8>``
+
+Usage example::
+
+    from core.test_window_tracker import make_run_tag, mark_session, close_tagged_sessions
+
+    tag = make_run_tag()
+
+    # After creating a session:
+    await mark_session(raw_iterm2_session, tag)
+
+    # In teardown:
+    closed = await close_tagged_sessions(connection, tag)
+"""
+
+import os
+import re
+import uuid
+import logging
+from typing import Optional
+
+import iterm2
+
+log = logging.getLogger("iterm-mcp.test-tracker")
+
+# Stable prefix that identifies any test-opened session by profile name.
+# Production profiles start with "MCP Agent" or "MCP Team:" — never this prefix.
+TAG_PREFIX = "MCP-TEST·"  # middle-dot U+00B7
+
+
+def make_run_tag() -> str:
+    """Mint a unique per-run tag string.
+
+    The tag encodes the current PID (to differentiate concurrent processes)
+    and 8 hex chars of a UUID4 (to handle PID reuse).
+
+    Returns:
+        A string like ``MCP-TEST·12345-a1b2c3d4``.
+    """
+    return f"{TAG_PREFIX}{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+
+async def mark_session(session: iterm2.Session, tag: str) -> None:
+    """Set the ``user.mcp_test_run`` variable on a session.
+
+    The variable must begin with ``user.`` — the iTerm2 API enforces this.
+    Errors are logged but not re-raised; a failure to tag is non-fatal at
+    mark time (the session just won't be closed at teardown).
+
+    Args:
+        session: The raw ``iterm2.Session`` object (not an ``ItermSession``
+            wrapper) returned by ``window.tabs[0].sessions[0]`` etc.
+        tag: The run tag produced by :func:`make_run_tag`.
+    """
+    try:
+        await session.async_set_variable("user.mcp_test_run", tag)
+        log.debug("Tagged session %s with %s", session.session_id, tag)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "Failed to tag session %s: %s", getattr(session, "session_id", "?"), exc
+        )
+
+
+async def close_tagged_sessions(
+    connection: iterm2.Connection,
+    tag: str,
+    *,
+    prefix_sweep: bool = False,
+) -> int:
+    """Enumerate every iTerm2 session and close those that belong to this run.
+
+    A session is closed if **either** of the following is true:
+
+    1. Its ``user.mcp_test_run`` variable equals *tag* exactly.
+    2. ``prefix_sweep=True`` AND its profile name starts with
+       :data:`TAG_PREFIX` (catches orphans from crashed prior runs).
+
+    Sessions that raise an exception during variable/profile reads are
+    **skipped** (not fatal).  Sessions whose marker does not match are
+    **never** touched.
+
+    Args:
+        connection: An active ``iterm2.Connection``.
+        tag: The run tag to match against.
+        prefix_sweep: If ``True``, also close sessions whose profile name
+            starts with :data:`TAG_PREFIX` regardless of their variable
+            value.  Use this once at the start of a test run to clean up
+            orphans from previously crashed runs.
+
+    Returns:
+        The number of sessions successfully closed.
+    """
+    try:
+        app = await iterm2.async_get_app(connection)
+    except Exception as exc:  # noqa: BLE001
+        log.error("close_tagged_sessions: could not get app: %s", exc)
+        return 0
+
+    closed = 0
+
+    for window in app.windows:
+        for tab in window.tabs:
+            for session in tab.sessions:
+                should_close = False
+
+                # --- primary check: user variable matches exactly ---
+                try:
+                    var = await session.async_get_variable("user.mcp_test_run")
+                    if var == tag:
+                        should_close = True
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "Could not read user.mcp_test_run from %s: %s",
+                        getattr(session, "session_id", "?"),
+                        exc,
+                    )
+
+                # --- secondary check: profile name prefix (orphan sweep) ---
+                if not should_close and prefix_sweep:
+                    try:
+                        prof = await session.async_get_profile()
+                        if prof.name.startswith(TAG_PREFIX):
+                            should_close = True
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "Could not read profile from %s: %s",
+                            getattr(session, "session_id", "?"),
+                            exc,
+                        )
+
+                if should_close:
+                    try:
+                        await session.async_close(force=True)
+                        closed += 1
+                        log.debug(
+                            "Closed test session %s",
+                            getattr(session, "session_id", "?"),
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        # Already closed by another path — not an error.
+                        log.debug(
+                            "Could not close session %s (may already be gone): %s",
+                            getattr(session, "session_id", "?"),
+                            exc,
+                        )
+
+    log.info("close_tagged_sessions: closed %d session(s) for tag=%s", closed, tag)
+    return closed
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers for tests that need to inspect the tag format
+# ---------------------------------------------------------------------------
+
+_TAG_PATTERN = re.compile(
+    r"^MCP-TEST·(\d+)-([0-9a-f]{8})$"
+)
+
+
+def _parse_tag(tag: str) -> Optional[tuple]:
+    """Parse a tag string into (pid_str, uuid8_str), or None if invalid.
+
+    Args:
+        tag: Tag string to parse.
+
+    Returns:
+        ``(pid_str, uuid8_str)`` if the tag is well-formed, else ``None``.
+    """
+    m = _TAG_PATTERN.match(tag)
+    if m:
+        return m.group(1), m.group(2)
+    return None

--- a/docs/superpowers/plans/2026-06-13-test-window-hygiene.md
+++ b/docs/superpowers/plans/2026-06-13-test-window-hygiene.md
@@ -31,20 +31,46 @@ approach alongside checking the session's profile name prefix.
 
 ## Profile Strategy
 
-**Approach chosen: user variable tagging (option b from brief)**
+**Approach: stable visible profile (primary for human ID) + user variable (primary for programmatic teardown)**
 
-We tag via `session.async_set_variable("user.mcp_test_run", tag)` rather
-than writing a new dynamic profile, because:
+Two complementary mechanisms work together:
 
-1. Writing a dynamic profile requires file I/O + iTerm2 to reload its
-   profile list before the profile name is available — introducing race
-   conditions and timing issues in tests.
-2. User variables are set per-session immediately and are readable back
-   synchronously.
-3. Profile name prefix `MCP-TEST·` is still available for orphan sweeps
-   because we always check both fields; the profile name stays `MCP Agent`
-   (or whatever the test's `create_window` call uses) but the user var
-   confirms ownership.
+### 1. Stable `MCP-TEST` Dynamic Profile (visual identification)
+
+`core/test_window_tracker.ensure_test_profile()` writes a single-file Dynamic
+Profile (`~/Library/Application Support/iTerm2/DynamicProfiles/iterm-mcp-test-profile.json`)
+with a stable GUID.  The profile has:
+- An amber/orange tab colour (visually distinct from `MCP Agent` and `MCP Team:` profiles)
+- Badge text `"MCP-TEST"` (readable even when tabs are narrow)
+
+`ensure_test_profile()` is called once from `LiveItermTestCase.async_setup()`,
+**before** any window is created, giving iTerm2 the best chance to load it.
+It is idempotent — it checks for the file first and skips writing if already present,
+avoiding per-run reload races.
+
+`create_tagged_window()` passes `profile="MCP-TEST"` to `create_window()`.
+`create_window()` already falls back to the default profile on any exception,
+so if iTerm2 hasn't loaded the profile yet the window still opens.
+
+### 2. `user.mcp_test_run` variable (programmatic teardown key)
+
+`mark_session()` sets `session.async_set_variable("user.mcp_test_run", tag)`
+immediately after window creation.  This is the **primary teardown key**:
+
+- Races to zero — no reload lag.
+- Exact-match only — the teardown never closes a window it doesn't own.
+- Works even when the `MCP-TEST` profile hasn't loaded (window opened under default).
+
+### Orphan sweep (`prefix_sweep=True`)
+
+For sessions left over from previously crashed runs (where the profile loaded
+but no variable remains readable), `close_tagged_sessions(prefix_sweep=True)` checks
+whether the profile name `startswith("MCP-TEST")`.  This matches both:
+- `"MCP-TEST"` — the stable profile
+- `"MCP-TEST·…"` — any per-run-named variants (historical / future)
+
+Production profiles (`"MCP Agent"`, `"MCP Team: …"`) never start with `"MCP-TEST"`
+so they are always safe.
 
 ---
 
@@ -150,18 +176,54 @@ All 7 live-iTerm2 integration modules use the same pattern:
 
 ## Unit Tests: `tests/test_window_tracker.py`
 
-Tests `close_tagged_sessions` logic with mock objects (no live iTerm2):
+Tests `close_tagged_sessions` and `ensure_test_profile` with mock/temp objects
+(no live iTerm2 required).  34 tests total.
 
-1. **test_closes_matching_tag** — session with correct tag gets closed
-2. **test_skips_different_tag** — session with wrong tag is NOT closed
-3. **test_skips_no_tag** — session with empty/None variable is NOT closed
-4. **test_skips_on_var_read_error** — session that raises on `async_get_variable` is skipped
-5. **test_prefix_sweep_closes_orphan_profile** — with `prefix_sweep=True`, session whose profile name starts with `MCP-TEST·` is closed
-6. **test_prefix_sweep_skips_normal_profile** — with `prefix_sweep=True`, session with `MCP Agent` profile is NOT closed
-7. **test_returns_correct_count** — count reflects only actually-closed sessions
-8. **test_mark_session_sets_variable** — `mark_session` calls `async_set_variable` with correct args
-9. **test_make_run_tag_format** — tag matches `MCP-TEST·<digits>-<hex8>` pattern
-10. **test_make_run_tag_unique** — two calls produce different tags
+### `make_run_tag` (5 tests)
+- format matches `MCP-TEST·<digits>-<hex8>` pattern
+- embeds current PID
+- two calls differ
+- starts with TAG_PREFIX
+- UUID portion is 8 lowercase hex chars
+
+### `mark_session` (2 tests)
+- calls `async_set_variable("user.mcp_test_run", tag)` correctly
+- tolerates `async_set_variable` failure (no re-raise)
+
+### `close_tagged_sessions` matching (10 tests)
+- closes session with matching tag
+- closes multiple matching sessions
+- `prefix_sweep` closes orphan profile (name starts with `MCP-TEST·`)
+- skips session with different tag
+- skips session with empty tag
+- skips session where variable raises (absent)
+- skips normal profile without prefix_sweep
+- `prefix_sweep` skips `MCP Agent` profile
+- `prefix_sweep` skips `MCP Team: Foo` profile
+- skips session where profile read raises during prefix_sweep
+- mixed batch: only matching session is closed
+
+### `close_tagged_sessions` robustness (4 tests)
+- continues after `async_close` error
+- returns 0 when `async_get_app` fails
+- returns 0 when app has no windows
+- returns correct count
+
+### `ensure_test_profile` (6 tests, filesystem — uses temp dir)
+- writes profile file
+- written profile contains `MCP-TEST` name
+- idempotent: second call does not overwrite
+- creates directory if missing
+- tolerates write failure (no raise)
+- profile has distinctive badge text `"MCP-TEST"`
+
+### `prefix_sweep` broadened matching (6 tests)
+- matches stable `"MCP-TEST"` profile name
+- matches `"MCP-TEST·orphan"` variant
+- NEVER matches `"MCP Agent"`
+- NEVER matches `"MCP Team: Engineering"`
+- NEVER matches `"MCP Team:"` (colon only)
+- NEVER matches `"Default"`
 
 ---
 

--- a/docs/superpowers/plans/2026-06-13-test-window-hygiene.md
+++ b/docs/superpowers/plans/2026-06-13-test-window-hygiene.md
@@ -1,0 +1,173 @@
+# Plan: Test-Window Hygiene (2026-06-13)
+
+## Goal
+
+During testing, every iTerm2 window/session opened by the test suite is
+tagged and closed on teardown — closing ONLY our own sessions, never
+windows the user (or a concurrent test run) opened.
+
+---
+
+## Tag Scheme
+
+Each test run mints a unique tag string once:
+
+```
+MCP-TEST·<pid>-<uuid8>
+```
+
+Example: `MCP-TEST·12345-a1b2c3d4`
+
+- **pid**: `os.getpid()` — differentiates concurrent processes
+- **uuid8**: first 8 hex chars of `uuid.uuid4()` — prevents pid-reuse collisions
+- **Prefix `MCP-TEST·`**: stable prefix used for orphan sweeps (never
+  used by production profiles which start with `MCP Agent` or `MCP Team:`)
+
+The tag is stored as the iTerm2 user variable `user.mcp_test_run` on
+every session the test suite opens. This is a belt-and-suspenders
+approach alongside checking the session's profile name prefix.
+
+---
+
+## Profile Strategy
+
+**Approach chosen: user variable tagging (option b from brief)**
+
+We tag via `session.async_set_variable("user.mcp_test_run", tag)` rather
+than writing a new dynamic profile, because:
+
+1. Writing a dynamic profile requires file I/O + iTerm2 to reload its
+   profile list before the profile name is available — introducing race
+   conditions and timing issues in tests.
+2. User variables are set per-session immediately and are readable back
+   synchronously.
+3. Profile name prefix `MCP-TEST·` is still available for orphan sweeps
+   because we always check both fields; the profile name stays `MCP Agent`
+   (or whatever the test's `create_window` call uses) but the user var
+   confirms ownership.
+
+---
+
+## Module: `core/test_window_tracker.py`
+
+### Public API
+
+```python
+TAG_PREFIX = "MCP-TEST·"
+
+def make_run_tag() -> str:
+    """Return a unique per-run tag like 'MCP-TEST·12345-a1b2c3d4'."""
+
+async def mark_session(session: iterm2.Session, tag: str) -> None:
+    """Set user.mcp_test_run = tag on the given session."""
+
+async def close_tagged_sessions(
+    connection: iterm2.Connection,
+    tag: str,
+    *,
+    prefix_sweep: bool = False,
+) -> int:
+    """Enumerate all sessions; close those that belong to this run.
+
+    Matching rules (session must satisfy at least one):
+      - user.mcp_test_run variable equals tag exactly
+      - If prefix_sweep=True: profile name starts with TAG_PREFIX
+
+    Safety: Any session whose variable read fails is SKIPPED (not fatal).
+    Sessions with a non-matching or absent marker are never closed.
+
+    Returns:
+        Count of sessions closed.
+    """
+```
+
+### Algorithm for `close_tagged_sessions`
+
+```
+app = await iterm2.async_get_app(connection)
+closed = 0
+for window in app.windows:
+  for tab in window.tabs:
+    for session in tab.sessions:
+      should_close = False
+      try:
+        var = await session.async_get_variable("user.mcp_test_run")
+        if var == tag:
+          should_close = True
+      except Exception:
+        pass  # skip unreadable sessions
+      if not should_close and prefix_sweep:
+        try:
+          prof = await session.async_get_profile()
+          if prof.name.startswith(TAG_PREFIX):
+            should_close = True
+        except Exception:
+          pass
+      if should_close:
+        try:
+          await session.async_close(force=True)
+          closed += 1
+        except Exception:
+          pass  # already closed is fine
+return closed
+```
+
+---
+
+## Base Class: `tests/live_iterm_base.py`
+
+`LiveItermTestCase(unittest.IsolatedAsyncioTestCase)`:
+
+- `asyncSetUp`: creates iTerm2 connection, initialises `ItermTerminal`,
+  generates `self._tag`, optionally does a prefix_sweep orphan cleanup.
+- `create_tagged_window()`: calls `terminal.create_window()` then
+  `mark_session(raw_session, self._tag)`. Returns `ItermSession`.
+- `asyncTearDown`: calls `close_tagged_sessions(conn, self._tag)`.
+
+---
+
+## Live Modules — Conversion Plan
+
+All 7 live-iTerm2 integration modules use the same pattern:
+- `async_setup` creates a connection + window
+- `async_teardown` closes the window
+- `run_async_test` drives the event loop
+
+**Target: subclass `LiveItermTestCase`, route window creation through
+`self.create_tagged_window()`, inherit teardown.**
+
+| Module | Conversion approach |
+|--------|---------------------|
+| `test_basic_functionality.py` | Full — simple async_setup pattern |
+| `test_advanced_features.py` | Full — simple async_setup pattern |
+| `test_persistent_session.py` | Full — simple async_setup pattern |
+| `test_logging.py` | Full — simple async_setup pattern |
+| `test_line_limits.py` | Full — simple async_setup pattern |
+| `test_expect.py` | Full — simple async_setup pattern |
+| `test_session_suspend.py` | Partial — `TestSuspendResumeIntegration` gets full conversion; `TestSuspendStateManagement` and `TestSuspendResumeAsync` are pure unit tests (no iTerm2) — leave as-is |
+
+---
+
+## Unit Tests: `tests/test_window_tracker.py`
+
+Tests `close_tagged_sessions` logic with mock objects (no live iTerm2):
+
+1. **test_closes_matching_tag** — session with correct tag gets closed
+2. **test_skips_different_tag** — session with wrong tag is NOT closed
+3. **test_skips_no_tag** — session with empty/None variable is NOT closed
+4. **test_skips_on_var_read_error** — session that raises on `async_get_variable` is skipped
+5. **test_prefix_sweep_closes_orphan_profile** — with `prefix_sweep=True`, session whose profile name starts with `MCP-TEST·` is closed
+6. **test_prefix_sweep_skips_normal_profile** — with `prefix_sweep=True`, session with `MCP Agent` profile is NOT closed
+7. **test_returns_correct_count** — count reflects only actually-closed sessions
+8. **test_mark_session_sets_variable** — `mark_session` calls `async_set_variable` with correct args
+9. **test_make_run_tag_format** — tag matches `MCP-TEST·<digits>-<hex8>` pattern
+10. **test_make_run_tag_unique** — two calls produce different tags
+
+---
+
+## Commit Plan
+
+1. `docs/superpowers/plans/2026-06-13-test-window-hygiene.md` — this file
+2. `core/test_window_tracker.py` + `tests/test_window_tracker.py` (TDD)
+3. `tests/live_iterm_base.py` — base class
+4. Convert 7 live modules (surgical edits only)

--- a/tests/live_iterm_base.py
+++ b/tests/live_iterm_base.py
@@ -1,0 +1,229 @@
+"""Base class for live-iTerm2 integration tests.
+
+Every test that creates iTerm2 windows/sessions should inherit from
+:class:`LiveItermTestCase`.  The base class integrates with the existing
+``async_setup`` / ``async_teardown`` / ``run_async_test`` pattern used in
+the live test modules, without breaking the event-loop structure.
+
+Design
+------
+The existing live modules share a common pattern::
+
+    def run_async_test(self, coro):
+        async def test_wrapper():
+            try:
+                await self.async_setup()
+                await coro()
+            finally:
+                await self.async_teardown()
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(test_wrapper())
+        loop.close()
+
+:class:`LiveItermTestCase` subclasses ``unittest.IsolatedAsyncioTestCase``
+but the existing ``test_*`` methods remain **synchronous** and call
+``run_async_test`` as before.  The base class overrides ``run_async_test``
+to inject:
+
+1. A unique per-run tag (``self._tag``).
+2. A call to :func:`~core.test_window_tracker.close_tagged_sessions` in
+   the ``finally`` block of the wrapper, using the **same event loop** as
+   the test so the iTerm2 connection object is valid.
+
+Subclasses override ``async_setup`` (instead of ``asyncSetUp``) to create
+their window via :meth:`create_tagged_window`, and ``async_teardown`` for
+any extra per-test cleanup they need (the base class will close tagged
+sessions automatically *after* the subclass teardown).
+
+Usage::
+
+    from tests.live_iterm_base import LiveItermTestCase
+
+    class TestFoo(LiveItermTestCase):
+        async def async_setup(self):
+            await super().async_setup()
+            self.test_session = await self.create_tagged_window()
+            await self.test_session.set_name("FooSession")
+
+        async def async_teardown(self):
+            if hasattr(self, "test_session") and self.test_session.is_monitoring:
+                await self.test_session.stop_monitoring()
+            # Base class closes tagged sessions automatically — no need to
+            # call terminal.close_session() manually.
+            await super().async_teardown()
+
+        def test_something(self):
+            async def test_impl():
+                output = await self.test_session.get_screen_contents()
+                self.assertIn("$", output)
+            self.run_async_test(test_impl)
+"""
+
+import asyncio
+import logging
+import shutil
+import tempfile
+import unittest
+from typing import Callable, Coroutine, Optional
+
+import iterm2
+
+from core.terminal import ItermTerminal
+from core.session import ItermSession
+from core.test_window_tracker import (
+    TAG_PREFIX,
+    close_tagged_sessions,
+    make_run_tag,
+    mark_session,
+)
+
+log = logging.getLogger("iterm-mcp.live-test-base")
+
+
+class LiveItermTestCase(unittest.IsolatedAsyncioTestCase):
+    """IsolatedAsyncioTestCase with per-run window tagging and safe teardown.
+
+    Subclasses MUST call ``await super().async_setup()`` from their own
+    ``async_setup`` to establish the connection and tag.  The base
+    ``run_async_test`` automatically calls ``close_tagged_sessions`` in its
+    ``finally`` block (same event loop as the test).
+
+    Attributes:
+        connection: The active ``iterm2.Connection`` (set by async_setup).
+        terminal: An initialised :class:`~core.terminal.ItermTerminal`.
+        _tag: The per-run tag string (e.g. ``MCP-TEST·12345-a1b2c3d4``).
+        _log_dir: Temporary directory for session logs.
+    """
+
+    # ------------------------------------------------------------------
+    # async_setup / async_teardown — called by run_async_test
+    # ------------------------------------------------------------------
+
+    async def async_setup(self) -> None:
+        """Establish an iTerm2 connection and set up the tagged terminal.
+
+        Subclasses must call ``await super().async_setup()`` first.
+        """
+        self._log_dir = tempfile.mkdtemp()
+        self._tag = make_run_tag()
+
+        try:
+            self.connection = await iterm2.Connection.async_create()
+            self.terminal = ItermTerminal(
+                connection=self.connection,
+                log_dir=self._log_dir,
+                enable_logging=True,
+            )
+            await self.terminal.initialize()
+        except Exception as exc:
+            self.fail(f"LiveItermTestCase.async_setup: failed to connect to iTerm2: {exc}")
+
+    async def async_teardown(self) -> None:
+        """Hook for per-test cleanup.
+
+        Subclasses may override; they SHOULD call ``await super().async_teardown()``
+        or at minimum not suppress exceptions raised here.  The base
+        implementation is a no-op; session cleanup is handled by
+        ``run_async_test``.
+        """
+
+    # ------------------------------------------------------------------
+    # create_tagged_window — open a window owned by this run
+    # ------------------------------------------------------------------
+
+    async def create_tagged_window(
+        self,
+        profile: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> ItermSession:
+        """Create a new iTerm2 window and tag it for teardown.
+
+        Calls :meth:`~core.terminal.ItermTerminal.create_window` and
+        immediately sets ``user.mcp_test_run = self._tag`` on the raw
+        iTerm2 session so that :func:`~core.test_window_tracker.close_tagged_sessions`
+        will close it.
+
+        Args:
+            profile: Optional iTerm2 profile name.
+            name: Optional name to set on the session after creation.
+
+        Returns:
+            The :class:`~core.session.ItermSession` for the new window.
+
+        Raises:
+            AssertionError: If the window could not be created.
+        """
+        try:
+            session = await self.terminal.create_window(profile=profile)
+        except Exception as exc:
+            self.fail(f"create_tagged_window: failed to create window: {exc}")
+
+        # Tag the raw iterm2.Session (not the ItermSession wrapper).
+        raw = session.session
+        await mark_session(raw, self._tag)
+
+        if name:
+            await session.set_name(name)
+            await asyncio.sleep(0.1)
+
+        return session
+
+    # ------------------------------------------------------------------
+    # run_async_test — replacement for the manual event-loop pattern
+    # ------------------------------------------------------------------
+
+    def run_async_test(self, coro: Callable[[], Coroutine]) -> None:
+        """Run an async test function with guaranteed tagged teardown.
+
+        Replaces the manual ``asyncio.new_event_loop()`` pattern in the
+        original test modules.  The flow is::
+
+            await self.async_setup()
+            await coro()
+            [finally]
+            await self.async_teardown()
+            await close_tagged_sessions(self.connection, self._tag)
+            shutil.rmtree(self._log_dir)
+
+        All of these run in the **same** event loop so the iTerm2
+        connection object is valid throughout.
+
+        Args:
+            coro: A zero-argument async callable (the test implementation).
+        """
+        async def _wrapper() -> None:
+            await self.async_setup()
+            try:
+                await coro()
+            finally:
+                # Per-test cleanup first (subclass teardown).
+                try:
+                    await self.async_teardown()
+                except Exception as exc:
+                    log.warning("async_teardown raised: %s", exc)
+
+                # Close all tagged sessions for this run.
+                if hasattr(self, "connection") and hasattr(self, "_tag"):
+                    try:
+                        closed = await close_tagged_sessions(
+                            self.connection, self._tag
+                        )
+                        log.info(
+                            "run_async_test teardown: closed %d session(s) for tag=%s",
+                            closed,
+                            self._tag,
+                        )
+                    except Exception as exc:
+                        log.warning("close_tagged_sessions raised: %s", exc)
+
+                # Clean up temp log dir.
+                if hasattr(self, "_log_dir"):
+                    shutil.rmtree(self._log_dir, ignore_errors=True)
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(_wrapper())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)

--- a/tests/live_iterm_base.py
+++ b/tests/live_iterm_base.py
@@ -71,7 +71,6 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.session import ItermSession
 from core.test_window_tracker import (
-    TAG_PREFIX,
     TEST_PROFILE_NAME,
     close_tagged_sessions,
     ensure_test_profile,

--- a/tests/live_iterm_base.py
+++ b/tests/live_iterm_base.py
@@ -72,7 +72,9 @@ from core.terminal import ItermTerminal
 from core.session import ItermSession
 from core.test_window_tracker import (
     TAG_PREFIX,
+    TEST_PROFILE_NAME,
     close_tagged_sessions,
+    ensure_test_profile,
     make_run_tag,
     mark_session,
 )
@@ -102,10 +104,19 @@ class LiveItermTestCase(unittest.IsolatedAsyncioTestCase):
     async def async_setup(self) -> None:
         """Establish an iTerm2 connection and set up the tagged terminal.
 
+        Writes the stable ``MCP-TEST`` Dynamic Profile (idempotent) before
+        creating any window, giving iTerm2 the best chance of loading it
+        before the first ``create_window`` call.  Even if the profile isn't
+        loaded yet, ``create_window`` falls back to the default profile and
+        the ``user.mcp_test_run`` variable still guarantees teardown.
+
         Subclasses must call ``await super().async_setup()`` first.
         """
         self._log_dir = tempfile.mkdtemp()
         self._tag = make_run_tag()
+
+        # Write the stable MCP-TEST profile (idempotent — no-op if already there).
+        ensure_test_profile()
 
         try:
             self.connection = await iterm2.Connection.async_create()
@@ -136,15 +147,19 @@ class LiveItermTestCase(unittest.IsolatedAsyncioTestCase):
         profile: Optional[str] = None,
         name: Optional[str] = None,
     ) -> ItermSession:
-        """Create a new iTerm2 window and tag it for teardown.
+        """Create a new iTerm2 window under the ``MCP-TEST`` profile and tag it.
 
-        Calls :meth:`~core.terminal.ItermTerminal.create_window` and
-        immediately sets ``user.mcp_test_run = self._tag`` on the raw
-        iTerm2 session so that :func:`~core.test_window_tracker.close_tagged_sessions`
-        will close it.
+        Opens the window under the stable ``MCP-TEST`` Dynamic Profile so that
+        test windows are visually distinct (amber tab colour, "MCP-TEST" badge).
+        The ``user.mcp_test_run`` variable is set unconditionally immediately
+        after creation — this is the primary teardown key and works even if
+        iTerm2 hasn't loaded the ``MCP-TEST`` profile yet (in which case
+        ``create_window`` falls back to the default profile silently).
 
         Args:
-            profile: Optional iTerm2 profile name.
+            profile: Override the profile name.  Defaults to ``TEST_PROFILE_NAME``
+                (``"MCP-TEST"``).  Pass ``None`` explicitly to use the default
+                iTerm2 profile, or any other profile name to use that instead.
             name: Optional name to set on the session after creation.
 
         Returns:
@@ -153,8 +168,10 @@ class LiveItermTestCase(unittest.IsolatedAsyncioTestCase):
         Raises:
             AssertionError: If the window could not be created.
         """
+        # Default to the stable MCP-TEST profile for visual identifiability.
+        effective_profile = profile if profile is not None else TEST_PROFILE_NAME
         try:
-            session = await self.terminal.create_window(profile=profile)
+            session = await self.terminal.create_window(profile=effective_profile)
         except Exception as exc:
             self.fail(f"create_tagged_window: failed to create window: {exc}")
 

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -13,6 +13,7 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
+from core.test_window_tracker import mark_session
 from utils.logging import ItermLogManager, ItermSessionLogger
 from tests.live_iterm_base import LiveItermTestCase
 
@@ -184,6 +185,13 @@ class TestAdvancedFeatures(LiveItermTestCase):
 
             logger.info("Creating multiple sessions...")
             session_map = await self.terminal.create_multiple_sessions(session_configs)
+
+            # Tag all created sessions so the base-class teardown sweep can
+            # close them on failure (create_multiple_sessions doesn't tag).
+            for session_id in session_map.values():
+                pane = await self.terminal.get_session_by_id(session_id)
+                if pane is not None:
+                    await mark_session(pane.session, self._tag)
 
             # Verify we got sessions back
             self.assertEqual(len(session_map), 2, "Should have created 2 sessions")

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -14,106 +14,64 @@ from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
 from utils.logging import ItermLogManager, ItermSessionLogger
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestAdvancedFeatures(unittest.TestCase):
+class TestAdvancedFeatures(LiveItermTestCase):
     """Test advanced features of the iTerm2 MCP integration."""
-
-    def setUp(self):
-        """Set up a temporary directory for logs."""
-        self.temp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        """Clean up the temporary directory."""
-        shutil.rmtree(self.temp_dir)
 
     async def async_setup(self):
         """Set up the test environment."""
-        try:
-            # Connect to iTerm2
-            self.connection = await iterm2.Connection.async_create()
+        await super().async_setup()
 
-            # Initialize terminal with logging enabled
-            self.terminal = ItermTerminal(
-                connection=self.connection,
-                log_dir=self.temp_dir,
-                enable_logging=True
-            )
-            await self.terminal.initialize()
-
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("AdvTestSession")
-
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="AdvTestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
 
     async def async_teardown(self):
-        """Clean up the test environment."""
-        # Close the test session if it exists
+        """Clean up per-test state before the base class closes tagged sessions."""
         if hasattr(self, "test_session"):
             # Use async version of stop_monitoring
             if self.test_session.is_monitoring:
                 await self.test_session.stop_monitoring()
-            await self.terminal.close_session(self.test_session.id)
-
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+        await super().async_teardown()
 
     def test_screen_monitoring(self):
         """Test screen monitoring functionality."""
         async def test_impl():
             import logging
             logger = logging.getLogger("test-screen-monitoring")
-            
+
             # Start monitoring the session
             output_received = asyncio.Event()
             captured_output = []
-            
+
             async def output_callback(content):
                 logger.info(f"Callback received content: {content[:50]}...")
                 captured_output.append(content)
                 output_received.set()
-            
+
             # Add the callback and start monitoring
             self.test_session.add_monitor_callback(output_callback)
-            
+
             # Start monitoring and wait longer to ensure it's properly initialized
             await self.test_session.start_monitoring(update_interval=0.2)
-            
+
             # Wait to ensure monitoring is started
             await asyncio.sleep(2)
-            
+
             # Verify monitoring is active
             self.assertTrue(self.test_session.is_monitoring, "Monitoring should be active")
-            
+
             # Use a unique marker for easier identification
             unique_marker = f"UNIQUE_TEST_MARKER_{time.time()}"
             test_string = f"echo '{unique_marker}'"
             logger.info(f"Sending test command: {test_string}")
-            
+
             # Send the command and wait longer to ensure it's processed
             await self.test_session.send_text(f"{test_string}\n")
-            
+
             # Wait for output to be received with a longer timeout
             try:
                 await asyncio.wait_for(output_received.wait(), timeout=10.0)
@@ -123,34 +81,34 @@ class TestAdvancedFeatures(unittest.TestCase):
                 current_output = await self.test_session.get_screen_contents()
                 logger.error(f"Timed out waiting for screen update. Current screen: {current_output}")
                 self.fail("Timed out waiting for screen update")
-            
+
             # Wait a bit more to ensure all output is captured
             await asyncio.sleep(2)
-            
+
             # Stop monitoring - using async version
             await self.test_session.stop_monitoring()
-            
+
             # Verify monitoring stopped
             self.assertFalse(self.test_session.is_monitoring, "Monitoring should be stopped")
-            
+
             # Log captured output for debugging
             logger.info(f"Captured {len(captured_output)} outputs")
             for i, output in enumerate(captured_output):
                 logger.info(f"Output {i}: {output[:100]}...")
-            
+
             # Verify we captured the output by checking each captured output
             output_found = False
             for output in captured_output:
                 if unique_marker in output:
                     output_found = True
                     break
-            
+
             self.assertTrue(output_found, f"Expected to find '{unique_marker}' in captured output")
-            
+
             # Verify snapshot file exists and contains our test string
             self.assertTrue(os.path.exists(self.test_session.logger.snapshot_file),
                           "Snapshot file should exist")
-            
+
             with open(self.test_session.logger.snapshot_file, 'r') as f:
                 snapshot = f.read()
                 self.assertIn(unique_marker, snapshot,
@@ -163,50 +121,50 @@ class TestAdvancedFeatures(unittest.TestCase):
         async def test_impl():
             # Add a filter to only capture lines with 'ERROR'
             self.test_session.logger.add_output_filter(r"ERROR")
-            
+
             # Enable monitoring to ensure we catch all output
             await self.test_session.start_monitoring()
-            
+
             # Use unique timestamps to ensure we don't match old log entries
             timestamp = time.time()
-            
+
             # Send various messages with consistent identifiers
             await self.test_session.send_text(f"echo 'TEST-{timestamp}: This is a normal message'\n")
             await self.test_session.send_text(f"echo 'TEST-{timestamp}: This message contains an ERROR'\n")
             await self.test_session.send_text(f"echo 'TEST-{timestamp}: Another normal message'\n")
-            
+
             # Wait longer for commands to complete and log file to be written
             await asyncio.sleep(3)
-            
+
             # Read the log file
             with open(self.test_session.logger.log_file, 'r') as f:
                 log_content = f.read()
-            
+
             # The normal messages should not be in the log
             normal_msg1 = f"OUTPUT: TEST-{timestamp}: This is a normal message"
             normal_msg2 = f"OUTPUT: TEST-{timestamp}: Another normal message"
             error_msg = f"OUTPUT: TEST-{timestamp}: This message contains an ERROR"
-            
+
             self.assertNotIn(normal_msg1, log_content, "Found normal message 1 when it should have been filtered")
             self.assertNotIn(normal_msg2, log_content, "Found normal message 2 when it should have been filtered")
-            
+
             # The error message should be in the log
             self.assertIn(error_msg, log_content, "Error message not found in log file")
-            
+
             # Clear filters and send another message
             self.test_session.logger.clear_output_filters()
             clear_msg = f"echo 'TEST-{timestamp}: After clearing filters'\n"
             await self.test_session.send_text(clear_msg)
             await asyncio.sleep(2)
-            
+
             # Read the log file again
             with open(self.test_session.logger.log_file, 'r') as f:
                 updated_log = f.read()
-                
+
             # Now the normal message should be in the log
-            self.assertIn(f"OUTPUT: TEST-{timestamp}: After clearing filters", updated_log, 
+            self.assertIn(f"OUTPUT: TEST-{timestamp}: After clearing filters", updated_log,
                          "Message after clearing filters not found")
-            
+
             # Stop monitoring
             await self.test_session.stop_monitoring()
 
@@ -217,24 +175,24 @@ class TestAdvancedFeatures(unittest.TestCase):
         async def test_impl():
             import logging
             logger = logging.getLogger("test-multiple-sessions")
-            
+
             # Create multiple sessions with different commands
             session_configs = [
                 {"name": "Session1", "command": "echo 'Hello from Session 1'", "monitor": True},
                 {"name": "Session2", "command": "echo 'Hello from Session 2'", "layout": True, "vertical": True}
             ]
-            
+
             logger.info("Creating multiple sessions...")
             session_map = await self.terminal.create_multiple_sessions(session_configs)
-            
+
             # Verify we got sessions back
             self.assertEqual(len(session_map), 2, "Should have created 2 sessions")
             self.assertIn("Session1", session_map, "Session1 should be in session_map")
             self.assertIn("Session2", session_map, "Session2 should be in session_map")
-            
+
             # Wait for sessions to be fully initialized and commands to execute
             await asyncio.sleep(3)
-            
+
             # Get session objects with robust retry logic
             async def get_session_with_retry(name):
                 session_id = session_map[name]
@@ -247,11 +205,11 @@ class TestAdvancedFeatures(unittest.TestCase):
                         logger.error(f"Error getting session {name} (attempt {attempt+1}): {str(e)}")
                     await asyncio.sleep(1)
                 self.fail(f"Failed to get session {name} after 3 attempts")
-                
+
             logger.info("Getting session objects...")
             session1 = await get_session_with_retry("Session1")
             session2 = await get_session_with_retry("Session2")
-            
+
             # For Session1, explicitly start monitoring since it may not have been started
             # or might have been terminated early
             logger.info("Ensuring Session1 monitoring is active...")
@@ -259,32 +217,32 @@ class TestAdvancedFeatures(unittest.TestCase):
                 logger.info("Session1 not monitoring, starting it now...")
                 await session1.start_monitoring(update_interval=0.2)
                 await asyncio.sleep(2)
-            
+
             # Now check that Session1 is being monitored
             self.assertTrue(session1.is_monitoring, "Session1 should be monitoring")
-            
+
             # Verify output from each session
             logger.info("Verifying output from sessions...")
             output1 = await session1.get_screen_contents()
             output2 = await session2.get_screen_contents()
-            
+
             logger.info(f"Session1 output: {output1}")
             logger.info(f"Session2 output: {output2}")
-            
+
             self.assertIn("Hello from Session 1", output1, "Expected output not found in Session1")
             self.assertIn("Hello from Session 2", output2, "Expected output not found in Session2")
-            
-            # Clean up
+
+            # Clean up extra sessions (base class will close tagged ones, but
+            # create_multiple_sessions doesn't tag the new sessions automatically,
+            # so we close them explicitly here).
             logger.info("Cleaning up sessions...")
             for name, session_id in session_map.items():
                 try:
-                    # Get the session and stop monitoring if active
                     session = await self.terminal.get_session_by_id(session_id)
                     if session:
                         if session.is_monitoring:
                             logger.info(f"Stopping monitoring for {name}...")
                             await session.stop_monitoring()
-                        # Close the session
                         logger.info(f"Closing session {name}...")
                         await self.terminal.close_session(session_id)
                 except Exception as e:

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -10,58 +10,23 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestBasicFunctionality(unittest.TestCase):
+class TestBasicFunctionality(LiveItermTestCase):
     """Test basic functionality of the iTerm2 MCP integration."""
 
     async def async_setup(self):
         """Set up the test environment."""
-        # Connect to iTerm2
-        try:
-            self.connection = await iterm2.Connection.async_create()
-            
-            # Initialize terminal and layout manager
-            self.terminal = ItermTerminal(self.connection)
-            await self.terminal.initialize()
-            
-            self.layout_manager = LayoutManager(self.terminal)
-            
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("TestSession")
-                
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
-    
-    async def async_teardown(self):
-        """Clean up the test environment."""
-        # Close the test window if it exists
-        if hasattr(self, "test_session"):
-            await self.terminal.close_session(self.test_session.id)
-    
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
+        await super().async_setup()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
-    
+        self.layout_manager = LayoutManager(self.terminal)
+
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="TestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
+
     def test_create_window(self):
         """Test creating a window and setting its name."""
         async def test_impl():
@@ -69,55 +34,55 @@ class TestBasicFunctionality(unittest.TestCase):
             session = await self.terminal.get_session_by_id(self.test_session.id)
             self.assertIsNotNone(session)
             self.assertEqual(session.id, self.test_session.id)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_send_and_receive_text(self):
         """Test sending text to a session and reading output."""
         async def test_impl():
             # Send a simple command
             await self.test_session.send_text("echo 'Hello, iTerm MCP!'\n")
-            
+
             # Wait for command to complete
             await asyncio.sleep(1)
-            
+
             # Get screen contents
             output = await self.test_session.get_screen_contents()
-            
+
             # Verify the output
             self.assertIn("Hello, iTerm MCP!", output)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_send_control_character(self):
         """Test sending a control character to a session."""
         async def test_impl():
             # Start a command that will hang
             await self.test_session.send_text("cat\n")
-            
+
             # Wait for command to start
             await asyncio.sleep(1)
-            
+
             # Send Ctrl-C to cancel
             await self.test_session.send_control_character("c")
-            
+
             # Wait for command to be cancelled
             await asyncio.sleep(1)
-            
+
             # Verify that command was cancelled (by running another command)
             await self.test_session.send_text("echo 'Command cancelled'\n")
-            
+
             # Wait for command to complete
             await asyncio.sleep(1)
-            
+
             # Get screen contents
             output = await self.test_session.get_screen_contents()
-            
+
             # Verify the output
             self.assertIn("Command cancelled", output)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_create_layout(self):
         """Test creating a layout with multiple panes."""
         async def test_impl():
@@ -126,18 +91,18 @@ class TestBasicFunctionality(unittest.TestCase):
                 layout_type=LayoutType.HORIZONTAL_SPLIT,
                 pane_names=["LeftPane", "RightPane"]
             )
-            
+
             # Verify that we got session IDs back for both panes
             for name in ["LeftPane", "RightPane"]:
                 session_id = session_map[name]
                 session = await self.terminal.get_session_by_id(session_id)
                 self.assertIsNotNone(session)
                 # Simply verify the session exists - don't check names as they might change
-            
+
             # Clean up the created sessions
             for session_id in session_map.values():
                 await self.terminal.close_session(session_id)
-        
+
         self.run_async_test(test_impl)
 
 

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -10,6 +10,7 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
+from core.test_window_tracker import mark_session
 from tests.live_iterm_base import LiveItermTestCase
 
 
@@ -92,6 +93,14 @@ class TestBasicFunctionality(LiveItermTestCase):
                 pane_names=["LeftPane", "RightPane"]
             )
 
+            # Tag every pane session so the base-class teardown sweep can close
+            # them on failure (LayoutManager opens windows outside the tagged
+            # path, so we tag after the fact).
+            for session_id in session_map.values():
+                pane = await self.terminal.get_session_by_id(session_id)
+                if pane is not None:
+                    await mark_session(pane.session, self._tag)
+
             # Verify that we got session IDs back for both panes
             for name in ["LeftPane", "RightPane"]:
                 session_id = session_map[name]
@@ -99,7 +108,7 @@ class TestBasicFunctionality(LiveItermTestCase):
                 self.assertIsNotNone(session)
                 # Simply verify the session exists - don't check names as they might change
 
-            # Clean up the created sessions
+            # Clean up the created sessions (in-body cleanup; teardown is a backup).
             for session_id in session_map.values():
                 await self.terminal.close_session(session_id)
 

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -16,67 +16,27 @@ from core.session import (
     ExpectError,
     ExpectTimeoutError,
 )
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestExpectPatternMatching(unittest.TestCase):
-    """Test expect-style pattern matching functionality."""
-
-    def setUp(self):
-        """Set up a temporary directory for logs."""
-        self.temp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        """Clean up the temporary directory."""
-        shutil.rmtree(self.temp_dir)
+class TestExpectPatternMatching(LiveItermTestCase):
+    """Test expect-style pattern matching functionality (live iTerm2 required)."""
 
     async def async_setup(self):
         """Set up the test environment."""
-        try:
-            # Connect to iTerm2
-            self.connection = await iterm2.Connection.async_create()
+        await super().async_setup()
 
-            # Initialize terminal with logging enabled
-            self.terminal = ItermTerminal(
-                connection=self.connection,
-                log_dir=self.temp_dir,
-                enable_logging=True
-            )
-            await self.terminal.initialize()
-
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("ExpectTestSession")
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="ExpectTestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
 
     async def async_teardown(self):
-        """Clean up the test environment."""
+        """Stop monitoring before base class teardown."""
         if hasattr(self, "test_session"):
             if self.test_session.is_monitoring:
                 await self.test_session.stop_monitoring()
-            await self.terminal.close_session(self.test_session.id)
-
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+        await super().async_teardown()
 
     def test_expect_basic_pattern_match(self):
         """Test basic pattern matching with expect()."""

--- a/tests/test_line_limits.py
+++ b/tests/test_line_limits.py
@@ -12,92 +12,63 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.session import ItermSession
 from utils.logging import ItermLogManager
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestLineLimits(unittest.TestCase):
+class TestLineLimits(LiveItermTestCase):
     """Test the configurable line limits functionality."""
 
-    def setUp(self):
-        """Set up a temporary directory for logs."""
-        self.temp_dir = tempfile.mkdtemp()
-    
-    def tearDown(self):
-        """Clean up the temporary directory."""
-        shutil.rmtree(self.temp_dir)
-    
     async def async_setup(self):
-        """Set up the test environment."""
+        """Set up the test environment.
+
+        Overrides base class to create a terminal with specific line limits.
+        Does NOT call super().async_setup() to avoid creating a second default
+        terminal — instead it replicates the connection+tag setup directly.
+        """
+        self._log_dir = tempfile.mkdtemp()
+        from core.test_window_tracker import make_run_tag
+        self._tag = make_run_tag()
+
         try:
-            # Connect to iTerm2
             self.connection = await iterm2.Connection.async_create()
-            
-            # Initialize terminal with logging enabled and specific default line limit
             self.default_max_lines = 10
             self.terminal = ItermTerminal(
                 connection=self.connection,
-                log_dir=self.temp_dir,
+                log_dir=self._log_dir,
                 enable_logging=True,
                 default_max_lines=self.default_max_lines,
                 max_snapshot_lines=100  # Large enough for our test
             )
             await self.terminal.initialize()
-            
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("LineLimitTestSession")
-                
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
-    
-    async def async_teardown(self):
-        """Clean up the test environment."""
-        # Close the test window if it exists
-        if hasattr(self, "test_session"):
-            await self.terminal.close_session(self.test_session.id)
-    
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
-    
+        except Exception as exc:
+            self.fail(f"async_setup: failed to connect to iTerm2: {exc}")
+
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="LineLimitTestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
+
     def test_default_line_limit(self):
         """Test that the default line limit is applied."""
         async def test_impl():
             # Verify the default line limit is set
             self.assertEqual(self.test_session.max_lines, self.default_max_lines)
-            
+
             # Generate more than the default number of lines
             line_count = self.default_max_lines * 2
             await self.test_session.send_text(f"for i in $(seq 1 {line_count}); do echo \"Line $i\"; done\n")
             await asyncio.sleep(2)  # Give time for command to complete
-            
+
             # Get screen contents without specifying max_lines (should use default)
             output = await self.test_session.get_screen_contents()
             output_lines = output.strip().split('\n')
-            
+
             # Allow for a few prompt lines in the output
             self.assertLessEqual(len(output_lines), self.default_max_lines + 3)
             self.assertGreaterEqual(len(output_lines), self.default_max_lines - 3)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_custom_line_limit(self):
         """Test that a custom line limit can be applied."""
         async def test_impl():
@@ -105,98 +76,98 @@ class TestLineLimits(unittest.TestCase):
             line_count = 50  # More than both limits we'll test
             await self.test_session.send_text(f"for i in $(seq 1 {line_count}); do echo \"Line $i\"; done\n")
             await asyncio.sleep(2)  # Give time for command to complete
-            
+
             # Get screen contents with custom max_lines
             custom_max_lines = 5
             output = await self.test_session.get_screen_contents(max_lines=custom_max_lines)
             output_lines = output.strip().split('\n')
-            
+
             # The output should respect the custom line limit (allowing for some variance)
             self.assertLessEqual(len(output_lines), custom_max_lines + 2)
-            
+
             # Now get with a different custom limit
             custom_max_lines_2 = 15
             output_2 = await self.test_session.get_screen_contents(max_lines=custom_max_lines_2)
             output_lines_2 = output_2.strip().split('\n')
-            
+
             # The output should respect the second custom line limit
             self.assertGreater(len(output_lines_2), len(output_lines))
             self.assertLessEqual(len(output_lines_2), custom_max_lines_2 + 2)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_set_max_lines_per_session(self):
         """Test that max_lines can be set per session."""
         async def test_impl():
             # Set a custom max_lines for the session
             custom_max_lines = 7  # Different from default
             self.test_session.set_max_lines(custom_max_lines)
-            
+
             # Verify the max_lines was set
             self.assertEqual(self.test_session.max_lines, custom_max_lines)
-            
+
             # Generate lines
             line_count = 30
             await self.test_session.send_text(f"for i in $(seq 1 {line_count}); do echo \"Line $i\"; done\n")
             await asyncio.sleep(2)  # Give time for command to complete
-            
+
             # Get screen contents without specifying max_lines (should use session's max_lines)
             output = await self.test_session.get_screen_contents()
             output_lines = output.strip().split('\n')
-            
+
             # The output should respect the session's max_lines
             self.assertLessEqual(len(output_lines), custom_max_lines + 2)
             self.assertGreaterEqual(len(output_lines), custom_max_lines - 2)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_overflow_file_creation(self):
         """Test that overflow files are created when needed."""
         async def test_impl():
             # Configure a small max_snapshot_lines to force overflow
             log_manager = self.terminal.log_manager
             logger = self.test_session.logger
-            
+
             # Original max snapshot lines
             original_max_lines = logger.max_snapshot_lines
             # Set to a small value to force overflow
             small_max_lines = 5
             logger.max_snapshot_lines = small_max_lines
-            
-            # For this test, we'll just test the functionality directly 
+
+            # For this test, we'll just test the functionality directly
             # rather than relying on the file system
-            
+
             # Generate a modest amount of output
             unique_marker = f"OVERFLOW_TEST_{int(time.time())}"
-            
+
             # Send a command to generate some output
             await self.test_session.send_text(f"echo '{unique_marker}_OUTPUT_TEST'\n")
             await asyncio.sleep(1)
-            
+
             # Get the output to trigger a snapshot
             output = await self.test_session.get_screen_contents()
             self.assertIn(unique_marker, output)
-            
+
             # Verify that the max_lines was set correctly
             self.assertEqual(logger.max_snapshot_lines, small_max_lines)
-            
+
             # Test the line limiting mechanism directly using a large string
             test_lines = ["Test line " + str(i) for i in range(1, small_max_lines * 2)]
             test_output = "\n".join(test_lines)
-            
+
             # Use the logger to parse and store this directly
             logger.log_output(test_output)
-            
+
             # Verify that the latest output cache is limited
             self.assertLessEqual(len(logger.latest_output), small_max_lines)
-            
+
             # The last lines should be kept
             for i in range(small_max_lines - 2, small_max_lines * 2 - 2):
                 if i >= small_max_lines * 2 - small_max_lines:
                     self.assertIn(f"Test line {i}", logger.latest_output)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_get_snapshot_with_line_limit(self):
         """Test that snapshots can be retrieved with line limits."""
         async def test_impl():
@@ -204,37 +175,37 @@ class TestLineLimits(unittest.TestCase):
             line_count = 30
             await self.test_session.send_text(f"for i in $(seq 1 {line_count}); do echo \"Line $i\"; done\n")
             await asyncio.sleep(2)  # Give time for command to complete
-            
+
             # Wait for snapshot to be created
             await asyncio.sleep(1)
-            
+
             # First capture some output to make sure we have something
             await self.test_session.get_screen_contents()
-            
+
             # Get a snapshot with different line limits
             log_manager = self.terminal.log_manager
             # Make sure the snapshot file exists
             self.assertTrue(os.path.exists(self.test_session.logger.snapshot_file))
-            
+
             # We'll make a direct comparison by reading from the snapshot file
             # instead of using the log_manager.get_snapshot method
             with open(self.test_session.logger.snapshot_file, 'r') as f:
                 full_content = f.read()
-                
+
             # Get a limited snapshot directly
             full_lines = full_content.strip().split('\n')
             if len(full_lines) > 5:
                 limited_lines = full_lines[-5:]
                 self.assertEqual(len(limited_lines), 5)
-                
+
                 # Verify by getting a limited snapshot through the API
                 limited_snapshot = log_manager.get_snapshot(self.test_session.id, max_lines=5)
                 if limited_snapshot:
                     api_limited_lines = limited_snapshot.strip().split('\n')
                     self.assertLessEqual(len(api_limited_lines), 5 + 2)  # Allow some buffer
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_create_multiple_sessions_with_custom_max_lines(self):
         """Test creating multiple sessions with different line limits."""
         async def test_impl():
@@ -249,39 +220,39 @@ class TestLineLimits(unittest.TestCase):
                     "max_lines": 15
                 }
             ]
-            
+
             # Create the sessions
             session_map = await self.terminal.create_multiple_sessions(configs)
-            
+
             # Verify the sessions were created
             session1_id = session_map["Session1"]
             session2_id = session_map["Session2"]
-            
+
             session1 = await self.terminal.get_session_by_id(session1_id)
             session2 = await self.terminal.get_session_by_id(session2_id)
-            
+
             # Verify sessions exist
             self.assertIsNotNone(session1)
             self.assertIsNotNone(session2)
-            
+
             # Note: Line limit tests disabled because the creation doesn't always
             # apply the max_lines setting properly in the test environment
             # Manually check contents with a reasonable line count
             await session1.send_text("echo 'Testing session 1 line limits'\n")
             await session2.send_text("echo 'Testing session 2 line limits'\n")
             await asyncio.sleep(1)
-            
+
             # Check that output is captured in both sessions
             output1 = await session1.get_screen_contents()
             output2 = await session2.get_screen_contents()
-            
+
             self.assertIn("Testing session 1 line limits", output1)
             self.assertIn("Testing session 2 line limits", output2)
-            
-            # Clean up the sessions
+
+            # Clean up the sessions (not tagged, so close explicitly)
             await self.terminal.close_session(session1_id)
             await self.terminal.close_session(session2_id)
-        
+
         self.run_async_test(test_impl)
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -13,178 +13,132 @@ from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
 from utils.logging import ItermLogManager, ItermSessionLogger
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestLogging(unittest.TestCase):
+class TestLogging(LiveItermTestCase):
     """Test the iTerm2 logging functionality."""
 
-    def setUp(self):
-        """Set up a temporary directory for logs."""
-        self.temp_dir = tempfile.mkdtemp()
-    
-    def tearDown(self):
-        """Clean up the temporary directory."""
-        shutil.rmtree(self.temp_dir)
-    
     async def async_setup(self):
         """Set up the test environment."""
-        try:
-            # Connect to iTerm2
-            self.connection = await iterm2.Connection.async_create()
-            
-            # Initialize terminal with logging enabled
-            self.terminal = ItermTerminal(
-                connection=self.connection,
-                log_dir=self.temp_dir,
-                enable_logging=True
-            )
-            await self.terminal.initialize()
-            
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("LogTestSession")
-                
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
-    
-    async def async_teardown(self):
-        """Clean up the test environment."""
-        # Close the test window if it exists
-        if hasattr(self, "test_session"):
-            await self.terminal.close_session(self.test_session.id)
-    
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
-    
+        await super().async_setup()
+
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="LogTestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
+
     def test_session_logger_creation(self):
         """Test that session loggers are created correctly."""
         async def test_impl():
             # Verify that a logger was created for the test session
             self.assertTrue(hasattr(self.test_session, "logger"))
             self.assertIsNotNone(self.test_session.logger)
-            
+
             # Verify that the log file exists
             self.assertTrue(os.path.exists(self.test_session.logger.log_file))
-            
+
             # Verify log file contains session information
             with open(self.test_session.logger.log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn(f"Session started - ID: {self.test_session.id}", log_content)
                 # Session name might be set by rename event, just check that the ID is correctly logged
                 self.assertIn(self.test_session.id, log_content)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_command_logging(self):
         """Test that commands are logged."""
         async def test_impl():
             # Send a command
             test_command = "echo 'Test command logging'"
             await self.test_session.send_text(f"{test_command}\n")
-            
+
             # Wait for command to complete
             await asyncio.sleep(1)
-            
+
             # Verify that the command was logged
             with open(self.test_session.logger.log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn(f"COMMAND: {test_command}", log_content)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_output_logging(self):
         """Test that output is logged."""
         async def test_impl():
             # Send a command
             test_output = "Test output logging"
             await self.test_session.send_text(f"echo '{test_output}'\n")
-            
+
             # Wait for command to complete
             await asyncio.sleep(1)
-            
+
             # Get screen contents to trigger output logging
             output = await self.test_session.get_screen_contents()
-            
+
             # Verify that the output was logged
             with open(self.test_session.logger.log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn(f"OUTPUT:", log_content)
                 self.assertIn(test_output, log_content)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_control_character_logging(self):
         """Test that control characters are logged."""
         async def test_impl():
             # Send a control character
             await self.test_session.send_control_character("c")
-            
+
             # Wait a moment
             await asyncio.sleep(1)
-            
+
             # Verify that the control character was logged
             with open(self.test_session.logger.log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn("CONTROL: Ctrl-C", log_content)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_session_rename_logging(self):
         """Test that session renames are logged."""
         async def test_impl():
             # Rename the session
             new_name = "RenamedLogTestSession"
             await self.test_session.set_name(new_name)
-            
+
             # Verify that the rename was logged
             with open(self.test_session.logger.log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn(f"RENAME: LogTestSession -> {new_name}", log_content)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_session_closure_logging(self):
         """Test that session closures are logged."""
         async def test_impl():
             # Get the log file path before closing
             log_file = self.test_session.logger.log_file
-            
+
             # Create another session we can use after closing the test session
             other_session = await self.terminal.create_window()
-            
+
             # Close the test session
             await self.terminal.close_session(self.test_session.id)
-            
+
             # Verify that the closure was logged
             with open(log_file, "r") as f:
                 log_content = f.read()
                 self.assertIn(f"Session closed - ID: {self.test_session.id}", log_content)
-            
+
             # Clean up the other session
             await self.terminal.close_session(other_session.id)
-            
+
             # Prevent the teardown from trying to close the already closed session
+            # (and the tagged teardown will gracefully skip already-closed sessions)
             delattr(self, "test_session")
-        
+
         self.run_async_test(test_impl)
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -12,6 +12,7 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.layouts import LayoutManager, LayoutType
 from core.session import ItermSession
+from core.test_window_tracker import mark_session
 from utils.logging import ItermLogManager, ItermSessionLogger
 from tests.live_iterm_base import LiveItermTestCase
 
@@ -121,8 +122,10 @@ class TestLogging(LiveItermTestCase):
             # Get the log file path before closing
             log_file = self.test_session.logger.log_file
 
-            # Create another session we can use after closing the test session
+            # Create another session we can use after closing the test session.
+            # Tag it so the base-class teardown closes it on failure.
             other_session = await self.terminal.create_window()
+            await mark_session(other_session.session, self._tag)
 
             # Close the test session
             await self.terminal.close_session(self.test_session.id)

--- a/tests/test_persistent_session.py
+++ b/tests/test_persistent_session.py
@@ -14,185 +14,138 @@ import iterm2
 from core.terminal import ItermTerminal
 from core.session import ItermSession
 from utils.logging import ItermLogManager
+from tests.live_iterm_base import LiveItermTestCase
 
 
-class TestPersistentSessions(unittest.TestCase):
+class TestPersistentSessions(LiveItermTestCase):
     """Test the persistent session functionality."""
 
-    def setUp(self):
-        """Set up a temporary directory for logs."""
-        self.temp_dir = tempfile.mkdtemp()
-    
-    def tearDown(self):
-        """Clean up the temporary directory."""
-        shutil.rmtree(self.temp_dir)
-    
     async def async_setup(self):
         """Set up the test environment."""
-        try:
-            # Connect to iTerm2
-            self.connection = await iterm2.Connection.async_create()
-            
-            # Initialize terminal with logging enabled
-            self.terminal = ItermTerminal(
-                connection=self.connection,
-                log_dir=self.temp_dir,
-                enable_logging=True
-            )
-            await self.terminal.initialize()
-            
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("PersistentTestSession")
-                
-                # Wait for window to be ready
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
-    
-    async def async_teardown(self):
-        """Clean up the test environment."""
-        # Close the test window if it exists
-        if hasattr(self, "test_session"):
-            await self.terminal.close_session(self.test_session.id)
-    
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
-    
+        await super().async_setup()
+
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="PersistentTestSession")
+        # Wait for window to be ready
+        await asyncio.sleep(1)
+
     def test_persistent_id_generation(self):
         """Test that persistent IDs are generated correctly."""
         async def test_impl():
             # Verify that the session has a persistent ID
             self.assertTrue(hasattr(self.test_session, "persistent_id"))
             self.assertIsNotNone(self.test_session.persistent_id)
-            
+
             # Verify that the persistent ID is a valid UUID
             try:
                 uuid_obj = uuid.UUID(self.test_session.persistent_id)
                 self.assertEqual(str(uuid_obj), self.test_session.persistent_id)
             except ValueError:
                 self.fail("Persistent ID is not a valid UUID")
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_persistent_id_saved(self):
         """Test that persistent IDs are saved to the persistent sessions file."""
         async def test_impl():
             # Get the persistent ID
             persistent_id = self.test_session.persistent_id
-            
+
             # Check if the persistent sessions file was created
-            persistent_sessions_file = os.path.join(self.temp_dir, "persistent_sessions.json")
+            persistent_sessions_file = os.path.join(self._log_dir, "persistent_sessions.json")
             self.assertTrue(os.path.exists(persistent_sessions_file))
-            
+
             # Verify that the persistent ID is in the file
             with open(persistent_sessions_file, "r") as f:
                 persistent_sessions = json.load(f)
                 self.assertIn(persistent_id, persistent_sessions)
-                
+
                 # Verify the session details
                 session_details = persistent_sessions[persistent_id]
                 self.assertEqual(session_details["session_id"], self.test_session.id)
-                # Note: The name test is disabled because iTerm sometimes 
+                # Note: The name test is disabled because iTerm sometimes
                 # changes the name before we can set it
                 # self.assertEqual(session_details["name"], "PersistentTestSession")
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_persistent_id_lookup(self):
         """Test that sessions can be looked up by persistent ID."""
         async def test_impl():
             # Get the persistent ID
             persistent_id = self.test_session.persistent_id
-            
+
             # Look up the session by persistent ID
             found_session = await self.terminal.get_session_by_persistent_id(persistent_id)
-            
+
             # Verify that the correct session was found
             self.assertIsNotNone(found_session)
             self.assertEqual(found_session.id, self.test_session.id)
-            # Note: The name test is disabled because iTerm sometimes 
+            # Note: The name test is disabled because iTerm sometimes
             # changes the name before we can set it
             # self.assertEqual(found_session.name, "PersistentTestSession")
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_persistent_id_reconnection(self):
         """Test reconnection to a session using persistent ID."""
         async def test_impl():
             # Get the persistent ID and session ID
             persistent_id = self.test_session.persistent_id
             original_session_id = self.test_session.id
-            
+
             # Send a command to create some unique output
             unique_marker = f"PERSISTENT_TEST_{int(time.time())}"
             await self.test_session.send_text(f"echo '{unique_marker}'\n")
             await asyncio.sleep(1)
-            
+
             # Create a new terminal manager (simulating a new connection)
             new_terminal = ItermTerminal(
                 connection=self.connection,
-                log_dir=self.temp_dir,
+                log_dir=self._log_dir,
                 enable_logging=True
             )
             await new_terminal.initialize()
-            
+
             # Look up the session by persistent ID in the new terminal
             found_session = await new_terminal.get_session_by_persistent_id(persistent_id)
-            
+
             # Verify that the correct session was found
             self.assertIsNotNone(found_session)
             self.assertEqual(found_session.id, original_session_id)
-            
+
             # Check that we can access the session's output
             output = await found_session.get_screen_contents()
             self.assertIn(unique_marker, output)
-        
+
         self.run_async_test(test_impl)
-    
+
     def test_log_manager_persistent_methods(self):
         """Test the log manager's persistent session methods."""
         async def test_impl():
             # Access the log manager
             log_manager = self.terminal.log_manager
-            
+
             # Get a list of persistent sessions
             persistent_sessions = log_manager.list_persistent_sessions()
-            
+
             # Verify that our test session is in the list
             found_session = False
             for persistent_id, details in persistent_sessions.items():
                 if details["session_id"] == self.test_session.id:
                     found_session = True
                     break
-            
+
             self.assertTrue(found_session)
-            
+
             # Get the persistent ID
             persistent_id = self.test_session.persistent_id
-            
+
             # Get session details
             session_details = log_manager.get_persistent_session(persistent_id)
             self.assertIsNotNone(session_details)
             self.assertEqual(session_details["session_id"], self.test_session.id)
-        
+
         self.run_async_test(test_impl)
 
 

--- a/tests/test_session_suspend.py
+++ b/tests/test_session_suspend.py
@@ -13,6 +13,7 @@ import iterm2
 
 from core.terminal import ItermTerminal
 from core.session import ItermSession
+from tests.live_iterm_base import LiveItermTestCase
 
 
 class TestSuspendStateManagement(unittest.TestCase):
@@ -199,7 +200,7 @@ class TestSuspendResumeAsync(unittest.TestCase):
         self.run_async(test_impl())
 
 
-class TestSuspendResumeIntegration(unittest.TestCase):
+class TestSuspendResumeIntegration(LiveItermTestCase):
     """Integration tests for suspend/resume with real iTerm2 connection.
 
     These tests require iTerm2 to be running.
@@ -207,23 +208,14 @@ class TestSuspendResumeIntegration(unittest.TestCase):
 
     async def async_setup(self):
         """Set up the test environment."""
-        try:
-            self.connection = await iterm2.Connection.async_create()
-            self.terminal = ItermTerminal(self.connection)
-            await self.terminal.initialize()
+        await super().async_setup()
 
-            # Create a test window
-            self.test_session = await self.terminal.create_window()
-            if self.test_session:
-                await self.test_session.set_name("SuspendTestSession")
-                await asyncio.sleep(1)
-            else:
-                self.fail("Failed to create test window")
-        except Exception as e:
-            self.fail(f"Failed to set up test environment: {str(e)}")
+        # Create a tagged test window (auto-closed by run_async_test teardown).
+        self.test_session = await self.create_tagged_window(name="SuspendTestSession")
+        await asyncio.sleep(1)
 
     async def async_teardown(self):
-        """Clean up the test environment."""
+        """Resume the session if suspended before base class closes it."""
         if hasattr(self, "test_session"):
             # Make sure to resume if suspended before closing
             if self.test_session.is_suspended:
@@ -231,24 +223,7 @@ class TestSuspendResumeIntegration(unittest.TestCase):
                     await self.test_session.resume()
                 except Exception:
                     pass
-            await self.terminal.close_session(self.test_session.id)
-
-    def run_async_test(self, coro):
-        """Run an async test function."""
-        async def test_wrapper():
-            try:
-                await self.async_setup()
-                await coro()
-            finally:
-                await self.async_teardown()
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(test_wrapper())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+        await super().async_teardown()
 
     def test_suspend_running_process(self):
         """Test suspending a running process with Ctrl+Z."""

--- a/tests/test_window_tracker.py
+++ b/tests/test_window_tracker.py
@@ -1,0 +1,354 @@
+"""Unit tests for core/test_window_tracker.py.
+
+These tests exercise the tag-matching and teardown logic using mock
+iTerm2 objects — no live iTerm2 connection is required.
+
+The safety-critical part is ``close_tagged_sessions``: it must ONLY close
+sessions whose ``user.mcp_test_run`` variable matches the given tag (or,
+with prefix_sweep, whose profile name starts with ``MCP-TEST·``).  Any
+session without a matching marker must be left untouched.
+"""
+
+import asyncio
+import os
+import re
+import unittest
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from core.test_window_tracker import (
+    TAG_PREFIX,
+    _parse_tag,
+    close_tagged_sessions,
+    make_run_tag,
+    mark_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build fake iTerm2 object trees
+# ---------------------------------------------------------------------------
+
+def _make_session(
+    session_id: str = "s1",
+    var_value=None,          # value returned by async_get_variable; None → raise
+    profile_name: str = "Default",
+    close_raises: bool = False,
+) -> MagicMock:
+    """Return a mock iterm2.Session.
+
+    Args:
+        session_id: Mock session_id attribute.
+        var_value: If not None, returned by async_get_variable; if None,
+            async_get_variable raises RuntimeError (simulates error).
+        profile_name: Name returned by the mock profile.
+        close_raises: If True, async_close raises RuntimeError.
+
+    Returns:
+        A MagicMock representing the session.
+    """
+    session = MagicMock()
+    session.session_id = session_id
+
+    if var_value is None:
+        session.async_get_variable = AsyncMock(
+            side_effect=RuntimeError("variable not found")
+        )
+    else:
+        session.async_get_variable = AsyncMock(return_value=var_value)
+
+    profile = MagicMock()
+    profile.name = profile_name
+    session.async_get_profile = AsyncMock(return_value=profile)
+
+    if close_raises:
+        session.async_close = AsyncMock(side_effect=RuntimeError("already closed"))
+    else:
+        session.async_close = AsyncMock()
+
+    return session
+
+
+def _make_app(*sessions) -> MagicMock:
+    """Build a fake app with a single window→tab→sessions tree.
+
+    Args:
+        *sessions: Mock session objects.
+
+    Returns:
+        A MagicMock representing the iterm2 app.
+    """
+    tab = MagicMock()
+    tab.sessions = list(sessions)
+
+    window = MagicMock()
+    window.tabs = [tab]
+
+    app = MagicMock()
+    app.windows = [window]
+    return app
+
+
+def _run(coro):
+    """Run a coroutine in a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# make_run_tag
+# ---------------------------------------------------------------------------
+
+class TestMakeRunTag(unittest.TestCase):
+    """Tests for make_run_tag()."""
+
+    def test_format_matches_pattern(self):
+        """Tag must match MCP-TEST·<digits>-<hex8>."""
+        tag = make_run_tag()
+        parsed = _parse_tag(tag)
+        self.assertIsNotNone(parsed, f"Tag did not parse: {tag!r}")
+
+    def test_contains_current_pid(self):
+        """Tag must embed the current process PID."""
+        tag = make_run_tag()
+        pid_str, _ = _parse_tag(tag)
+        self.assertEqual(int(pid_str), os.getpid())
+
+    def test_two_calls_differ(self):
+        """Two calls must produce different tags (UUID portion differs)."""
+        tag1 = make_run_tag()
+        tag2 = make_run_tag()
+        self.assertNotEqual(tag1, tag2)
+
+    def test_starts_with_prefix(self):
+        """Tag must start with TAG_PREFIX."""
+        tag = make_run_tag()
+        self.assertTrue(tag.startswith(TAG_PREFIX))
+
+    def test_uuid_portion_is_hex(self):
+        """UUID portion must be 8 lowercase hex chars."""
+        tag = make_run_tag()
+        _, uuid8 = _parse_tag(tag)
+        self.assertRegex(uuid8, r"^[0-9a-f]{8}$")
+
+
+# ---------------------------------------------------------------------------
+# mark_session
+# ---------------------------------------------------------------------------
+
+class TestMarkSession(unittest.IsolatedAsyncioTestCase):
+    """Tests for mark_session()."""
+
+    async def test_sets_correct_variable(self):
+        """mark_session must call async_set_variable with user.mcp_test_run."""
+        session = MagicMock()
+        session.session_id = "s1"
+        session.async_set_variable = AsyncMock()
+
+        tag = "MCP-TEST·99-deadbeef"
+        await mark_session(session, tag)
+
+        session.async_set_variable.assert_called_once_with("user.mcp_test_run", tag)
+
+    async def test_tolerates_set_variable_error(self):
+        """mark_session must not raise if async_set_variable fails."""
+        session = MagicMock()
+        session.session_id = "s1"
+        session.async_set_variable = AsyncMock(
+            side_effect=RuntimeError("permission denied")
+        )
+
+        # Should not raise
+        await mark_session(session, "MCP-TEST·99-deadbeef")
+
+
+# ---------------------------------------------------------------------------
+# close_tagged_sessions — matching
+# ---------------------------------------------------------------------------
+
+class TestCloseTaggedSessionsMatching(unittest.IsolatedAsyncioTestCase):
+    """Safety-critical tests: matching/skipping logic in close_tagged_sessions."""
+
+    _TAG = "MCP-TEST·42-aabbccdd"
+    _OTHER_TAG = "MCP-TEST·99-11223344"
+
+    async def _run_close(self, app, *, prefix_sweep=False):
+        conn = MagicMock()
+        with patch(
+            "core.test_window_tracker.iterm2.async_get_app",
+            AsyncMock(return_value=app),
+        ):
+            return await close_tagged_sessions(conn, self._TAG, prefix_sweep=prefix_sweep)
+
+    # --- sessions that SHOULD be closed ---
+
+    async def test_closes_session_with_matching_tag(self):
+        """Session whose user.mcp_test_run == tag must be closed."""
+        s = _make_session("s1", var_value=self._TAG)
+        app = _make_app(s)
+        count = await self._run_close(app)
+        self.assertEqual(count, 1)
+        s.async_close.assert_called_once_with(force=True)
+
+    async def test_closes_multiple_matching_sessions(self):
+        """All matching sessions in one tab must be closed."""
+        s1 = _make_session("s1", var_value=self._TAG)
+        s2 = _make_session("s2", var_value=self._TAG)
+        app = _make_app(s1, s2)
+        count = await self._run_close(app)
+        self.assertEqual(count, 2)
+        s1.async_close.assert_called_once_with(force=True)
+        s2.async_close.assert_called_once_with(force=True)
+
+    async def test_prefix_sweep_closes_orphan_profile(self):
+        """With prefix_sweep, session with MCP-TEST· profile name is closed."""
+        # Session has no matching variable (empty string returned), but profile
+        # name starts with TAG_PREFIX — classic orphan from crashed prior run.
+        s = _make_session("s1", var_value="", profile_name="MCP-TEST·orphan")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 1)
+        s.async_close.assert_called_once_with(force=True)
+
+    # --- sessions that must NOT be closed ---
+
+    async def test_skips_session_with_different_tag(self):
+        """Session whose variable contains a different tag must be skipped."""
+        s = _make_session("s1", var_value=self._OTHER_TAG)
+        app = _make_app(s)
+        count = await self._run_close(app)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_skips_session_with_empty_tag(self):
+        """Session whose variable is empty string must be skipped."""
+        s = _make_session("s1", var_value="")
+        app = _make_app(s)
+        count = await self._run_close(app)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_skips_session_with_no_tag_variable(self):
+        """Session where async_get_variable raises (variable absent) is skipped."""
+        s = _make_session("s1", var_value=None)  # → raises RuntimeError
+        app = _make_app(s)
+        count = await self._run_close(app)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_skips_normal_profile_without_prefix_sweep(self):
+        """Default profile with MCP Agent name must never be closed (no prefix_sweep)."""
+        s = _make_session("s1", var_value=None, profile_name="MCP Agent")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=False)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_prefix_sweep_skips_non_test_profile(self):
+        """With prefix_sweep, sessions with non-test profile are still skipped."""
+        s = _make_session("s1", var_value="", profile_name="MCP Agent")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_prefix_sweep_skips_production_team_profile(self):
+        """'MCP Team: Foo' profile must never be closed by prefix_sweep."""
+        s = _make_session("s1", var_value="", profile_name="MCP Team: Foo")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_skips_session_whose_profile_read_errors(self):
+        """If async_get_profile raises, session is skipped during prefix_sweep."""
+        s = _make_session("s1", var_value="")
+        s.async_get_profile = AsyncMock(side_effect=RuntimeError("profile error"))
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    # --- mixed scenarios ---
+
+    async def test_mixed_sessions_closes_only_matching(self):
+        """In a mixed batch, only the matching session is closed."""
+        s_match = _make_session("s1", var_value=self._TAG)
+        s_other = _make_session("s2", var_value=self._OTHER_TAG)
+        s_none = _make_session("s3", var_value=None)
+        s_empty = _make_session("s4", var_value="")
+        app = _make_app(s_match, s_other, s_none, s_empty)
+
+        count = await self._run_close(app)
+        self.assertEqual(count, 1)
+        s_match.async_close.assert_called_once_with(force=True)
+        s_other.async_close.assert_not_called()
+        s_none.async_close.assert_not_called()
+        s_empty.async_close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# close_tagged_sessions — robustness
+# ---------------------------------------------------------------------------
+
+class TestCloseTaggedSessionsRobustness(unittest.IsolatedAsyncioTestCase):
+    """Robustness tests: errors during close must not abort other closes."""
+
+    _TAG = "MCP-TEST·42-aabbccdd"
+
+    async def _run_close(self, app, *, prefix_sweep=False):
+        conn = MagicMock()
+        with patch(
+            "core.test_window_tracker.iterm2.async_get_app",
+            AsyncMock(return_value=app),
+        ):
+            return await close_tagged_sessions(conn, self._TAG, prefix_sweep=prefix_sweep)
+
+    async def test_continues_after_close_error(self):
+        """If async_close raises for one session, others are still closed."""
+        s1 = _make_session("s1", var_value=self._TAG, close_raises=True)
+        s2 = _make_session("s2", var_value=self._TAG)
+        app = _make_app(s1, s2)
+
+        count = await self._run_close(app)
+        # s1 raised, s2 succeeded
+        self.assertEqual(count, 1)
+        s2.async_close.assert_called_once_with(force=True)
+
+    async def test_returns_zero_when_app_get_fails(self):
+        """If async_get_app raises, return 0 without crashing."""
+        conn = MagicMock()
+        with patch(
+            "core.test_window_tracker.iterm2.async_get_app",
+            AsyncMock(side_effect=RuntimeError("no connection")),
+        ):
+            count = await close_tagged_sessions(conn, self._TAG)
+        self.assertEqual(count, 0)
+
+    async def test_empty_windows_returns_zero(self):
+        """App with no windows returns 0."""
+        app = MagicMock()
+        app.windows = []
+        conn = MagicMock()
+        with patch(
+            "core.test_window_tracker.iterm2.async_get_app",
+            AsyncMock(return_value=app),
+        ):
+            count = await close_tagged_sessions(conn, self._TAG)
+        self.assertEqual(count, 0)
+
+    async def test_returns_correct_count(self):
+        """Return value is the number of sessions actually closed."""
+        s1 = _make_session("s1", var_value=self._TAG)
+        s2 = _make_session("s2", var_value=self._TAG)
+        s3 = _make_session("s3", var_value="other")
+        app = _make_app(s1, s2, s3)
+
+        count = await self._run_close(app)
+        self.assertEqual(count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_window_tracker.py
+++ b/tests/test_window_tracker.py
@@ -5,20 +5,28 @@ iTerm2 objects — no live iTerm2 connection is required.
 
 The safety-critical part is ``close_tagged_sessions``: it must ONLY close
 sessions whose ``user.mcp_test_run`` variable matches the given tag (or,
-with prefix_sweep, whose profile name starts with ``MCP-TEST·``).  Any
+with prefix_sweep, whose profile name starts with ``"MCP-TEST"``).  Any
 session without a matching marker must be left untouched.
+
+``ensure_test_profile`` tests point at a temp dir so the real iTerm2
+DynamicProfiles directory is never written during testing.
 """
 
 import asyncio
+import json
 import os
 import re
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from core.test_window_tracker import (
     TAG_PREFIX,
+    TEST_PROFILE_NAME,
     _parse_tag,
     close_tagged_sessions,
+    ensure_test_profile,
     make_run_tag,
     mark_session,
 )
@@ -348,6 +356,148 @@ class TestCloseTaggedSessionsRobustness(unittest.IsolatedAsyncioTestCase):
 
         count = await self._run_close(app)
         self.assertEqual(count, 2)
+
+
+# ---------------------------------------------------------------------------
+# ensure_test_profile
+# ---------------------------------------------------------------------------
+
+class TestEnsureTestProfile(unittest.TestCase):
+    """Tests for ensure_test_profile() — filesystem writes go to a temp dir."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._profiles_dir = Path(self._tmp) / "DynamicProfiles"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_writes_profile_file(self):
+        """ensure_test_profile() must create the profile JSON file."""
+        path = ensure_test_profile(profiles_dir=self._profiles_dir)
+        self.assertTrue(path.exists(), "Profile file should exist after ensure_test_profile()")
+
+    def test_profile_contains_mcp_test_name(self):
+        """The written profile must contain the MCP-TEST profile name."""
+        ensure_test_profile(profiles_dir=self._profiles_dir)
+        files = list(self._profiles_dir.glob("*.json"))
+        self.assertEqual(len(files), 1, "Exactly one JSON file should be written")
+        data = json.loads(files[0].read_text())
+        names = [p["Name"] for p in data.get("Profiles", [])]
+        self.assertIn(TEST_PROFILE_NAME, names, f"Expected 'MCP-TEST' in profiles; got {names}")
+
+    def test_idempotent_does_not_overwrite(self):
+        """A second call must not overwrite the file (idempotent)."""
+        ensure_test_profile(profiles_dir=self._profiles_dir)
+        target = self._profiles_dir / "iterm-mcp-test-profile.json"
+        first_mtime = target.stat().st_mtime
+
+        ensure_test_profile(profiles_dir=self._profiles_dir)
+        second_mtime = target.stat().st_mtime
+
+        self.assertEqual(
+            first_mtime,
+            second_mtime,
+            "ensure_test_profile() must not touch the file if it already exists",
+        )
+
+    def test_creates_directory_if_missing(self):
+        """ensure_test_profile() must create the DynamicProfiles directory."""
+        nested = Path(self._tmp) / "nested" / "DynamicProfiles"
+        self.assertFalse(nested.exists())
+        ensure_test_profile(profiles_dir=nested)
+        self.assertTrue(nested.exists(), "Directory should be created")
+
+    def test_tolerates_write_failure(self):
+        """ensure_test_profile() must not raise even if the write fails."""
+        # Point at a file (not a dir) so the mkdir will fail on the JSON write.
+        bogus = Path("/dev/null/cannot_create_dir")
+        # Should not raise — just logs a warning.
+        ensure_test_profile(profiles_dir=bogus)
+
+    def test_profile_has_distinctive_badge(self):
+        """MCP-TEST profile must carry the 'MCP-TEST' badge for visual ID."""
+        ensure_test_profile(profiles_dir=self._profiles_dir)
+        files = list(self._profiles_dir.glob("*.json"))
+        data = json.loads(files[0].read_text())
+        test_profile = next(
+            (p for p in data.get("Profiles", []) if p.get("Name") == TEST_PROFILE_NAME),
+            None,
+        )
+        self.assertIsNotNone(test_profile, "MCP-TEST entry not found in Profiles list")
+        self.assertEqual(
+            test_profile.get("Badge Text"),
+            "MCP-TEST",
+            "Badge Text must be 'MCP-TEST' for visual identification",
+        )
+
+
+# ---------------------------------------------------------------------------
+# prefix_sweep broadened to startswith("MCP-TEST")
+# ---------------------------------------------------------------------------
+
+class TestPrefixSweepBroadened(unittest.IsolatedAsyncioTestCase):
+    """The prefix_sweep must match both 'MCP-TEST' and 'MCP-TEST·…' profiles
+    but NEVER touch production profiles ('MCP Agent', 'MCP Team: …')."""
+
+    _TAG = "MCP-TEST·42-aabbccdd"
+
+    async def _run_close(self, app, *, prefix_sweep=False):
+        conn = MagicMock()
+        with patch(
+            "core.test_window_tracker.iterm2.async_get_app",
+            AsyncMock(return_value=app),
+        ):
+            return await close_tagged_sessions(conn, self._TAG, prefix_sweep=prefix_sweep)
+
+    async def test_prefix_sweep_matches_stable_profile_name(self):
+        """With prefix_sweep, a session with the stable 'MCP-TEST' profile is closed."""
+        s = _make_session("s1", var_value="", profile_name="MCP-TEST")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 1)
+        s.async_close.assert_called_once_with(force=True)
+
+    async def test_prefix_sweep_matches_tagged_variant_profile(self):
+        """With prefix_sweep, 'MCP-TEST·orphan' profile is still closed."""
+        s = _make_session("s1", var_value="", profile_name="MCP-TEST·crashed-abc")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 1)
+        s.async_close.assert_called_once_with(force=True)
+
+    async def test_prefix_sweep_never_matches_mcp_agent(self):
+        """'MCP Agent' must NEVER be closed by prefix_sweep."""
+        s = _make_session("s1", var_value="", profile_name="MCP Agent")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_prefix_sweep_never_matches_mcp_team(self):
+        """'MCP Team: Engineering' must NEVER be closed by prefix_sweep."""
+        s = _make_session("s1", var_value="", profile_name="MCP Team: Engineering")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_prefix_sweep_never_matches_mcp_team_colon_only(self):
+        """'MCP Team:' (no name) must NEVER be closed by prefix_sweep."""
+        s = _make_session("s1", var_value="", profile_name="MCP Team:")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
+
+    async def test_prefix_sweep_never_matches_default(self):
+        """'Default' profile must NEVER be closed by prefix_sweep."""
+        s = _make_session("s1", var_value="", profile_name="Default")
+        app = _make_app(s)
+        count = await self._run_close(app, prefix_sweep=True)
+        self.assertEqual(count, 0)
+        s.async_close.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

During testing, every iTerm2 window we open is now tagged and closed on teardown — closing **only ours**, never windows you (or a concurrent test run) opened. Tracking is by tag, never by a start-time snapshot.

- **Dual marker.** Each run mints a tag `MCP-TEST·<pid>-<uuid8>`. Test windows open under a stable, visible `MCP-TEST` dynamic profile (amber tab + `MCP-TEST` badge, so test windows are obvious at a glance — written once, idempotent, same JSON schema as the existing `MCP Agent` profile), and each session also gets a `user.mcp_test_run = <tag>` variable. The variable is the race-free key teardown matches on; the profile is for human visibility (if iTerm hasn't loaded the profile yet, creation falls back to default and the variable still makes the window closeable).
- **Conservative teardown.** `close_tagged_sessions` enumerates every app session and `async_close(force=True)`s only those whose `user.mcp_test_run` equals this run's tag; a per-session read error is skipped, never fatal, never a wrong close. An optional `prefix_sweep` also closes orphans whose profile name starts with `MCP-TEST` (crashed prior runs) — production `MCP Agent` / `MCP Team:` profiles never match.
- **`LiveItermTestCase`** base runs the sweep in `finally`, so windows are closed even when a test fails. The 7 live-iTerm2 modules subclass it; three windows previously created off the tagged path are now tagged too.

Note: a stable `iterm-mcp-test-profile.json` (the `MCP-TEST` profile) now exists in your iTerm2 DynamicProfiles dir — that's the intended persistent marker, written once. Pairs with #133: once background-windows lands, test windows open in the background too.

## Test Plan
- [x] `python -m unittest tests.test_window_tracker` — **34 tests** (matching/teardown logic + profile schema + broadened sweep guards), mocked, no live iTerm2.
- [x] `python scripts/test_baseline.py --timeout 60` — no regression (the 7 live modules still require an interactive iTerm2 session).
- [ ] Live: run a converted live test against a real iTerm2; confirm test windows show the amber `MCP-TEST` tab and are all gone after the run, and that your own windows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
