### PR TITLE
feat(tests): skip live window tests when iTerm2 is frontmost

### DIFF
--- a/core/test_window_tracker.py
+++ b/core/test_window_tracker.py
@@ -42,6 +42,7 @@ if it missed the profile.
 import json
 import os
 import re
+import subprocess
 import uuid
 import logging
 from pathlib import Path
@@ -260,6 +261,90 @@ async def close_tagged_sessions(
 
     log.info("close_tagged_sessions: closed %d session(s) for tag=%s", closed, tag)
     return closed
+
+
+# ---------------------------------------------------------------------------
+# Active-iTerm guard — keep live tests from opening windows while iTerm2 is
+# the frontmost app, so they never interrupt an interactive session.
+# ---------------------------------------------------------------------------
+
+#: macOS bundle identifier for iTerm2.
+ITERM_BUNDLE_ID = "com.googlecode.iterm2"
+
+#: Env var to force live window-opening tests to run even when iTerm2 is active.
+ALLOW_ACTIVE_ENV = "ITERM_MCP_TEST_ALLOW_ACTIVE"
+
+
+def iterm_frontmost_state() -> Optional[bool]:
+    """Best-effort check of whether iTerm2 is the frontmost macOS app.
+
+    Read-only and side-effect free — never opens a window.
+
+    Returns:
+        ``True`` if iTerm2 is frontmost, ``False`` if another app is, or
+        ``None`` if it could not be determined (no GUI session, missing
+        tooling, permission denied, etc.).
+    """
+    # Prefer pyobjc/AppKit if available (in-process, no subprocess).
+    try:
+        from AppKit import NSWorkspace  # type: ignore
+
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        if app is not None:
+            return app.bundleIdentifier() == ITERM_BUNDLE_ID
+    except Exception:  # noqa: BLE001 — AppKit not installed, no GUI, etc.
+        pass
+
+    # Fall back to osascript (always present on macOS).
+    try:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                'tell application "System Events" to get bundle identifier of '
+                "first application process whose frontmost is true",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip() == ITERM_BUNDLE_ID
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None  # undetermined
+
+
+def skip_reason_if_iterm_active() -> Optional[str]:
+    """Return a ``skipTest`` reason if live window tests should not run now.
+
+    Live tests open real iTerm2 windows.  To avoid disrupting an interactive
+    session, they are skipped when iTerm2 is the frontmost app — and, to be
+    safe, also when the frontmost app cannot be determined.  Set the
+    ``ITERM_MCP_TEST_ALLOW_ACTIVE`` env var (``1``/``true``/``yes``/``on``) to
+    override and always run them.
+
+    Returns:
+        A human-readable reason string when the test should be skipped, or
+        ``None`` when it is safe to open windows (iTerm2 is in the background).
+    """
+    override = os.environ.get(ALLOW_ACTIVE_ENV, "").strip().lower()
+    if override in ("1", "true", "yes", "on"):
+        return None
+
+    state = iterm_frontmost_state()
+    if state is True:
+        return (
+            "iTerm2 is the frontmost app — skipping live window-opening test to "
+            f"avoid disrupting the session (set {ALLOW_ACTIVE_ENV}=1 to run anyway)."
+        )
+    if state is None:
+        return (
+            "Could not determine the frontmost app — skipping live window-opening "
+            f"test to be safe (set {ALLOW_ACTIVE_ENV}=1 to run anyway)."
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/live_iterm_base.py
+++ b/tests/live_iterm_base.py
@@ -76,6 +76,7 @@ from core.test_window_tracker import (
     ensure_test_profile,
     make_run_tag,
     mark_session,
+    skip_reason_if_iterm_active,
 )
 
 log = logging.getLogger("iterm-mcp.live-test-base")
@@ -207,6 +208,13 @@ class LiveItermTestCase(unittest.IsolatedAsyncioTestCase):
         Args:
             coro: A zero-argument async callable (the test implementation).
         """
+        # Guard: never open windows while iTerm2 is the frontmost app (or when
+        # the frontmost app can't be determined). This skips BEFORE any
+        # connection or window creation. Override with ITERM_MCP_TEST_ALLOW_ACTIVE=1.
+        reason = skip_reason_if_iterm_active()
+        if reason:
+            self.skipTest(reason)
+
         async def _wrapper() -> None:
             await self.async_setup()
             try:

--- a/tests/test_active_guard.py
+++ b/tests/test_active_guard.py
@@ -1,0 +1,62 @@
+"""Tests for the active-iTerm guard that keeps live tests from opening windows.
+
+These are fully headless: they mock the frontmost-app detector and never open
+an iTerm2 window or touch a live connection.
+"""
+import os
+import unittest
+from unittest import mock
+
+from core import test_window_tracker as twt
+
+
+class TestSkipReasonIfItermActive(unittest.TestCase):
+    def setUp(self):
+        # Make sure no override leaks in from the real environment.
+        os.environ.pop(twt.ALLOW_ACTIVE_ENV, None)
+
+    def test_skips_when_iterm_frontmost(self):
+        with mock.patch.object(twt, "iterm_frontmost_state", return_value=True):
+            reason = twt.skip_reason_if_iterm_active()
+        self.assertIsNotNone(reason)
+        self.assertIn("frontmost", reason)
+        self.assertIn(twt.ALLOW_ACTIVE_ENV, reason)
+
+    def test_skips_when_undetermined(self):
+        with mock.patch.object(twt, "iterm_frontmost_state", return_value=None):
+            reason = twt.skip_reason_if_iterm_active()
+        self.assertIsNotNone(reason)
+        self.assertIn("determine", reason.lower())
+
+    def test_runs_when_iterm_backgrounded(self):
+        with mock.patch.object(twt, "iterm_frontmost_state", return_value=False):
+            reason = twt.skip_reason_if_iterm_active()
+        self.assertIsNone(reason)
+
+    def test_override_runs_even_when_frontmost(self):
+        with mock.patch.dict(os.environ, {twt.ALLOW_ACTIVE_ENV: "1"}), \
+             mock.patch.object(twt, "iterm_frontmost_state", return_value=True) as detector:
+            reason = twt.skip_reason_if_iterm_active()
+        self.assertIsNone(reason)
+        # Override short-circuits before the detector is consulted.
+        detector.assert_not_called()
+
+    def test_override_accepts_truthy_words(self):
+        for val in ("1", "true", "YES", "On"):
+            with mock.patch.dict(os.environ, {twt.ALLOW_ACTIVE_ENV: val}), \
+                 mock.patch.object(twt, "iterm_frontmost_state", return_value=True):
+                self.assertIsNone(
+                    twt.skip_reason_if_iterm_active(), f"override value {val!r} should run"
+                )
+
+    def test_falsey_override_still_skips_when_frontmost(self):
+        for val in ("0", "false", "", "no"):
+            with mock.patch.dict(os.environ, {twt.ALLOW_ACTIVE_ENV: val}), \
+                 mock.patch.object(twt, "iterm_frontmost_state", return_value=True):
+                self.assertIsNotNone(
+                    twt.skip_reason_if_iterm_active(), f"override value {val!r} should skip"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

After #134, the live-iTerm2 test modules open **real** iTerm windows via `LiveItermTestCase`. Running them incidentally (e.g. an agent running the full suite) floods the screen with `MCP-TEST` windows. This adds the guard requested after that incident: **live window-opening tests skip when iTerm2 is the frontmost app**, so they never interrupt an active session.

- `core/test_window_tracker.py`: `iterm_frontmost_state()` (best-effort, read-only — AppKit if available, else `osascript`; returns True/False/None) and `skip_reason_if_iterm_active()` (the decision: skip when iTerm2 is frontmost **or** undetermined; override via `ITERM_MCP_TEST_ALLOW_ACTIVE=1`).
- `tests/live_iterm_base.py`: `run_async_test` calls the guard at the very top and `skipTest`s **before** any connection or window creation — so no window opens when iTerm2 is active.
- `tests/test_active_guard.py`: 6 headless tests (detector fully mocked — no windows, no `osascript`/AppKit calls).

Default is conservative: when in doubt, skip. Pairs with the `test_baseline.py` change (#19/CI work) that skips the live modules entirely via `headless_unsafe.txt` — two layers so live tests don't open windows by accident.

## Test Plan
- [x] `python -m unittest tests.test_active_guard tests.test_window_tracker` — 40 tests pass (6 new + 34 existing), fully headless.
- [ ] Live: with iTerm2 frontmost, a live module skips with the guard reason; with `ITERM_MCP_TEST_ALLOW_ACTIVE=1` (and iTerm2 backgrounded) it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
