### PR TITLE
feat: CWD-based project segmentation (v1)

### DIFF
--- a/core/bus.py
+++ b/core/bus.py
@@ -198,6 +198,9 @@ class AgentMessageBus:
             # consumers that subscribe without a specific name.
             return [f"agent:{a.name}" for a in agents] + ["broadcast"]
 
+        # Future (manager phase): a ``project:<id>`` branch mirrors team: —
+        # strip the prefix and fan out via agent_registry.list_agents(project=...).
+        # Needs a first-class Agent.project field (deferred), so not added here.
         if recipient.startswith("team:"):
             team_name = recipient[len("team:"):]
             if agent_registry is None:

--- a/core/models.py
+++ b/core/models.py
@@ -958,6 +958,7 @@ class SessionInfo(BaseModel):
     last_activity: Optional[datetime] = Field(default=None, description="Time of last output change")
     last_message: Optional[str] = Field(default=None, description="Last Claude response (truncated)")
     process_name: Optional[str] = Field(default=None, description="Running process name")
+    project: Optional[str] = Field(default=None, description="Project root directory for this session")
 
     # SP2: fields returned by HEAD (compact projection).
     # is_processing and locked give just enough to identify a session's state.

--- a/core/projects.py
+++ b/core/projects.py
@@ -14,6 +14,12 @@ import os
 import subprocess
 from typing import Optional
 
+from core.iterm_path_monitor import (  # noqa: E402
+    get_user_variable,
+    set_user_variable,
+    get_session_path,
+)
+
 #: The session variable that holds a session's project (absolute path).
 PROJECT_VAR = "mcp_project"  # stored by iTerm as ``user.mcp_project``
 
@@ -50,3 +56,24 @@ def build_setuservar_escape(name: str, value: str) -> str:
     """Build iTerm2's OSC 1337 SetUserVar escape (value base64-encoded)."""
     b64 = base64.b64encode(value.encode()).decode()
     return f"\033]1337;SetUserVar={name}={b64}\007"
+
+
+async def get_session_project(connection, session_id: str) -> Optional[str]:
+    """Return a session's project, inferring + pinning it once if unset.
+
+    Sticky / first-observation-wins: if ``user.mcp_project`` is already set
+    (declared by the agent or pinned earlier), it is returned unchanged and
+    never overwritten. Otherwise the project is inferred from the session's
+    current CWD (git repo root) and pinned by setting ``user.mcp_project``
+    exactly once. Returns ``None`` if the project is unset and no CWD is
+    available yet (nothing is pinned in that case).
+    """
+    existing = await get_user_variable(connection, session_id, PROJECT_VAR)
+    if existing:
+        return existing
+    cwd = await get_session_path(connection, session_id)
+    project = resolve_project(cwd)
+    if not project:
+        return None
+    await set_user_variable(connection, session_id, f"user.{PROJECT_VAR}", project)
+    return project

--- a/core/projects.py
+++ b/core/projects.py
@@ -77,3 +77,11 @@ async def get_session_project(connection, session_id: str) -> Optional[str]:
         return None
     await set_user_variable(connection, session_id, PROJECT_VAR, project)
     return project
+
+
+# --- Future seam (manager phase): per-project activity summaries ---
+# def project_summary(project_id: str, *, since=None) -> dict:
+#     """Digest recent activity for a project (captured actions + notifications +
+#     bus messages stamped with this project) for a per-project manager agent.
+#     Built in the manager phase; the ``project`` stamp on those streams is what
+#     makes it queryable."""

--- a/core/projects.py
+++ b/core/projects.py
@@ -1,0 +1,52 @@
+"""Project identity for iTerm sessions.
+
+The authoritative key is the iTerm2 session variable ``user.mcp_project``.
+This module derives a stable project id from a CWD (the git repo root) and
+builds the iTerm ``SetUserVar`` escape an agent uses to declare its project.
+
+Env-assumption findings (Task 1 of the plan):
+    SetUserVar form: ESC ] 1337 ; SetUserVar=<name>=<base64(value)> BEL
+    (record any correction discovered during live verification here)
+"""
+
+import base64
+import os
+import subprocess
+from typing import Optional
+
+#: The session variable that holds a session's project (absolute path).
+PROJECT_VAR = "mcp_project"  # stored by iTerm as ``user.mcp_project``
+
+
+def resolve_project(cwd: Optional[str]) -> Optional[str]:
+    """Return the project id for a working directory.
+
+    The project is the git repo root of ``cwd`` (so subdir navigation within
+    a repo stays the same project). Non-git dirs fall back to ``cwd`` itself.
+    Returns ``None`` for an empty/None cwd.
+    """
+    if not cwd:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return cwd
+
+
+def project_label(project_id: Optional[str]) -> Optional[str]:
+    """Human-readable label for a project id (its basename)."""
+    if not project_id:
+        return None
+    return os.path.basename(project_id.rstrip("/")) or project_id
+
+
+def build_setuservar_escape(name: str, value: str) -> str:
+    """Build iTerm2's OSC 1337 SetUserVar escape (value base64-encoded)."""
+    b64 = base64.b64encode(value.encode()).decode()
+    return f"\033]1337;SetUserVar={name}={b64}\007"

--- a/core/projects.py
+++ b/core/projects.py
@@ -14,7 +14,7 @@ import os
 import subprocess
 from typing import Optional
 
-from core.iterm_path_monitor import (  # noqa: E402
+from core.iterm_path_monitor import (
     get_user_variable,
     set_user_variable,
     get_session_path,
@@ -75,5 +75,5 @@ async def get_session_project(connection, session_id: str) -> Optional[str]:
     project = resolve_project(cwd)
     if not project:
         return None
-    await set_user_variable(connection, session_id, f"user.{PROJECT_VAR}", project)
+    await set_user_variable(connection, session_id, PROJECT_VAR, project)
     return project

--- a/docs/examples/hooks-settings.json
+++ b/docs/examples/hooks-settings.json
@@ -11,6 +11,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/project_declare.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [

--- a/hooks/project_declare.py
+++ b/hooks/project_declare.py
@@ -1,0 +1,67 @@
+"""UserPromptSubmit hook: nudge an agent to declare its project (once)."""
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+MARKER_DIR = os.path.expanduser("~/.iterm-mcp/projects")
+MAX_PROMPTS = 2
+
+_INSTRUCTION = (
+    "PROJECT SETUP: Your iTerm session is not yet tagged with the repo/project "
+    "you are working on. Run this once, with the absolute path of the repo you "
+    "are actually working on (NOT necessarily your current directory):\n"
+    "  iterm-mcp project set <repo-path> --session-id {sid}\n"
+    "This lets the system group your session under the right project."
+)
+
+
+def _safe(session_id: str) -> str:
+    """Sanitize a session id for path keying (mirrors project_cli._key)."""
+    return re.sub(r"[^A-Za-z0-9_\-]", "_", session_id or "default") or "default"
+
+
+def _marker(sid: str) -> Path:
+    return Path(MARKER_DIR) / _safe(sid)
+
+
+def _asked_path(sid: str) -> Path:
+    return Path(MARKER_DIR) / f"{_safe(sid)}.asked"
+
+
+def _read_asked(sid: str) -> int:
+    try:
+        return int(_asked_path(sid).read_text().strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def decide(payload: dict) -> dict:
+    """Return the UserPromptSubmit hook JSON for this turn."""
+    base = {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+    sid = payload.get("session_id") or "default"
+    if _marker(sid).exists():
+        return base  # declared -> no-op
+    asked = _read_asked(sid)
+    if asked >= MAX_PROMPTS:
+        return base  # gave up nagging; server-side inference will pin a fallback
+    try:
+        Path(MARKER_DIR).mkdir(parents=True, exist_ok=True)
+        _asked_path(sid).write_text(str(asked + 1))
+    except OSError:
+        pass
+    base["hookSpecificOutput"]["additionalContext"] = _INSTRUCTION.format(sid=sid)
+    return base
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        payload = {}
+    json.dump(decide(payload), sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/project_declare.sh
+++ b/hooks/project_declare.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python "$(dirname "$0")/project_declare.py"

--- a/iterm_mcpy/main.py
+++ b/iterm_mcpy/main.py
@@ -29,6 +29,14 @@ def main() -> None:
     p_install.add_argument("--code", action="store_true",
                            help="print the 'claude mcp add' command for Claude Code")
 
+    p_project = sub.add_parser("project", help="declare/inspect a session's project")
+    p_project_sub = p_project.add_subparsers(dest="project_command")
+    p_pset = p_project_sub.add_parser("set", help="declare the repo you're working on")
+    p_pset.add_argument("repo")
+    p_pset.add_argument("--session-id", default=None)
+    p_pget = p_project_sub.add_parser("get", help="show this session's declared project")
+    p_pget.add_argument("--session-id", default=None)
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -46,6 +54,14 @@ def main() -> None:
         _stop()
     elif args.command == "install":
         _install(desktop=args.desktop, code=args.code)
+    elif args.command == "project":
+        from iterm_mcpy import project_cli
+        if args.project_command == "set":
+            project_cli.cmd_set(args.repo, session_id=args.session_id)
+        elif args.project_command == "get":
+            project_cli.cmd_get(session_id=args.session_id)
+        else:
+            parser.parse_args(["project", "--help"])
 
 
 def _status() -> None:

--- a/iterm_mcpy/project_cli.py
+++ b/iterm_mcpy/project_cli.py
@@ -1,0 +1,39 @@
+"""`iterm-mcp project` CLI — an agent declares the repo it's working on.
+
+`project set <repo>` emits iTerm's SetUserVar escape (so iTerm sets
+``user.mcp_project`` for the current pane) and writes a marker file so the
+declaration hook knows to stop asking. `project get` reports the marker.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from core.projects import build_setuservar_escape, PROJECT_VAR, resolve_project
+
+MARKER_DIR = os.path.expanduser("~/.iterm-mcp/projects")
+
+
+def _key(session_id: Optional[str]) -> str:
+    return session_id or os.environ.get("CLAUDE_SESSION_ID", "") or "default"
+
+
+def cmd_set(repo: str, session_id: Optional[str] = None) -> None:
+    """Declare the current session's project and mark it declared."""
+    project = resolve_project(repo) or repo  # accept a repo path or any dir
+    # 1) Tell iTerm (sets user.mcp_project for THIS pane's session).
+    sys.stdout.write(build_setuservar_escape(PROJECT_VAR, project))
+    sys.stdout.flush()
+    # 2) Persist the marker so the declaration hook stops asking.
+    Path(MARKER_DIR).mkdir(parents=True, exist_ok=True)
+    (Path(MARKER_DIR) / _key(session_id)).write_text(project + "\n")
+    print(f"\nproject set to {project}", file=sys.stderr)
+
+
+def cmd_get(session_id: Optional[str] = None) -> None:
+    marker = Path(MARKER_DIR) / _key(session_id)
+    if marker.exists():
+        print(marker.read_text().strip())
+    else:
+        print("project not set for this session")

--- a/iterm_mcpy/project_cli.py
+++ b/iterm_mcpy/project_cli.py
@@ -6,6 +6,7 @@ declaration hook knows to stop asking. `project get` reports the marker.
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Optional
@@ -16,7 +17,9 @@ MARKER_DIR = os.path.expanduser("~/.iterm-mcp/projects")
 
 
 def _key(session_id: Optional[str]) -> str:
-    return session_id or os.environ.get("CLAUDE_SESSION_ID", "") or "default"
+    """Filesystem-safe marker key for a session (sanitized)."""
+    raw = session_id or os.environ.get("CLAUDE_SESSION_ID", "") or "default"
+    return re.sub(r"[^A-Za-z0-9_\-]", "_", raw) or "default"
 
 
 def cmd_set(repo: str, session_id: Optional[str] = None) -> None:
@@ -32,6 +35,7 @@ def cmd_set(repo: str, session_id: Optional[str] = None) -> None:
 
 
 def cmd_get(session_id: Optional[str] = None) -> None:
+    """Print the current session's declared project, or a 'not set' notice."""
     marker = Path(MARKER_DIR) / _key(session_id)
     if marker.exists():
         print(marker.read_text().strip())

--- a/iterm_mcpy/tools/__init__.py
+++ b/iterm_mcpy/tools/__init__.py
@@ -20,14 +20,14 @@ def register_all(mcp):
         sessions, agents, teams, managers,
         feedback, memory, services, roles, workflows,
         messages, orchestrate, delegate, wait_for, subscribe, telemetry,
-        bus,
+        bus, projects,
     )
 
     _MODULES = [
         sessions, agents, teams, managers,
         feedback, memory, services, roles, workflows,
         messages, orchestrate, delegate, wait_for, subscribe, telemetry,
-        bus,
+        bus, projects,
     ]
 
     for mod in _MODULES:

--- a/iterm_mcpy/tools/__init__.py
+++ b/iterm_mcpy/tools/__init__.py
@@ -1,18 +1,18 @@
 """iTerm MCP tool modules (SP2 method-semantic surface).
 
 Each module exposes a ``register(mcp)`` function that registers its
-single tool with the FastMCP instance. The 16 tools together cover the
+single tool with the FastMCP instance. The 17 tools together cover the
 full method-semantic API:
 
   Collections (9): sessions, agents, teams, managers, feedback, memory,
                    services, roles, workflows
-  Actions (7):     messages, orchestrate, delegate, wait_for, subscribe,
-                   telemetry, bus
+  Actions (8):     messages, orchestrate, delegate, wait_for, subscribe,
+                   telemetry, bus, projects
 """
 
 
 def register_all(mcp):
-    """Register all 16 SP2 tools with the FastMCP instance.
+    """Register all 17 SP2 tools with the FastMCP instance.
 
     Called from fastmcp_server.py after mcp creation and before run().
     """

--- a/iterm_mcpy/tools/projects.py
+++ b/iterm_mcpy/tools/projects.py
@@ -1,0 +1,58 @@
+"""`projects` tool — list iTerm sessions grouped by their project tag."""
+from collections import defaultdict
+from typing import Any
+
+from iterm_mcpy.responses import err_envelope, ok_envelope
+from core.projects import get_session_project, project_label
+
+_OPTIONS = {
+    "tool": "projects", "kind": "action",
+    "ops": {"GET": "list sessions grouped by project", "OPTIONS": "this schema"},
+}
+
+
+async def projects(ctx, op: str = "GET", **kwargs) -> dict[str, Any]:
+    """List iTerm sessions grouped by their project tag.
+
+    Args:
+        ctx: FastMCP context carrying lifespan state.
+        op: HTTP verb or alias. Supported: GET (default), OPTIONS.
+
+    Returns:
+        Envelope dict with ``data`` list of project groups or OPTIONS schema.
+    """
+    if str(op).upper() == "OPTIONS":
+        return ok_envelope(method="OPTIONS", data=_OPTIONS)
+
+    lifespan = ctx.request_context.lifespan_context
+    terminal = lifespan["terminal"]
+    logger = lifespan.get("logger")
+
+    try:
+        groups: dict[str, list[str]] = defaultdict(list)
+        for session in list(terminal.sessions.values()):
+            proj = await get_session_project(
+                getattr(terminal, "connection", None), session.id
+            )
+            groups[proj or "(unassigned)"].append(session.id)
+
+        data = [
+            {
+                "project": p,
+                "label": project_label(p) if p != "(unassigned)" else p,
+                "sessions": sids,
+                "count": len(sids),
+            }
+            for p, sids in sorted(groups.items())
+        ]
+        return ok_envelope(method="GET", data=data)
+
+    except Exception as exc:  # noqa: BLE001
+        if logger:
+            logger.error("projects tool error: %s", exc)
+        return err_envelope(method="GET", error=str(exc))
+
+
+def register(mcp):
+    """Register the projects action tool."""
+    mcp.tool(name="projects")(projects)

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -57,6 +57,7 @@ from core.models import (
     SplitSessionResponse,
     WriteToSessionsRequest,
 )
+from core.projects import get_session_project
 from core.roles import RoleManager
 from core.session import ItermSession
 from core.tags import FocusCooldownManager
@@ -140,6 +141,7 @@ async def _list_sessions_core(
     role: Optional[str] = None,
     include_message: bool = True,
     force_enrich: bool = True,
+    project: Optional[str] = None,
 ) -> ListSessionsResponse:
     """Core listing/filtering pipeline backing the sessions GET handler.
 
@@ -243,6 +245,11 @@ async def _list_sessions_core(
         if team is not None and (agent_obj is None or team not in (agent_obj.teams or [])):
             continue
 
+        # Apply project filter.
+        session_project = await get_session_project(terminal.connection, session.id)
+        if project is not None and session_project != project:
+            continue
+
         # Apply role filter.
         if role_session_ids is not None and session.id not in role_session_ids:
             continue
@@ -334,6 +341,7 @@ async def _list_sessions_core(
             last_activity=last_activity_dt,
             last_message=last_message,
             process_name=process_name,
+            project=session_project,
         )
         result.append(session_info)
 
@@ -734,6 +742,7 @@ _GET_CORE_PARAMS = {
     "team",
     "role",
     "include_message",
+    "project",
 }
 
 
@@ -1581,6 +1590,7 @@ async def sessions(
     agent: Optional[str] = None,
     team: Optional[str] = None,
     role: Optional[str] = None,
+    project: Optional[str] = None,
     tag: Optional[str] = None,
     tags: Optional[List[str]] = None,
     match: str = "any",
@@ -1677,6 +1687,7 @@ async def sessions(
         "agent": agent,
         "team": team,
         "role": role,
+        "project": project,
         "tag": tag,
         "tags": tags,
         "match": match,

--- a/iterm_mcpy/tools/sessions.py
+++ b/iterm_mcpy/tools/sessions.py
@@ -245,10 +245,12 @@ async def _list_sessions_core(
         if team is not None and (agent_obj is None or team not in (agent_obj.teams or [])):
             continue
 
-        # Apply project filter.
-        session_project = await get_session_project(terminal.connection, session.id)
-        if project is not None and session_project != project:
-            continue
+        # Resolve the project only when filtering — avoids mutating/slowing plain lists.
+        session_project: Optional[str] = None
+        if project is not None:
+            session_project = await get_session_project(terminal.connection, session.id)
+            if session_project != project:
+                continue
 
         # Apply role filter.
         if role_session_ids is not None and session.id not in role_session_ids:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,11 @@ class TestCliRouting(unittest.TestCase):
         self.assertIn("claude mcp add", printed)
         self.assertIn("-m iterm_mcpy", printed)
 
+    def test_project_set_routes_to_cmd_set(self):
+        with mock.patch("iterm_mcpy.project_cli.cmd_set") as cset:
+            self._run(["project", "set", "/Users/me/repoA"])
+        cset.assert_called_once_with("/Users/me/repoA", session_id=None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_project_cli.py
+++ b/tests/test_project_cli.py
@@ -1,0 +1,53 @@
+"""Tests for the `iterm-mcp project` CLI (set/get)."""
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from iterm_mcpy import project_cli
+
+
+class TestProjectCli(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.p = mock.patch.object(project_cli, "MARKER_DIR", os.path.join(self.tmp.name, "projects"))
+        self.p.start()
+        self.addCleanup(self.p.stop)
+
+    def test_set_emits_escape_and_writes_marker(self):
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"CLAUDE_SESSION_ID": "cc-1"}), redirect_stdout(out):
+            project_cli.cmd_set("/Users/me/repoA", session_id=None)
+        self.assertIn("SetUserVar=mcp_project=", out.getvalue())
+        marker = os.path.join(self.tmp.name, "projects", "cc-1")
+        self.assertTrue(os.path.exists(marker))
+        with open(marker) as fh:
+            self.assertEqual(fh.read().strip(), "/Users/me/repoA")
+
+    def test_set_uses_explicit_session_id_when_env_absent(self):
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {}, clear=True), redirect_stdout(out):
+            project_cli.cmd_set("/Users/me/repoA", session_id="explicit-9")
+        self.assertTrue(os.path.exists(os.path.join(self.tmp.name, "projects", "explicit-9")))
+
+    def test_get_reads_marker(self):
+        os.makedirs(os.path.join(self.tmp.name, "projects"), exist_ok=True)
+        with open(os.path.join(self.tmp.name, "projects", "cc-1"), "w") as fh:
+            fh.write("/Users/me/repoA\n")
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"CLAUDE_SESSION_ID": "cc-1"}), redirect_stdout(out):
+            project_cli.cmd_get(session_id=None)
+        self.assertIn("/Users/me/repoA", out.getvalue())
+
+    def test_get_when_undeclared_prints_none(self):
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"CLAUDE_SESSION_ID": "nope"}), redirect_stdout(out):
+            project_cli.cmd_get(session_id=None)
+        self.assertIn("not set", out.getvalue().lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_hook.py
+++ b/tests/test_project_hook.py
@@ -1,0 +1,44 @@
+"""Tests for the project-declaration UserPromptSubmit hook (headless)."""
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from hooks import project_declare as ph
+
+
+class TestProjectDeclareHook(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.p = mock.patch.object(ph, "MARKER_DIR", os.path.join(self.tmp.name, "projects"))
+        self.p.start()
+        self.addCleanup(self.p.stop)
+        os.makedirs(ph.MARKER_DIR, exist_ok=True)
+
+    def _decide(self, session_id):
+        return ph.decide({"session_id": session_id, "hook_event_name": "UserPromptSubmit"})
+
+    def test_injects_when_undeclared(self):
+        out = self._decide("s1")
+        self.assertIn("additionalContext", out["hookSpecificOutput"])
+        self.assertIn("iterm-mcp project set", out["hookSpecificOutput"]["additionalContext"])
+
+    def test_noop_when_declared(self):
+        open(os.path.join(ph.MARKER_DIR, "s2"), "w").close()
+        out = self._decide("s2")
+        self.assertNotIn("additionalContext", out["hookSpecificOutput"])
+
+    def test_stops_after_max_prompts(self):
+        for _ in range(ph.MAX_PROMPTS):
+            self.assertIn("additionalContext", self._decide("s3")["hookSpecificOutput"])
+        self.assertNotIn("additionalContext", self._decide("s3")["hookSpecificOutput"])
+
+    def test_shape_is_userpromptsubmit(self):
+        out = self._decide("s4")
+        self.assertEqual(out["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,5 @@
 """Tests for the pure project resolver + SetUserVar escape builder."""
+import asyncio
 import base64
 import unittest
 from unittest import mock
@@ -40,6 +41,37 @@ class TestSetUserVarEscape(unittest.TestCase):
         esc = projects.build_setuservar_escape("mcp_project", "/Users/me/repoA")
         b64 = base64.b64encode(b"/Users/me/repoA").decode()
         self.assertEqual(esc, f"\033]1337;SetUserVar=mcp_project={b64}\007")
+
+
+class TestSessionProject(unittest.IsolatedAsyncioTestCase):
+    def _conn(self):
+        return mock.MagicMock()  # opaque connection handle
+
+    async def test_returns_existing_declared_project_without_pinning(self):
+        with mock.patch("core.projects.get_user_variable", new=mock.AsyncMock(return_value="/Users/me/repoB")), \
+             mock.patch("core.projects.set_user_variable", new=mock.AsyncMock()) as setv:
+            got = await projects.get_session_project(self._conn(), "sess-1")
+        self.assertEqual(got, "/Users/me/repoB")
+        setv.assert_not_awaited()  # already declared -> never overwrite (sticky)
+
+    async def test_infers_and_pins_when_unset(self):
+        conn = self._conn()
+        with mock.patch("core.projects.get_user_variable", new=mock.AsyncMock(return_value="")), \
+             mock.patch("core.projects.get_session_path", new=mock.AsyncMock(return_value="/Users/me/repoA/sub")), \
+             mock.patch("core.projects.resolve_project", return_value="/Users/me/repoA"), \
+             mock.patch("core.projects.set_user_variable", new=mock.AsyncMock(return_value=True)) as setv:
+            got = await projects.get_session_project(conn, "sess-2")
+        self.assertEqual(got, "/Users/me/repoA")
+        setv.assert_awaited_once()
+        self.assertEqual(setv.await_args.args[1:], ("sess-2", "user.mcp_project", "/Users/me/repoA"))
+
+    async def test_returns_none_and_does_not_pin_when_no_cwd(self):
+        with mock.patch("core.projects.get_user_variable", new=mock.AsyncMock(return_value="")), \
+             mock.patch("core.projects.get_session_path", new=mock.AsyncMock(return_value=None)), \
+             mock.patch("core.projects.set_user_variable", new=mock.AsyncMock()) as setv:
+            got = await projects.get_session_project(self._conn(), "sess-3")
+        self.assertIsNone(got)
+        setv.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,46 @@
+"""Tests for the pure project resolver + SetUserVar escape builder."""
+import base64
+import unittest
+from unittest import mock
+
+from core import projects
+
+
+class TestResolveProject(unittest.TestCase):
+    def test_git_repo_returns_toplevel(self):
+        with mock.patch("core.projects.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout="/Users/me/repoA\n")
+            self.assertEqual(projects.resolve_project("/Users/me/repoA/sub/dir"), "/Users/me/repoA")
+        args = run.call_args[0][0]
+        self.assertIn("rev-parse", args)
+        self.assertIn("--show-toplevel", args)
+        self.assertIn("/Users/me/repoA/sub/dir", args)
+
+    def test_non_git_falls_back_to_cwd(self):
+        with mock.patch("core.projects.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=128, stdout="")
+            self.assertEqual(projects.resolve_project("/tmp/loose"), "/tmp/loose")
+
+    def test_git_missing_or_error_falls_back_to_cwd(self):
+        with mock.patch("core.projects.subprocess.run", side_effect=FileNotFoundError):
+            self.assertEqual(projects.resolve_project("/tmp/loose"), "/tmp/loose")
+
+    def test_blank_cwd_returns_none(self):
+        self.assertIsNone(projects.resolve_project(""))
+        self.assertIsNone(projects.resolve_project(None))
+
+    def test_label_is_basename(self):
+        self.assertEqual(projects.project_label("/Users/me/repoA"), "repoA")
+        self.assertEqual(projects.project_label("/"), "/")
+        self.assertIsNone(projects.project_label(None))
+
+
+class TestSetUserVarEscape(unittest.TestCase):
+    def test_escape_is_osc1337_with_base64_value(self):
+        esc = projects.build_setuservar_escape("mcp_project", "/Users/me/repoA")
+        b64 = base64.b64encode(b"/Users/me/repoA").decode()
+        self.assertEqual(esc, f"\033]1337;SetUserVar=mcp_project={b64}\007")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -63,7 +63,7 @@ class TestSessionProject(unittest.IsolatedAsyncioTestCase):
             got = await projects.get_session_project(conn, "sess-2")
         self.assertEqual(got, "/Users/me/repoA")
         setv.assert_awaited_once()
-        self.assertEqual(setv.await_args.args[1:], ("sess-2", "user.mcp_project", "/Users/me/repoA"))
+        self.assertEqual(setv.await_args.args[1:], ("sess-2", "mcp_project", "/Users/me/repoA"))
 
     async def test_returns_none_and_does_not_pin_when_no_cwd(self):
         with mock.patch("core.projects.get_user_variable", new=mock.AsyncMock(return_value="")), \

--- a/tests/test_projects_tool.py
+++ b/tests/test_projects_tool.py
@@ -28,6 +28,16 @@ class TestProjectsTool(unittest.TestCase):
         parsed = asyncio.run(projects_tool(ctx=_ctx(MagicMock(sessions={})), op="OPTIONS"))
         self.assertEqual(parsed["method"], "OPTIONS")
 
+    def test_unassigned_bucket_for_none_project(self):
+        terminal = MagicMock(); terminal.sessions = {"a": self._s("a"), "b": self._s("b")}
+        async def fake_proj(conn, sid):
+            return "/repoA" if sid == "a" else None
+        with patch("iterm_mcpy.tools.projects.get_session_project", new=fake_proj):
+            parsed = asyncio.run(projects_tool(ctx=_ctx(terminal), op="GET"))
+        groups = {g["project"]: sorted(g["sessions"]) for g in parsed["data"]}
+        self.assertEqual(groups["(unassigned)"], ["b"])
+        self.assertEqual(groups["/repoA"], ["a"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_projects_tool.py
+++ b/tests/test_projects_tool.py
@@ -1,0 +1,33 @@
+"""Tests for the `projects` MCP tool (grouping)."""
+import asyncio, unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+from iterm_mcpy.tools.projects import projects as projects_tool
+
+
+def _ctx(terminal):
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {"terminal": terminal, "logger": MagicMock(),
+                                            "agent_registry": MagicMock()}
+    return ctx
+
+
+class TestProjectsTool(unittest.TestCase):
+    def _s(self, sid):
+        s = MagicMock(); s.id = sid; s.name = sid; return s
+
+    def test_groups_sessions_by_project(self):
+        terminal = MagicMock(); terminal.sessions = {"a": self._s("a"), "b": self._s("b"), "c": self._s("c")}
+        async def fake_proj(conn, sid):
+            return {"a": "/repoA", "b": "/repoA", "c": "/repoB"}[sid]
+        with patch("iterm_mcpy.tools.projects.get_session_project", new=fake_proj):
+            parsed = asyncio.run(projects_tool(ctx=_ctx(terminal), op="GET"))
+        groups = {g["project"]: sorted(g["sessions"]) for g in parsed["data"]}
+        self.assertEqual(groups, {"/repoA": ["a", "b"], "/repoB": ["c"]})
+
+    def test_options_returns_schema(self):
+        parsed = asyncio.run(projects_tool(ctx=_ctx(MagicMock(sessions={})), op="OPTIONS"))
+        self.assertEqual(parsed["method"], "OPTIONS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1136,6 +1136,18 @@ class TestSessionsProjectFilter(unittest.TestCase):
         ids = [s["session_id"] for s in parsed["data"]]
         self.assertEqual(ids, ["a"])
 
+    def test_unfiltered_list_does_not_resolve_project(self):
+        from iterm_mcpy.tools.sessions import sessions
+        terminal = MagicMock()
+        terminal.sessions = {"a": self._session("a")}
+        reg = MagicMock(); reg.get_agent_by_session = MagicMock(return_value=None)
+        ctx = _make_ctx(terminal=terminal, agent_registry=reg)
+        gsp = AsyncMock(return_value="/repoA")
+        with patch("iterm_mcpy.tools.sessions.get_session_project", new=gsp):
+            parsed = asyncio.run(sessions(ctx=ctx, op="GET"))  # no project filter
+        gsp.assert_not_awaited()
+        self.assertIsNone(parsed["data"][0].get("project"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1108,5 +1108,34 @@ class TestOptionsAdvertises4e(unittest.TestCase):
             self.assertIn(name, subs)
 
 
+class TestSessionsProjectFilter(unittest.TestCase):
+    def _session(self, sid):
+        s = MagicMock()
+        s.id = sid
+        s.name = sid
+        s.persistent_id = None
+        s.is_processing = False
+        s.is_suspended = False
+        s.suspended_at = None
+        s.suspended_by = None
+        s.last_update_time = None
+        s.get_cwd = AsyncMock(return_value="/x")
+        s.get_screen_contents = AsyncMock(return_value="")
+        return s
+
+    def test_filters_by_project(self):
+        from iterm_mcpy.tools.sessions import sessions
+        terminal = MagicMock()
+        terminal.sessions = {"a": self._session("a"), "b": self._session("b")}
+        reg = MagicMock(); reg.get_agent_by_session = MagicMock(return_value=None)
+        ctx = _make_ctx(terminal=terminal, agent_registry=reg)
+        async def fake_proj(conn, sid):
+            return "/repoA" if sid == "a" else "/repoB"
+        with patch("iterm_mcpy.tools.sessions.get_session_project", new=fake_proj):
+            parsed = asyncio.run(sessions(ctx=ctx, op="GET", project="/repoA"))
+        ids = [s["session_id"] for s in parsed["data"]]
+        self.assertEqual(ids, ["a"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

CWD-based **project segmentation** (v1): tag each iTerm session with a stable `project` so sessions can be listed, filtered, and targeted by project — robustly, even when an agent's CWD lies or resets every turn.

The authoritative key is the iTerm session variable **`user.mcp_project`**, set **declared-first** with a **git-root inference fallback** that's **sticky** (first-observation-wins; never overwritten):
- **`core/projects.py`** — `resolve_project(cwd)` (git repo root, non-git → dir), `build_setuservar_escape`, and `get_session_project` (reads `user.mcp_project`; if unset, infers the git-root of the session's CWD and pins it once).
- **`iterm-mcp project set/get`** (`iterm_mcpy/project_cli.py` + `main.py`) — an agent declares its project; `set` emits iTerm's `SetUserVar` escape (sets `user.mcp_project` for the pane) and writes a marker.
- **Ask-once `UserPromptSubmit` hook** (`hooks/project_declare.py`) — nudges an undeclared agent to run `iterm-mcp project set`, at most twice, then stops (no-op once declared). The hook and CLI sanitize the session id identically so the marker matches.
- **Query/targeting** — a `project=` filter on the `sessions` tool (resolved only when filtering — a plain list never mutates or pays the cost) and a new **`projects`** tool that groups sessions by project.

**Design notes:** the spec's "first-observation-wins path monitor" is implemented as **on-demand lazy pinning** instead (the repo's `PathMonitor` is dormant and carries unrelated side effects) — identical semantics, simpler, no background connection. Source of truth is the session var, so **no `Agent` dataclass/persistence change** in v1.

**Deferred (documented as seams, not built):** the explicit B handoff, first-class `Agent.project`, `project:` bus addressing (comment marks the exact insertion in `core/bus.py`), per-project visual profiles, and `project_summary()` (commented seam in `core/projects.py`) — these compose on top for the later "per-project manager → global manager" phase.

## Manual verification needed (cannot be unit-tested)
1. On a **real** iTerm pane, confirm the `SetUserVar` escape actually sets `user.mcp_project` (unit tests pin only the byte-shape). If iTerm's framing differs, only `build_setuservar_escape` changes.
2. `$CLAUDE_SESSION_ID` availability — the design is robust either way (the hook tells the agent to pass `--session-id` explicitly), so this is informational.

## Test Plan
- [x] `python -m unittest tests.test_projects tests.test_project_cli tests.test_project_hook tests.test_sessions tests.test_projects_tool tests.test_cli` — **94 tests**, all pass, fully headless (no live iTerm windows).
- [ ] Live: the two checks above.

Spec: `docs/superpowers/specs/2026-06-13-project-segmentation-design.md` · Plan: `docs/superpowers/plans/2026-06-13-project-segmentation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
